### PR TITLE
Fix movit.rect incorrectly disabled when pan without zoom

### DIFF
--- a/src/modules/opengl/filter_movit_resize.cpp
+++ b/src/modules/opengl/filter_movit_resize.cpp
@@ -169,7 +169,7 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		mlt_properties_set_double( filter_properties, "_movit.parms.float.left", rect.x );
 		mlt_properties_set_double( filter_properties, "_movit.parms.float.top", rect.y );
 
-		bool disable = ( *width == owidth && *height == oheight );
+		bool disable = ( *width == owidth && *height == oheight && rect.x == 0 && rect.y == 0 );
 		mlt_properties_set_int( filter_properties, "_movit.parms.int.disable", disable );
 
 		GlslManager::get_instance()->unlock_service( frame );


### PR DESCRIPTION
movit.rect was incorrectly disabled when trying to move the image without resizing it.
Reproducible:

melt myclip.mpg -attach movit.rect rect="10% 10% 100% 100%" -consumer xgl glsl.=1
displayed the frame without movit.rect effect, while
melt myclip.mpg -attach movit.rect rect="10% 10% 99% 99%" -consumer xgl glsl.=1
correctly displayed the frame with an x/y offset pos of 10%