### PR TITLE
Fix gcc detection

### DIFF
--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ build_config()
 		if [ "$optimisations" = "true" ]
 		then
 			echo "OPTIMISATIONS=-O2 -pipe"
-			if $("$CC" --version 2> /dev/null | grep gcc); then
+			if $("$CC" --version | grep gcc > /dev/null); then
 				# Since gcc 4.6, this optimization enabled with -O1 causes filter_line_sse2 to crash.
 				echo "OPTIMISATIONS+=-fno-tree-dominator-opts"
 				# Since gcc 4.6, this optimization enabled with -O2 causes filter_line_sse2 to crash.


### PR DESCRIPTION
I am not a bash expert, but with the current grep line in the configure script, I get the following result when trying to configure mlt (using Ubuntu 14.10):

gcc: error: (Ubuntu: No such file or directory
gcc: error: 4.9.1-15ubuntu1): No such file or directory
gcc: error: 4.9.1: No such file or directory
gcc: fatal error: no input files
compilation terminated.

My patch fixes the detection of GCC on my system
