### PR TITLE
Decklink improvements

### DIFF
--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -474,6 +474,9 @@ protected:
 
 		*decklinkFrame = frame;
 
+		if ( !frame )
+			return false;
+
 		// Make the first line black for field order correction.
 		if ( S_OK == frame->GetBytes( (void**) &buffer ) && buffer )
 		{
@@ -762,6 +765,7 @@ protected:
 		{
 			mlt_log_verbose( getConsumer(), "ScheduledFrameCompleted: bmdOutputFrameDropped == completed\n" );
 			m_count++;
+			ScheduleNextFrame( false );
 		}
 
 		return S_OK;

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -729,6 +729,9 @@ protected:
 				mlt_log_error( getConsumer(), "%s:%d mlt_frame_get_audio failed\n", __FUNCTION__, __LINE__);
 
 			mlt_frame_close( frame );
+
+			if ( !preroll )
+				RenderAudioSamples ( preroll );
 		}
 
 		if ( preroll )

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -64,6 +64,7 @@ private:
 	uint32_t                    m_reprio;
 
 	mlt_deque                   m_aqueue;
+	pthread_mutex_t             m_aqueue_lock;
 	mlt_deque                   m_frames;
 
 	pthread_mutex_t             m_op_lock;
@@ -128,6 +129,7 @@ public:
 		pthread_mutexattr_settype( &mta, PTHREAD_MUTEX_RECURSIVE );
 		pthread_mutex_init( &m_op_lock, &mta );
 		pthread_mutex_init( &m_op_arg_mutex, &mta );
+		pthread_mutex_init( &m_aqueue_lock, &mta );
 		pthread_mutexattr_destroy( &mta );
 		pthread_cond_init( &m_op_arg_cond, NULL );
 		pthread_create( &m_op_thread, NULL, op_main, this );
@@ -150,6 +152,7 @@ public:
 		pthread_join(m_op_thread, NULL);
 		mlt_log_debug( getConsumer(), "%s: finished op thread\n", __FUNCTION__ );
 
+		pthread_mutex_destroy( &m_aqueue_lock );
 		pthread_mutex_destroy(&m_op_lock);
 		pthread_mutex_destroy(&m_op_arg_mutex);
 		pthread_cond_destroy(&m_op_arg_cond);
@@ -440,8 +443,10 @@ protected:
 			m_deckLinkOutput->DisableVideoOutput();
 		}
 
+		pthread_mutex_lock( &m_aqueue_lock );
 		while ( mlt_frame frame = (mlt_frame) mlt_deque_pop_back( m_aqueue ) )
 			mlt_frame_close( frame );
+		pthread_mutex_unlock( &m_aqueue_lock );
 
 		while ( IDeckLinkMutableVideoFrame* frame = (IDeckLinkMutableVideoFrame*) mlt_deque_pop_back( m_frames ) )
 			SAFE_RELEASE( frame );
@@ -462,8 +467,10 @@ protected:
 		properties = MLT_FRAME_PROPERTIES( frame );
 		mlt_properties_set_int64( properties, "m_count", m_count);
 		mlt_properties_inc_ref( properties );
+		pthread_mutex_lock( &m_aqueue_lock );
 		mlt_deque_push_back( m_aqueue, frame );
 		mlt_log_debug( getConsumer(), "%s:%d frame=%p, len=%d\n", __FUNCTION__, __LINE__, frame, mlt_deque_count( m_aqueue ));
+		pthread_mutex_unlock( &m_aqueue_lock );
 	}
 
 	bool createFrame( IDeckLinkMutableVideoFrame** decklinkFrame )
@@ -678,8 +685,10 @@ protected:
 	virtual HRESULT STDMETHODCALLTYPE RenderAudioSamples ( bool preroll )
 #endif
 	{
+		pthread_mutex_lock( &m_aqueue_lock );
 		mlt_log_debug( getConsumer(), "%s: ENTERING preroll=%d, len=%d\n", __FUNCTION__, (int)preroll, mlt_deque_count( m_aqueue ));
 		mlt_frame frame = (mlt_frame) mlt_deque_pop_front( m_aqueue );
+		pthread_mutex_unlock( &m_aqueue_lock );
 
 		reprio( 2 );
 

--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -361,6 +361,9 @@ public:
 			IDeckLinkAudioInputPacket* audio )
 	{
 		mlt_frame frame = NULL;
+		struct timeval arrived;
+
+		gettimeofday(&arrived, NULL);
 
 		if( !m_reprio )
 		{
@@ -534,6 +537,8 @@ public:
 		// Put frame in queue
 		if ( frame )
 		{
+			mlt_properties_set_int64( MLT_FRAME_PROPERTIES( frame ), "arrived",
+				arrived.tv_sec * 1000000LL + arrived.tv_usec );
 			int queueMax = mlt_properties_get_int( MLT_PRODUCER_PROPERTIES( getProducer() ), "buffer" );
 			pthread_mutex_lock( &m_mutex );
 			if ( mlt_deque_count( m_queue ) < queueMax )

--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -487,7 +487,8 @@ public:
 			}
 
 			// Get timecode
-			if ( video->GetTimecode( bmdTimecodeVITC, &timecode ) == S_OK && timecode )
+			if ( ( S_OK == video->GetTimecode( bmdTimecodeRP188, &timecode ) ||
+				S_OK == video->GetTimecode( bmdTimecodeVITC, &timecode ))  && timecode )
 			{
 				DLString timecodeString = 0;
 


### PR DESCRIPTION
**Save frame arrivial time**

Implementing timecode from current time require frame timestamp. This patch set property *arrived* for frame with 64-bit scalar value based on a gettimeofday data.

**Use RP188 to get timecode from signal**

In current implementation only VITC timecode extracted from incoming frame, but fo HD mode RP188 timecode should be queried.

**Dropped frames recovery**

On high loaded system dropped frames happens very often. I noticed that dropping frames number equal to prerolled video callback stopped and only audio callback called. Scheduling one more frame for each dropped frame recover video-callback.

**Push all available audio samples to decklink**

In 25fps mode audio interrupt (callback) called twice per frame (i.e. once per field). In 50fps mode only one audio callback happens. as result queued audio frames not been sent at appropriate time decklink and as result muted audio

**Avoid possible race condition**

I noticed some segfault when getting frames from a_queue. I suspect it could be caused by damaging queue because of audio and video callbacks running in parallel because of IRQs scheduled amount free CPUs. 
