### PR TITLE
pkg-config instead of sdl-config allows cross-builds

### DIFF
--- a/src/melt/Makefile
+++ b/src/melt/Makefile
@@ -11,8 +11,8 @@ SRCS := $(OBJS:.o=.c)
 
 ifeq ($(targetos), MinGW)
 ifeq (, $(findstring MELT_NOSDL, $(CFLAGS)))
-CFLAGS += $(shell sdl-config --cflags)
-LDFLAGS += $(shell sdl-config --libs)
+CFLAGS += $(shell  pkg-config --cflags sdl)
+LDFLAGS += $(shell pkg-config --libs sdl)
 endif
 bindir = $(prefix)
 endif

--- a/src/modules/sdl/Makefile
+++ b/src/modules/sdl/Makefile
@@ -21,9 +21,9 @@ else ifneq ($(targetos), MinGW)
 LDFLAGS += -lX11
 endif
 
-CFLAGS += $(shell sdl-config --cflags)
+CFLAGS += $(shell pkg-config --cflags sdl)
 
-LDFLAGS += $(shell sdl-config --libs)
+LDFLAGS += $(shell pkg-config --libs sdl)
 
 ifeq ($(WITH_SDL_IMAGE),1)
 OBJS += producer_sdl_image.o

--- a/src/modules/sdl/configure
+++ b/src/modules/sdl/configure
@@ -3,13 +3,13 @@
 if [ "$help" != "1" ]
 then
 
-	sdl-config --version > /dev/null 2>&1
+	pkg-config --exists sdl > /dev/null 2>&1
 	disable_sdl=$?
 
 	if [ "$disable_sdl" = "0" ]
 	then
 		echo > config.mak
-		image=`sdl-config --prefix`/include/SDL/SDL_image.h
+		image=`pkg-config --variable=prefix sdl`/include/SDL/SDL_image.h
 		if [ -f "$image" ]
 		then
 			echo "WITH_SDL_IMAGE=1" >> config.mak


### PR DESCRIPTION
Hello,

In the process of building kdenlive & all deps through MXE, I applied this patch to MLT.
pkg-config is automatically configured to point to target libs, what I didn't manage to do with sdl-config (always pointing to host libs).
MLT now cross-builds properly with MXE, and of course still builds natively.
Would you be interested in building this way in any case?

Cheers,

Vincent