### PR TITLE
Improve detection for low volume in audiolevel filter

### DIFF
--- a/src/modules/normalize/filter_audiolevel.c
+++ b/src/modules/normalize/filter_audiolevel.c
@@ -75,7 +75,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 
 		for ( s = 0; s < num_samples; s++ )
 		{
-			double sample = cabs( pcm[c + s * num_channels] / 128.0 );
+			double sample = fabs( pcm[c + s * num_channels] / 128.0 );
 			val += sample;
 			if ( sample == 128 )
 				num_oversample++;

--- a/src/modules/normalize/filter_audiolevel.c
+++ b/src/modules/normalize/filter_audiolevel.c
@@ -70,12 +70,12 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 
 	for ( c = 0; c < *channels; c++ )
 	{
-		long val = 0;
+		double val = 0;
 		double level = 0.0;
 
 		for ( s = 0; s < num_samples; s++ )
 		{
-			int sample = abs( pcm[c + s * num_channels] / 128 );
+			double sample = cabs( pcm[c + s * num_channels] / 128.0 );
 			val += sample;
 			if ( sample == 128 )
 				num_oversample++;


### PR DESCRIPTION
Currently, the audiolevel filter returns a 0 volume for all audio below -20dB. However, the -50dB to -20dB range is still audible, and it feels strange to have no apparent volume with this filter. My patch proposal increases sensitivity to return non zero values for low volume (allowing improved audio level meter in Kdenlive)