### PR TITLE
WIN32: Modify system path to allow module libraries find required dlls

### DIFF
--- a/src/framework/mlt_repository.c
+++ b/src/framework/mlt_repository.c
@@ -81,7 +81,8 @@ mlt_repository mlt_repository_init( const char *directory )
 	mlt_properties dir = mlt_properties_new();
 	int count = mlt_properties_dir_list( dir, directory, NULL, 0 );
 	int i;
-	
+
+#ifdef WIN32
 	char *syspath = getenv("PATH");
 	char *exedir = mlt_environment( "MLT_APPDIR" );
 	char *newpath = "PATH=";
@@ -91,6 +92,7 @@ mlt_repository mlt_repository_init( const char *directory )
 	strcat( newpath, ";" );
 	strcat( newpath, syspath );
 	putenv(newpath);
+#endif
 
 	// Iterate over files
 	for ( i = 0; i < count; i++ )


### PR DESCRIPTION
Without this fix the modules are failed to load when working directory is different from melt.exe location.

Sorry for the crappy code, but I'm sure you've got the idea.
