### PR TITLE
print message when libexif is missing on configure

### DIFF
--- a/src/modules/gtk2/configure
+++ b/src/modules/gtk2/configure
@@ -84,6 +84,8 @@ else
 		else
 			echo "- Libexif not found, disabling exif features (auto rotate)"
 		fi
+	else
+		echo "- Libexif not found, disabling exif features (auto rotate)"
 	fi
 
 	exit 0

--- a/src/modules/qt/configure
+++ b/src/modules/qt/configure
@@ -78,6 +78,8 @@ else
 		else
 			echo "- Libexif not found, disabling exif features (auto rotate)"
 		fi
+	else
+		echo "- Libexif not found, disabling exif features (auto rotate)"
 	fi
 
 	if [ -d "$qt_libdir" -a -d "$qt_includedir" ]


### PR DESCRIPTION
This should help packagers notice that libexif can bring extra features.
