### PR TITLE
register jack ports before activating client

### DIFF
--- a/src/modules/jackrack/filter_jackrack.c
+++ b/src/modules/jackrack/filter_jackrack.c
@@ -191,7 +191,7 @@ static void initialise_jack_ports( mlt_properties properties )
 		}
 	}
 	
-	// Start Jack processing - required before registering ports
+	// Start Jack processing
 	pthread_mutex_lock( &g_activate_mutex );
 	jack_activate( jack_client );
 	pthread_mutex_unlock( &g_activate_mutex  );


### PR DESCRIPTION
this is the order it should be done. Otherwise there is a problem if
other jack clients (e.g ardour) are already running and you want to start mlt jack (registering
ports fail)

I checked several clients they all are doing it in this order and it works just fine now.
