### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+before_script:
+- sudo apt-get -qq update
+- sudo apt-get build-dep melt
+script:
+- ./configure && make -j


### PR DESCRIPTION
Usage of this service pervents issues like [failure of make due to `factory.c:42:53: error: unknown type name ‘plugin_desc_t’`](https://travis-ci.org/krichter722/mlt/builds/167195137) (I assume you don't need an extra report for this).