### PR TITLE
Correctly reset cached bitmap when discarding luma in composite transition

### DIFF
--- a/src/modules/core/transition_composite.c
+++ b/src/modules/core/transition_composite.c
@@ -655,6 +655,7 @@ static uint16_t* get_luma( mlt_transition self, mlt_properties properties, int w
 		if ( old_luma && old_luma[0] )
 		{
 			mlt_properties_set_data( properties, "_luma.orig_bitmap", NULL, 0, NULL, NULL );
+			mlt_properties_set_data( properties, "_luma.bitmap", NULL, 0, NULL, NULL );
 			luma_bitmap = NULL;
 			mlt_properties_set( properties, "_luma", NULL);
 		}


### PR DESCRIPTION
When using a composite transition with a luma, if you want to remove the luma it didn't work because cached luma was not deleted. (Kdenlive bug 356200)