### PR TITLE
Add loop option to pixbuf producer

### DIFF
--- a/src/modules/gtk2/producer_pixbuf.c
+++ b/src/modules/gtk2/producer_pixbuf.c
@@ -92,6 +92,7 @@ mlt_producer producer_pixbuf_init( char *filename )
 		mlt_properties_set_int( properties, "aspect_ratio", 1 );
 		mlt_properties_set_int( properties, "progressive", 1 );
 		mlt_properties_set_int( properties, "seekable", 1 );
+                mlt_properties_set_int( properties, "loop", 1 );
 
 		// Validate the resource
 		if ( filename )
@@ -371,7 +372,13 @@ static int refresh_pixbuf( producer_pixbuf self, mlt_frame frame )
 	position += mlt_producer_get_in( producer );
 
 	// Image index
-	int current_idx = ( int )floor( ( double )position / ttl ) % self->count;
+        int loop = mlt_properties_get_int( producer_props, "loop" );
+        int current_idx;
+        if (loop) {
+		current_idx = ( int )floor( ( double )position / ttl ) % self->count;
+        } else {
+		current_idx = MIN(( double )position / ttl, self->count - 1);
+        }
 
 	// Key for the cache
 	char image_key[ 10 ];

--- a/src/modules/gtk2/producer_pixbuf.yml
+++ b/src/modules/gtk2/producer_pixbuf.yml
@@ -108,3 +108,12 @@ parameters:
     type: float
     description: Optionally override a (mis)detected aspect ratio
     mutable: yes
+
+  - identifier: loop
+    title: Loop sequence of images indefinitively
+    description: when 1 (default) loop sequences of images, when 0, play them only once
+    type: integer
+    default: 1
+    minimum: 0
+    maximum: 1
+    widget: checkbox


### PR DESCRIPTION
We use the pixbuf producer to show our tv channel's logo, but only want it to spin once per block,
hence this simple patch to add a 'loop' option to our .mlt.

Signed-off-by: Niv Sardi xaiki@evilgiggle.com
