### PR TITLE
Fix image sequence not playing (issue #343326)

### DIFF
--- a/src/modules/gtk2/producer_pixbuf.c
+++ b/src/modules/gtk2/producer_pixbuf.c
@@ -632,14 +632,14 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		// Set the producer on the frame properties
 		mlt_properties_set_data( properties, "producer_pixbuf", self, 0, NULL, NULL );
 
-		// Update timecode on the frame we're creating
-		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
-
 		// Refresh the pixbuf
 		self->pixbuf_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "pixbuf.pixbuf" );
 		self->pixbuf = mlt_cache_item_data( self->pixbuf_cache, NULL );
 		refresh_pixbuf( self, *frame );
 		mlt_cache_item_close( self->pixbuf_cache );
+
+                // Update timecode on the frame we're creating
+		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
 
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( producer_properties, "progressive" ) );

--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -317,14 +317,14 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		// Set the producer on the frame properties
 		mlt_properties_set_data( properties, "producer_qimage", self, 0, NULL, NULL );
 
-		// Update timecode on the frame we're creating
-		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
-
 		// Refresh the image
 		self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
 		self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
 		refresh_qimage( self, *frame );
 		mlt_cache_item_close( self->qimage_cache );
+
+                // Update timecode on the frame we're creating
+		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
 
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( producer_properties, "progressive" ) );


### PR DESCRIPTION
Trying to play an image sequence pauses / freezes with SDL/xgl consumers. Reproducible with the images provided in this kdenlive bug:
https://bugs.kde.org/show_bug.cgi?id=343326 (see attachment "Image files used to create the slideshow").

The issue did not appear on the avformat consumer, so I guess it is related to frame dropping consumers. This patch fixes the issue - looks like the frame position must be set after loading the image.