### PR TITLE
fix unique name problem in filter_jackrack

### DIFF
--- a/src/modules/jackrack/filter_jackrack.c
+++ b/src/modules/jackrack/filter_jackrack.c
@@ -432,8 +432,8 @@ mlt_filter filter_jackrack_init( mlt_profile profile, mlt_service_type type, con
 	if ( this != NULL )
 	{
 		char name[16];
-		char * jack_client_name;
-		jack_status_t status;
+		char *jack_client_name;
+		jack_status_t status = 0;
 
 		snprintf( name, sizeof( name ), "mlt%d", getpid() );
 		jack_client_t *jack_client = jack_client_open( name, JackNullOption, &status, NULL );


### PR DESCRIPTION
Hi Dan,
can you review this commit and if you think its ok commit it.

As mentioned in earlier emails my dream is to have the possibility to give own/custom jack_client names. 
But as a workaround this patch works for me. Perhaps its possible to introduce this feature in the future :-))

comit log:
fix unique name problem in filter_jackrack when several filter instances are loaded within one process on evaluating the jack status JackNameNotUnique
