### PR TITLE
fill support in composite transition

### DIFF
--- a/src/modules/core/transition_composite.c
+++ b/src/modules/core/transition_composite.c
@@ -811,12 +811,12 @@ static int get_b_frame_image( mlt_transition self, mlt_frame b_frame, uint8_t **
 		// ????: Shouln't this be the default behaviour?
 		if ( mlt_properties_get_int( properties, "fill" ) && scaled_width > 0 && scaled_height > 0 )
 		{
-			if ( scaled_height < normalised_height && scaled_width * normalised_height / scaled_height <= normalised_width )
+			if ( scaled_height < normalised_height && scaled_width * normalised_height / scaled_height >= normalised_width )
 			{
 				scaled_width = rint( scaled_width * normalised_height / scaled_height );
 				scaled_height = normalised_height;
 			}
-			else if ( scaled_width < normalised_width && scaled_height * normalised_width / scaled_width < normalised_height )
+			else if ( scaled_width < normalised_width && scaled_height * normalised_width / scaled_width > normalised_height )
 			{
 				scaled_height = rint( scaled_height * normalised_width / scaled_width );
 				scaled_width = normalised_width;
@@ -1278,6 +1278,13 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 				{
 					// Otherwise, align
 					alignment_calculate( &result );
+					if ( mlt_properties_get_int( properties, "fill" ) )
+					{
+						if ( result.item.w <= result.sw )
+							result.x_src = - rint( ( result.sw - result.item.w ) / 2 );
+						if ( result.item.h <= result.sh )
+							result.y_src = - rint( ( result.sh - result.item.h ) / 2 );
+					}
 				}
 
 				// Composite the b_frame on the a_frame

--- a/src/modules/core/transition_composite.yml
+++ b/src/modules/core/transition_composite.yml
@@ -56,6 +56,17 @@ parameters:
     maximum: 1
     mutable: yes
     widget: checkbox
+  - identifier: fill
+    title: Allow filling without distorting
+    description: >
+      When set, causes the B frame image to fill the WxH completely by cropping
+      B frame image.
+    type: integer
+    default: 0
+    minimum: 0
+    maximum: 1
+    mutable: yes
+    widget: checkbox
   - identifier: halign
     title: Horizontal alignment
     description: >


### PR DESCRIPTION
I would like to completely fill a composite-transition region by automatically cropping the B frame while compositing into the A frame. Using filter crop is an alternative but it is cumbersome as I would need to specify the exact pixel cropping sizes.
I use it to create a left-right split view:
melt -profile atsc_720p_30 \
colour:black length=1000 out=999 \
-track b_left.mkv out=999
-track b_right.mkv out=999
-transition composite out=999 a_track=0 b_track=1 geometry=0%/0%:50%x100% fill=1
-transition composite out=999 a_track=0 b_track=2 geometry=50%/0%:50%x100% fill=1
