### PR TITLE
Add a preferred-width attribute to kdenlivetitle text content properties

### DIFF
--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -239,6 +239,10 @@ void loadFromXml( mlt_producer producer, QGraphicsScene *scene, const char *temp
 				{
 					//txt->setData(OriginYTop, txtProperties.namedItem("kdenlive-axis-y-inverted").nodeValue().toInt());
 				}
+				if ( !txtProperties.namedItem("preferred-width").isNull() )
+				{
+					txt->setTextWidth( txtProperties.namedItem("preferred-width").nodeValue().toInt() );
+				}
 					gitem = txt;
 			}
 			else if ( nodeAttributes.namedItem( "type" ).nodeValue() == "QGraphicsRectItem" )


### PR DESCRIPTION
Would you be interested in such a solution for centered text? It's a requested feature:

https://kdenlive.org/forum/title-template-aligning-doesnt-work
https://kdenlive.org/forum/center-align-template-title
https://kdenlive.org/forum/template-documentation

The current implementation sets the preferred width to be the text item's actual width [(kdenlivetitle_wrapper.cpp:229)](https://github.com/mltframework/mlt/blob/9010dc080a7a6b9c4b0561a3eafa5853ea3be8a8/src/modules/qt/kdenlivetitle_wrapper.cpp#L229), making center- and right-alignment meaningless unless the text is multiline. (When it *is* multiline, it merely aligns shorter lines according to the longest one)

With this change, you can set preferred-width="x" and it will act as though the text item had that width. Set x to the video's width and you can have perfectly centered (or right-aligned) titles.