### PR TITLE
Fix possible segfault in mlt_multitrack_count()

### DIFF
--- a/src/framework/mlt_multitrack.c
+++ b/src/framework/mlt_multitrack.c
@@ -346,7 +346,10 @@ int mlt_multitrack_disconnect( mlt_multitrack self, int track )
 
 int mlt_multitrack_count( mlt_multitrack self )
 {
-	return self->count;
+	if ( self == NULL )
+		return 0;
+	else
+		return self->count;
 }
 
 /** Get an individual track as a producer.


### PR DESCRIPTION
I was just trying to open an MLT-generated XML with Kdenlive, but I get a segfault in `mlt_multitrack_count()` with the following backtrace:

```
$ gdb kdenlive
Reading symbols from kdenlive...Reading symbols from /usr/lib/debug/.build-id/04/6159545fb813bff8868b0421d49201ff3d26ce.debug...^[[Adone.
done.
(gdb) r foo.xml 
Starting program: /usr/bin/kdenlive foo.xml
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7fffe2811700 (LWP 324)]
[New Thread 0x7fffc2738700 (LWP 346)]
[New Thread 0x7fffbd4c3700 (LWP 385)]
[New Thread 0x7fffb7fff700 (LWP 386)]
Invalid playlist
Removing cache at "/home/rohieb/.cache/kdenlive-thumbs.kcache"
 // / processing file open
 // / processing file open: validate
[New Thread 0x7fffb6665700 (LWP 396)]
[New Thread 0x7fffb5e64700 (LWP 397)]
Opening a document with version  0  /  0.91
 // / processing file validate ok
QXcbConnection: XCB error: 8 (BadMatch), sequence: 746, resource id: 52428818, major code: 155 (Unknown), minor code: 11
Invalid playlist
QCursor: Cannot create bitmap cursor; invalid bitmap(s)
// TRACTOR PROBLEM xml-string
// TRACTOR PROBLEM

Program received signal SIGSEGV, Segmentation fault.
mlt_multitrack_count (self=0x0) at mlt_multitrack.c:349
349	mlt_multitrack.c: No such file or directory.
(gdb) bt
    at /tmp/buildd/kdenlive-15.08.3/src/timeline/timeline.cpp:366
    ok=<optimized out>, parent=0xba62e0) at /tmp/buildd/kdenlive-15.08.3/src/timeline/timeline.cpp:118
    stale=<optimized out>, stale@entry=0x0) at /tmp/buildd/kdenlive-15.08.3/src/project/projectmanager.cpp:461
    at /tmp/buildd/kdenlive-15.08.3/src/project/projectmanager.cpp:410
    at /tmp/buildd/kdenlive-15.08.3/src/project/projectmanager.cpp:297
    at /tmp/buildd/kdenlive-15.08.3/src/project/projectmanager.cpp:79
    _id=<optimized out>, _a=<optimized out>)
    at /tmp/buildd/kdenlive-15.08.3/obj-x86_64-linux-gnu/src/moc_projectmanager.cpp:143
[…]
```

The problem here is that `mlt_multitrack_count()` is called with `self=0` and tries to access `self->count` (see [the code][0]). I don't know why this happens here, if anyone is interested in debugging this, `foo.xml` is [in this gist](https://gist.github.com/rohieb/ac0876d6edd365009120). This pull-request only fixes the null-pointer access ;-)

[0]: https://github.com/mltframework/mlt/blob/master/src/framework/mlt_multitrack.c#L349