### PR TITLE
This fixes framebuffer producer that was corrupted when encountering an invalid frame

### DIFF
--- a/src/modules/kdenlive/producer_framebuffer.c
+++ b/src/modules/kdenlive/producer_framebuffer.c
@@ -157,7 +157,8 @@ static int framebuffer_get_image( mlt_frame frame, uint8_t **image, mlt_image_fo
 		int error = mlt_frame_get_image( first_frame, &first_image, format, width, height, writable );
 
 		if ( error != 0 ) {
-			mlt_log_error( MLT_PRODUCER_SERVICE( producer ), "first_image == NULL get image died\n" );
+			mlt_log_warning( MLT_PRODUCER_SERVICE( producer ), "first_image == NULL get image died\n" );
+			mlt_properties_set_data( properties, "first_frame", NULL, 0, NULL, NULL );
 			mlt_service_unlock( MLT_PRODUCER_SERVICE( producer ) );
 			return error;
 		}


### PR DESCRIPTION
Previously, when an invalid frame was encountered (could happen especially when reversing a clip whose last frames are broken), the producer triggered a big error and remained corrupted.

With this patch, the error level is lowered and as soon as a valid frame is encountered, the producer behaves correctly
