### PR TITLE
Fix automask filter starting with wrong profile info for geometry

### DIFF
--- a/src/modules/motion_est/filter_autotrack_rectangle.c
+++ b/src/modules/motion_est/filter_autotrack_rectangle.c
@@ -255,17 +255,7 @@ static int attach_boundry_to_frame( mlt_frame frame, uint8_t **image, mlt_image_
 		char *arg = mlt_properties_get(filter_properties, "geometry");
 
 		// Parse the geometry if we have one
-		int in = mlt_filter_get_in( filter );
-		int out = mlt_filter_get_out( filter );
-		int length;
-
-		// Special case for attached filters - in/out come through on the frame
-		if ( out == 0 )
-		{
-			in = mlt_properties_get_int( frame_properties, "in" );
-			out = mlt_properties_get_int( frame_properties, "out" );
-		}
-		length = out - in + 1;
+		mlt_position length = mlt_filter_get_length2( filter, frame );
 		mlt_profile profile = mlt_service_profile( MLT_FILTER_SERVICE( filter ) );
 		mlt_geometry_parse( geom, arg, length, profile->width, profile->height );
 

--- a/src/modules/motion_est/filter_autotrack_rectangle.c
+++ b/src/modules/motion_est/filter_autotrack_rectangle.c
@@ -254,6 +254,21 @@ static int attach_boundry_to_frame( mlt_frame frame, uint8_t **image, mlt_image_
 		mlt_geometry geom = mlt_geometry_init();
 		char *arg = mlt_properties_get(filter_properties, "geometry");
 
+		// Parse the geometry if we have one
+		int in = mlt_filter_get_in( filter );
+		int out = mlt_filter_get_out( filter );
+		int length;
+
+		// Special case for attached filters - in/out come through on the frame
+		if ( out == 0 )
+		{
+			in = mlt_properties_get_int( frame_properties, "in" );
+			out = mlt_properties_get_int( frame_properties, "out" );
+		}
+		length = out - in + 1;
+		mlt_profile profile = mlt_service_profile( MLT_FILTER_SERVICE( filter ) );
+		mlt_geometry_parse( geom, arg, length, profile->width, profile->height );
+
 		// Initialize with the supplied geometry
 		struct mlt_geometry_item_s item;
 		mlt_geometry_parse_item( geom, &item, arg  );

--- a/src/modules/vmfx/filter_shape.c
+++ b/src/modules/vmfx/filter_shape.c
@@ -115,20 +115,7 @@ static mlt_frame filter_process( mlt_filter this, mlt_frame frame )
 
 	// Calculate the position and length
 	int position = mlt_filter_get_position( this, frame );
-	int in = mlt_filter_get_in( this );
-	int out = mlt_filter_get_out( this );
-	int length;
-
-	// Special case for attached filters - in/out come through on the frame
-	if ( out == 0 )
-	{
-		in = mlt_properties_get_int( MLT_FRAME_PROPERTIES( frame ), "in" );
-		out = mlt_properties_get_int( MLT_FRAME_PROPERTIES( frame ), "out" );
-		position -= in;
-	}
-
-	// Duration of the shape
-	length = out - in + 1;
+	mlt_position length = mlt_filter_get_length2( filter, frame );
 
 	// If we haven't created the instance or it's changed
 	if ( producer == NULL || strcmp( resource, last_resource ) )


### PR DESCRIPTION
When starting an automask filter, it was using default pal_dv profile instead of actual profile. For example:
melt myclip.mpg -attach autotrack_rectangle obscure=1 geometry="50%/50%:50%x50%"

When using an HD video file, the initial rect was using 360x288 position and size instead of real half size of the clp