### PR TITLE
Rename config.h to MltConfig.h

### DIFF
--- a/src/mlt++/Makefile
+++ b/src/mlt++/Makefile
@@ -51,7 +51,7 @@ OBJS = MltAnimation.o \
 	   MltTransition.o
 
 SRCS = $(OBJS:.o=.cpp)
-HEADERS = config.h Mlt.h $(OBJS:.o=.h)
+HEADERS = MltConfig.h Mlt.h $(OBJS:.o=.h)
 
 all:		$(TARGET)
 

--- a/src/mlt++/MltAnimation.h
+++ b/src/mlt++/MltAnimation.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_ANIMATION_H
 #define MLTPP_ANIMATION_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltConfig.h
+++ b/src/mlt++/MltConfig.h
@@ -1,5 +1,5 @@
 /**
- * config.h - Convenience header file for all mlt++ objects
+ * MltConfig.h - Convenience header file for all mlt++ objects
  * Copyright (C) 2004-2015 Meltytech, LLC
  * Author: Charles Yates <charles.yates@gmail.com>
  *

--- a/src/mlt++/MltConsumer.h
+++ b/src/mlt++/MltConsumer.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_CONSUMER_H
 #define MLTPP_CONSUMER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltDeque.h
+++ b/src/mlt++/MltDeque.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_DEQUE_H
 #define MLTPP_DEQUE_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltEvent.h
+++ b/src/mlt++/MltEvent.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_EVENT_H
 #define MLTPP_EVENT_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltFactory.h
+++ b/src/mlt++/MltFactory.h
@@ -22,7 +22,7 @@
 #ifndef MLTPP_FACTORY_H
 #define MLTPP_FACTORY_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #ifdef SWIG
 #define MLTPP_DECLSPEC

--- a/src/mlt++/MltField.h
+++ b/src/mlt++/MltField.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_FIELD_H
 #define MLTPP_FIELD_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltFilter.h
+++ b/src/mlt++/MltFilter.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_FILTER_H
 #define MLTPP_FILTER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltFilteredConsumer.h
+++ b/src/mlt++/MltFilteredConsumer.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_FILTERED_CONSUMER_H
 #define MLTPP_FILTERED_CONSUMER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include "MltConsumer.h"
 #include "MltFilter.h"

--- a/src/mlt++/MltFilteredProducer.h
+++ b/src/mlt++/MltFilteredProducer.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_FILTERED_PRODUCER_H
 #define MLTPP_FILTERED_PRODUCER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include "MltProducer.h"
 #include "MltFilter.h"

--- a/src/mlt++/MltFrame.h
+++ b/src/mlt++/MltFrame.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_FRAME_H
 #define MLTPP_FRAME_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 #include "MltProperties.h"

--- a/src/mlt++/MltGeometry.h
+++ b/src/mlt++/MltGeometry.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_GEOMETRY_H
 #define MLTPP_GEOMETRY_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltMultitrack.h
+++ b/src/mlt++/MltMultitrack.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_MULTITRACK_H
 #define MLTPP_MULTITRACK_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltParser.h
+++ b/src/mlt++/MltParser.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_PARSER_H
 #define MLTPP_PARSER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 #include "MltProperties.h"

--- a/src/mlt++/MltPlaylist.h
+++ b/src/mlt++/MltPlaylist.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_PLAYLIST_H
 #define MLTPP_PLAYLIST_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_PRODUCER_H
 #define MLTPP_PRODUCER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltProfile.h
+++ b/src/mlt++/MltProfile.h
@@ -20,7 +20,7 @@
 #ifndef MLTPP_PROFILE_H
 #define MLTPP_PROFILE_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #ifdef SWIG
 #define MLTPP_DECLSPEC

--- a/src/mlt++/MltProperties.h
+++ b/src/mlt++/MltProperties.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_PROPERTIES_H
 #define MLTPP_PROPERTIES_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <stdio.h>
 #include <framework/mlt.h>

--- a/src/mlt++/MltPushConsumer.h
+++ b/src/mlt++/MltPushConsumer.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_PUSH_CONSUMER_H
 #define MLTPP_PUSH_CONSUMER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include "MltConsumer.h"
 

--- a/src/mlt++/MltRepository.h
+++ b/src/mlt++/MltRepository.h
@@ -20,7 +20,7 @@
 #ifndef MLTPP_REPOSITORY_H
 #define MLTPP_REPOSITORY_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #ifdef SWIG
 #define MLTPP_DECLSPEC

--- a/src/mlt++/MltService.h
+++ b/src/mlt++/MltService.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_SERVICE_H
 #define MLTPP_SERVICE_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltTokeniser.h
+++ b/src/mlt++/MltTokeniser.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_TOKENISER_H
 #define MLTPP_TOKENISER_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltTractor.h
+++ b/src/mlt++/MltTractor.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_TRACTOR_H
 #define MLTPP_TRACTOR_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 

--- a/src/mlt++/MltTransition.h
+++ b/src/mlt++/MltTransition.h
@@ -21,7 +21,7 @@
 #ifndef MLTPP_TRANSITION_H
 #define MLTPP_TRANSITION_H
 
-#include "config.h"
+#include "MltConfig.h"
 
 #include <framework/mlt.h>
 #include "MltService.h"


### PR DESCRIPTION
Hi,

config.h is usually the name of a per-project autoconf generated header. Shipping a header named as such seems like a potential issue for any project using autotools
