### PR TITLE
Add Animation::insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.moc
 *.o
 *.so
 *.so.*
@@ -29,3 +30,5 @@ mlt-config
 packages.dat
 make.inc
 src/examples/play
+src/tests/*Makefile
+src/tests/*/[^.]*

--- a/src/mlt++/MltAnimation.cpp
+++ b/src/mlt++/MltAnimation.cpp
@@ -170,6 +170,17 @@ void Animation::set_length( int length )
 	return mlt_animation_set_length( instance, length );
 }
 
+int Animation::insert( int position, char* value, mlt_keyframe_type type )
+{
+    struct mlt_animation_item_s item;
+    item.is_key = 1;
+    item.keyframe_type = type;
+    item.property = mlt_property_init();
+    item.frame = position;
+    mlt_property_set_string(item.property, value);
+	return mlt_animation_insert( instance, &item );
+}
+
 int Animation::remove( int position )
 {
 	return mlt_animation_remove( instance, position );

--- a/src/mlt++/MltAnimation.h
+++ b/src/mlt++/MltAnimation.h
@@ -53,6 +53,7 @@ namespace Mlt
 			mlt_keyframe_type key_get_type( int index );
 
 			void set_length( int length );
+            int insert( int position, char* value, mlt_keyframe_type type );
 			int remove( int position );
 			void interpolate();
 			char* serialize_cut( int in = -1, int out = -1 );

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -506,6 +506,7 @@ MLTPP_0.9.8 {
         "Mlt::Animation::key_get_frame(int)";
         "Mlt::Animation::key_get_type(int)";
         "Mlt::Animation::set_length(int)";
+        "Mlt::Animation::insert(int, char*, mlt_keyframe_type)";
         "Mlt::Animation::remove(int)";
         "Mlt::Animation::interpolate()";
         "Mlt::Animation::serialize_cut(int, int)";

--- a/src/tests/test_animation/test_animation.cpp
+++ b/src/tests/test_animation/test_animation.cpp
@@ -182,6 +182,45 @@ private Q_SLOTS:
 		QCOMPARE(a.serialize_cut(), "50=100;60=60");
 	}
 
+	void InsertMiddleKeyframe()
+	{
+		Properties p;
+		p.set("foo", "50=100; 100=0");
+		// Cause the string to be interpreted as animated value.
+		p.anim_get_int("foo", 0);
+		Animation a = p.get_animation("foo");
+		QVERIFY(a.is_valid());
+		int error = a.insert(60, "60", mlt_keyframe_linear);
+		QVERIFY(!error);
+		QCOMPARE(a.serialize_cut(), "50=100;60=60;100=0");
+	}
+
+	void InsertFirstKeyframe()
+    {
+		Properties p;
+		p.set("foo", "60=60; 100=0");
+		// Cause the string to be interpreted as animated value.
+		p.anim_get_int("foo", 0);
+		Animation a = p.get_animation("foo");
+		QVERIFY(a.is_valid());
+		int error = a.insert(50, "100", mlt_keyframe_linear);
+		QVERIFY(!error);
+		QCOMPARE(a.serialize_cut(), "50=100;60=60;100=0");
+	}
+
+	void InsertLastKeyframe()
+    {
+		Properties p;
+		p.set("foo", "50=100; 60=60");
+		// Cause the string to be interpreted as animated value.
+		p.anim_get_int("foo", 0);
+		Animation a = p.get_animation("foo");
+		QVERIFY(a.is_valid());
+		int error = a.insert(100, "0", mlt_keyframe_linear);
+		QVERIFY(!error);
+		QCOMPARE(a.serialize_cut(), "50=100;60=60;100=0");
+	}
+
 	void RemoveMiddleKeyframe()
 	{
 		Properties p;


### PR DESCRIPTION
Hello,

I'm mentoring Kdenlive's GSoC student for integration of property animation.
He is missing a Mlt++ keyframe insert function : here is a quick one that seems to work in unit tests...

Vincent.
PS: I'm very happy to start contributing to MLT ;)