### PR TITLE
Allow setting audio_device and audio_driver on sdl_audio consumer

### DIFF
--- a/src/modules/sdl/consumer_sdl_audio.c
+++ b/src/modules/sdl/consumer_sdl_audio.c
@@ -166,10 +166,10 @@ int consumer_start( mlt_consumer parent )
 		char *audio_driver = mlt_properties_get( properties, "audio_driver" );
 		char *audio_device = mlt_properties_get( properties, "audio_device" );
 
-		if ( audio_driver != NULL )
+		if ( audio_driver && strcmp( audio_driver, "" ) )
 			setenv( "SDL_AUDIODRIVER", audio_driver, 1 );
 
-		if ( audio_device != NULL )
+		if ( audio_device && strcmp( audio_device, "" ) )
 			setenv( "AUDIODEV", audio_device, 1 );
 
 		pthread_mutex_lock( &mlt_sdl_mutex );

--- a/src/modules/sdl/consumer_sdl_audio.c
+++ b/src/modules/sdl/consumer_sdl_audio.c
@@ -162,6 +162,16 @@ int consumer_start( mlt_consumer parent )
 	{
 		consumer_stop( parent );
 
+		mlt_properties properties = MLT_CONSUMER_PROPERTIES( parent );
+		char *audio_driver = mlt_properties_get( properties, "audio_driver" );
+		char *audio_device = mlt_properties_get( properties, "audio_device" );
+
+		if ( audio_driver != NULL )
+			setenv( "SDL_AUDIODRIVER", audio_driver, 1 );
+
+		if ( audio_device != NULL )
+			setenv( "AUDIODEV", audio_device, 1 );
+
 		pthread_mutex_lock( &mlt_sdl_mutex );
 		int ret = SDL_Init( SDL_INIT_AUDIO | SDL_INIT_NOPARACHUTE );
 		pthread_mutex_unlock( &mlt_sdl_mutex );


### PR DESCRIPTION
Since we now mostly use sdl_audio, we should be able to set SDL's audio_device and audio_driver like on other sdl consumer I think.