### PR TITLE
Preview - changes for ffmpeg 2.8 and additional features for av_player

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -820,13 +820,15 @@ static int seek_video( producer_avformat self, mlt_position position,
 	int64_t req_position, int preseek )
 {
 	mlt_producer producer = self->parent;
+        mlt_properties properties = MLT_PRODUCER_PROPERTIES( producer );
 	int paused = 0;
+        int seek_threshold=mlt_properties_get_int( properties, "seek_threshold" );
+        if (seek_threshold<=0) seek_threshold=12;
 
 	pthread_mutex_lock( &self->packets_mutex );
 
 	if ( self->seekable && ( position != self->video_expected || self->last_position < 0 ) )
 	{
-		mlt_properties properties = MLT_PRODUCER_PROPERTIES( producer );
 
 		// Fetch the video format context
 		AVFormatContext *context = self->video_format;
@@ -849,7 +851,7 @@ static int seek_video( producer_avformat self, mlt_position position,
 			// We're paused - use last image
 			paused = 1;
 		}
-		else if ( self->seekable && ( position < self->video_expected || position - self->video_expected >= 12 || self->last_position < 0 ) )
+		else if ( self->seekable && ( position < self->video_expected || position - self->video_expected >= seek_threshold || self->last_position < 0 ) )
 		{
 			// Calculate the timestamp for the requested frame
 			int64_t timestamp = req_position / ( av_q2d( self->video_time_base ) * source_fps );

--- a/src/modules/avformat/producer_avformat.yml
+++ b/src/modules/avformat/producer_avformat.yml
@@ -228,3 +228,15 @@ parameters:
     minimum: 0
     maximum: 1
     widget: checkbox
+
+  - identifier: seek_threshold
+    title: Seek Threshold
+    description: >
+      Number of frames required to trigger a seek forward rather than continuous read
+      when reading forward - this can be useful to optimise some applications which
+      rely on accelerated readin of a media file, or in cases where lack of I-frames in orignal
+      media files cause ffmpeg to face issues in seeking and where user tries to minimise the
+      number of call to seek.
+    type: integer
+    unit: frames
+    readonly: no


### PR DESCRIPTION
Dear MLT team,

Thanks to consider the patches for integration in a future releases

I. We needed to access the "rotate" metadata of a file.
- I have added the code to extract the information in avformat_producer. I think it can be useful to others.

II. Seek Threshold
- We have experienced problem with 3GP files and other files with long GOP in seeking however as our application on read forward, it easily solved by changing the threshold required for a "seek", this option was not accessible in previous avproducer. I have made this available by adding an option seek_threshold to the avformat_producer.

III. FFMPEG 2.8
Finally, we tried using the producer with ffmpeg 2.8 and the API has changed, and numerous minor fixes were needed. The current patch is likely to cause issues with previous version of 2.7 as no version checking has been integrated and it has not yet been thoroughly checked - but it could be a good start in that direction.

Best regards,

Bertrand NOUVEL

