### PR TITLE
crop_to_fill property to composite transition

### DIFF
--- a/src/modules/core/transition_composite.yml
+++ b/src/modules/core/transition_composite.yml
@@ -56,6 +56,17 @@ parameters:
     maximum: 1
     mutable: yes
     widget: checkbox
+  - identifier: crop_to_fill
+    title: Fill by cropping
+    description: >
+      When set, causes the B frame image to fill the WxH completely by 
+      cropping edges in order to maintain B's aspect ratio.
+    type: integer
+    default: 0
+    minimum: 0
+    maximum: 1
+    mutable: yes
+    widget: checkbox	
   - identifier: halign
     title: Horizontal alignment
     description: >

--- a/src/modules/core/transition_composite.yml
+++ b/src/modules/core/transition_composite.yml
@@ -59,14 +59,14 @@ parameters:
   - identifier: crop_to_fill
     title: Fill by cropping
     description: >
-      When set, causes the B frame image to fill the WxH completely by 
+      When set, causes the B frame image to fill the WxH completely by
       cropping edges in order to maintain B's aspect ratio.
     type: integer
     default: 0
     minimum: 0
     maximum: 1
     mutable: yes
-    widget: checkbox	
+    widget: checkbox
   - identifier: halign
     title: Horizontal alignment
     description: >


### PR DESCRIPTION
The property crop_to_fill on composite transition fills the B frame completely by cropping edges of the A frame, in order to maintain the aspect ratio.
halign and valign properties can be used to select which edges to crop.