### PR TITLE
Process audio before video when multi-threading

### DIFF
--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -1377,8 +1377,10 @@ static mlt_frame worker_get_frame( mlt_consumer self, mlt_properties properties 
 	// Frame to return
 	mlt_frame frame = NULL;
 	consumer_private *priv = self->local;
-	double fps = mlt_properties_get_double( properties, "fps" );
 	int threads = abs( priv->real_time );
+	int audio_off = mlt_properties_get_int( properties, "audio_off" );
+	int samples = 0;
+	void *audio = NULL;
 	int buffer = mlt_properties_get_int( properties, "_buffer" );
 	buffer = buffer > 0 ? buffer : mlt_properties_get_int( properties, "buffer" );
 	// This is a heuristic to determine a suitable minimum buffer size for the number of threads.
@@ -1402,6 +1404,12 @@ static mlt_frame worker_get_frame( mlt_consumer self, mlt_properties properties 
 			frame = mlt_consumer_get_frame( self );
 			if ( frame )
 			{
+				// Process the audio
+				if ( !audio_off )
+				{
+					samples = mlt_sample_calculator( priv->fps, priv->frequency, priv->aud_counter++ );
+					mlt_frame_get_audio( frame, &audio, &priv->audio_format, &priv->frequency, &priv->channels, &samples );
+				}
 				pthread_mutex_lock( &priv->queue_mutex );
 				mlt_deque_push_back( priv->queue, frame );
 				pthread_cond_signal( &priv->queue_cond );
@@ -1428,6 +1436,12 @@ static mlt_frame worker_get_frame( mlt_consumer self, mlt_properties properties 
 		frame = mlt_consumer_get_frame( self );
 		if ( frame )
 		{
+			// Process the audio
+			if ( !audio_off )
+			{
+				samples = mlt_sample_calculator( priv->fps, priv->frequency, priv->aud_counter++ );
+				mlt_frame_get_audio( frame, &audio, &priv->audio_format, &priv->frequency, &priv->channels, &samples );
+			}
 			pthread_mutex_lock( &priv->queue_mutex );
 			mlt_deque_push_back( priv->queue, frame );
 			pthread_cond_signal( &priv->queue_cond );
@@ -1488,7 +1502,7 @@ static mlt_frame worker_get_frame( mlt_consumer self, mlt_properties properties 
 				// Auto-scale the buffer to compensate
 				mlt_log_verbose( self, "increasing buffer to %d\n", buffer + threads );
 				mlt_properties_set_int( properties, "_buffer", buffer + threads );
-				priv->consecutive_dropped = fps / 2;
+				priv->consecutive_dropped = priv->fps / 2;
 			}
 			else
 			{

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -821,6 +821,8 @@ static int seek_video( producer_avformat self, mlt_position position,
 	mlt_producer producer = self->parent;
 	int paused = 0;
 
+	pthread_mutex_lock( &self->packets_mutex );
+
 	if ( self->seekable && ( position != self->video_expected || self->last_position < 0 ) )
 	{
 		mlt_properties properties = MLT_PRODUCER_PROPERTIES( producer );
@@ -876,6 +878,7 @@ static int seek_video( producer_avformat self, mlt_position position,
 			av_freep( &self->video_frame );
 		}
 	}
+	pthread_mutex_unlock( &self->packets_mutex );
 	return paused;
 }
 
@@ -1943,6 +1946,8 @@ static int seek_audio( producer_avformat self, mlt_position position, double tim
 {
 	int paused = 0;
 
+	pthread_mutex_lock( &self->packets_mutex );
+
 	// Seek if necessary
 	if ( self->seekable && ( position != self->audio_expected || self->last_position < 0 ) )
 	{
@@ -1980,6 +1985,7 @@ static int seek_audio( producer_avformat self, mlt_position position, double tim
 				self->audio_used[i - 1] = 0;
 		}
 	}
+	pthread_mutex_unlock( &self->packets_mutex );
 	return paused;
 }
 


### PR DESCRIPTION
This request restores processing audio before video when real_time is < -1 or > 1.

The change in producer_avformat was reliable with my testing and is congruent with the fact that av_read_frame() is mutex protected everywhere else.

It is important to note that this change to mlt_consumer does NOT add parallel audio processing. The audio for each frame is processed sequentially in worker_get_frame() before the frame is passed to the thread pool for parallel image processing. So it is not necessary to make sure all audio producers/filters are thread save.

I propose that we do not merge these changes until after the next Shotcut release.