### PR TITLE
Pango adons

### DIFF
--- a/src/modules/gtk2/producer_pango.c
+++ b/src/modules/gtk2/producer_pango.c
@@ -90,6 +90,7 @@ struct producer_pango_s
 	int   size;
 	int   style;
 	int   weight;
+	int   stretch;
 	int   rotate;
 	int   width_type;
 	int   width_value;
@@ -114,7 +115,7 @@ static void producer_close( mlt_producer parent );
 static void pango_draw_background( GdkPixbuf *pixbuf, rgba_color bg );
 static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font,
 		rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family,
-		int style, int weight, int size, int outline, int rotate, int width_type, int width_value,
+		int style, int weight, int stretch, int size, int outline, int rotate, int width_type, int width_value,
 		int line_spacing, double aspect_ratio );
 static void fill_pixbuf( GdkPixbuf* pixbuf, FT_Bitmap* bitmap, int w, int h, int pad, int align, rgba_color fg, rgba_color bg );
 static void fill_pixbuf_with_outline( GdkPixbuf* pixbuf, FT_Bitmap* bitmap, int w, int h, int pad, int align, rgba_color fg, rgba_color bg, rgba_color ol, int outline );
@@ -202,6 +203,7 @@ mlt_producer producer_pango_init( const char *filename )
 		mlt_properties_set( properties, "style", "normal" );
 		mlt_properties_set( properties, "encoding", "UTF-8" );
 		mlt_properties_set_int( properties, "weight", PANGO_WEIGHT_NORMAL );
+		mlt_properties_set_int( properties, "stretch", PANGO_STRETCH_NORMAL + 1);
 		mlt_properties_set_int( properties, "rotate", 0 );
 		mlt_properties_set_int( properties, "seekable", 1 );
 
@@ -422,6 +424,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 	int style = parse_style( mlt_properties_get( producer_props, "style" ) );
 	char *encoding = mlt_properties_get( producer_props, "encoding" );
 	int weight = mlt_properties_get_int( producer_props, "weight" );
+	int stretch = mlt_properties_get_int( producer_props, "stretch" );
 	int rotate = mlt_properties_get_int( producer_props, "rotate" );
 	int size = mlt_properties_get_int( producer_props, "size" );
 	int width_type = mlt_properties_get_int( producer_props, "width_type" );
@@ -456,6 +459,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		property_changed = property_changed || ( font && this->font && strcmp( font, this->font ) );
 		property_changed = property_changed || ( family && this->family && strcmp( family, this->family ) );
 		property_changed = property_changed || ( weight != this->weight );
+		property_changed = property_changed || ( stretch != this->stretch );
 		property_changed = property_changed || ( rotate != this->rotate );
 		property_changed = property_changed || ( style != this->style );
 		property_changed = property_changed || ( size != this->size );
@@ -476,6 +480,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		set_string( &this->font, font, NULL );
 		set_string( &this->family, family, "Sans" );
 		this->weight = weight;
+		this->stretch = stretch;
 		this->rotate = rotate;
 		this->style = style;
 		this->size = size;
@@ -513,7 +518,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		
 		// Render the title
 		pixbuf = pango_get_pixbuf( markup, text, font, fgcolor, bgcolor, olcolor, pad, align, family,
-			style, weight, size, outline, rotate, width_type, width_value,
+			style, weight, stretch, size, outline, rotate, width_type, width_value,
 			line_spacing, aspect_ratio );
 
 		if ( pixbuf != NULL )
@@ -785,7 +790,7 @@ static void pango_draw_background( GdkPixbuf *pixbuf, rgba_color bg )
 
 static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font,
 	rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family, int style,
-	int weight, int size, int outline, int rotate, int width_type, int width_value,
+	int weight, int stretch, int size, int outline, int rotate, int width_type, int width_value,
 	int line_spacing, double aspect_ratio )
 {
 	PangoContext *context = pango_ft2_font_map_create_context( fontmap );
@@ -810,6 +815,9 @@ static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const 
 	}
 
 	pango_font_description_set_weight( desc, ( PangoWeight ) weight  );
+
+	if ( stretch )
+		pango_font_description_set_stretch( desc, ( PangoStretch ) ( stretch - 1 ) );
 
 	// set line_spacing
 	if ( line_spacing )

--- a/src/modules/gtk2/producer_pango.c
+++ b/src/modules/gtk2/producer_pango.c
@@ -147,6 +147,8 @@ static int parse_style( char* style )
 	int ret = PANGO_STYLE_NORMAL;
 	if( !strncmp(style, "italic", 6) )
 		ret = PANGO_STYLE_ITALIC;
+	if( !strncmp(style, "oblique", 7) )
+		ret = PANGO_STYLE_OBLIQUE;
 	return ret;
 }
 

--- a/src/modules/gtk2/producer_pango.c
+++ b/src/modules/gtk2/producer_pango.c
@@ -93,6 +93,7 @@ struct producer_pango_s
 	int   rotate;
 	int   width_type;
 	int   width_value;
+	int   line_spacing;
 	double aspect_ratio;
 };
 
@@ -114,7 +115,7 @@ static void pango_draw_background( GdkPixbuf *pixbuf, rgba_color bg );
 static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font,
 		rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family,
 		int style, int weight, int size, int outline, int rotate, int width_type, int width_value,
-		double aspect_ratio );
+		int line_spacing, double aspect_ratio );
 static void fill_pixbuf( GdkPixbuf* pixbuf, FT_Bitmap* bitmap, int w, int h, int pad, int align, rgba_color fg, rgba_color bg );
 static void fill_pixbuf_with_outline( GdkPixbuf* pixbuf, FT_Bitmap* bitmap, int w, int h, int pad, int align, rgba_color fg, rgba_color bg, rgba_color ol, int outline );
 
@@ -425,6 +426,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 	int size = mlt_properties_get_int( producer_props, "size" );
 	int width_type = mlt_properties_get_int( producer_props, "width_type" );
 	int width_value = mlt_properties_get_int( producer_props, "width_value" );
+	int line_spacing = mlt_properties_get_int( producer_props, "line_spacing" );
 	double aspect_ratio = mlt_properties_get_double( properties, "aspect_ratio" );
 	int property_changed = 0;
 
@@ -459,6 +461,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		property_changed = property_changed || ( size != this->size );
 		property_changed = property_changed || ( width_type != this->width_type );
 		property_changed = property_changed || ( width_value != this->width_value );
+		property_changed = property_changed || ( line_spacing != this->line_spacing );
 		property_changed = property_changed || ( aspect_ratio != this->aspect_ratio );
 
 		// Save the properties for next comparison
@@ -478,6 +481,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		this->size = size;
 		this->width_type = width_type;
 		this->width_value = width_value;
+		this->line_spacing = line_spacing;
 		this->aspect_ratio = aspect_ratio;
 	}
 
@@ -510,7 +514,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		// Render the title
 		pixbuf = pango_get_pixbuf( markup, text, font, fgcolor, bgcolor, olcolor, pad, align, family,
 			style, weight, size, outline, rotate, width_type, width_value,
-			aspect_ratio );
+			line_spacing, aspect_ratio );
 
 		if ( pixbuf != NULL )
 		{
@@ -781,7 +785,8 @@ static void pango_draw_background( GdkPixbuf *pixbuf, rgba_color bg )
 
 static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font,
 	rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family, int style,
-	int weight, int size, int outline, int rotate, int width_type, int width_value, double aspect_ratio )
+	int weight, int size, int outline, int rotate, int width_type, int width_value,
+	int line_spacing, double aspect_ratio )
 {
 	PangoContext *context = pango_ft2_font_map_create_context( fontmap );
 	PangoLayout *layout = pango_layout_new( context );
@@ -805,6 +810,10 @@ static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const 
 	}
 
 	pango_font_description_set_weight( desc, ( PangoWeight ) weight  );
+
+	// set line_spacing
+	if ( line_spacing )
+		pango_layout_set_spacing( layout,  PANGO_SCALE * line_spacing );
 
 	// set wrapping constraints
 	if ( width_value && ( WIDTH_TYPE_WRAP_WORD == width_type

--- a/src/modules/gtk2/producer_pango.c
+++ b/src/modules/gtk2/producer_pango.c
@@ -32,6 +32,16 @@
 
 typedef struct producer_pango_s *producer_pango;
 
+enum
+{
+	WIDTH_TYPE_NONE = 0,
+	WIDTH_TYPE_CROP,
+	WIDTH_TYPE_FIT,
+	WIDTH_TYPE_WRAP_WORD,
+	WIDTH_TYPE_WRAP_CHAR,
+	WIDTH_TYPE_WRAP_WORDCHAR
+};
+
 typedef enum
 {
 	pango_align_left = 0,
@@ -81,8 +91,8 @@ struct producer_pango_s
 	int   style;
 	int   weight;
 	int   rotate;
-	int   width_crop;
-	int   width_fit;
+	int   width_type;
+	int   width_value;
 	double aspect_ratio;
 };
 
@@ -103,7 +113,7 @@ static void producer_close( mlt_producer parent );
 static void pango_draw_background( GdkPixbuf *pixbuf, rgba_color bg );
 static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font,
 		rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family,
-		int style, int weight, int size, int outline, int rotate, int width_crop, int width_fit,
+		int style, int weight, int size, int outline, int rotate, int width_type, int width_value,
 		double aspect_ratio );
 static void fill_pixbuf( GdkPixbuf* pixbuf, FT_Bitmap* bitmap, int w, int h, int pad, int align, rgba_color fg, rgba_color bg );
 static void fill_pixbuf_with_outline( GdkPixbuf* pixbuf, FT_Bitmap* bitmap, int w, int h, int pad, int align, rgba_color fg, rgba_color bg, rgba_color ol, int outline );
@@ -413,8 +423,8 @@ static void refresh_image( mlt_frame frame, int width, int height )
 	int weight = mlt_properties_get_int( producer_props, "weight" );
 	int rotate = mlt_properties_get_int( producer_props, "rotate" );
 	int size = mlt_properties_get_int( producer_props, "size" );
-	int width_crop = mlt_properties_get_int( producer_props, "width_crop" );
-	int width_fit = mlt_properties_get_int( producer_props, "width_fit" );
+	int width_type = mlt_properties_get_int( producer_props, "width_type" );
+	int width_value = mlt_properties_get_int( producer_props, "width_value" );
 	double aspect_ratio = mlt_properties_get_double( properties, "aspect_ratio" );
 	int property_changed = 0;
 
@@ -447,8 +457,8 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		property_changed = property_changed || ( rotate != this->rotate );
 		property_changed = property_changed || ( style != this->style );
 		property_changed = property_changed || ( size != this->size );
-		property_changed = property_changed || ( width_crop != this->width_crop );
-		property_changed = property_changed || ( width_fit != this->width_fit );
+		property_changed = property_changed || ( width_type != this->width_type );
+		property_changed = property_changed || ( width_value != this->width_value );
 		property_changed = property_changed || ( aspect_ratio != this->aspect_ratio );
 
 		// Save the properties for next comparison
@@ -466,8 +476,8 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		this->rotate = rotate;
 		this->style = style;
 		this->size = size;
-		this->width_crop = width_crop;
-		this->width_fit = width_fit;
+		this->width_type = width_type;
+		this->width_value = width_value;
 		this->aspect_ratio = aspect_ratio;
 	}
 
@@ -499,7 +509,7 @@ static void refresh_image( mlt_frame frame, int width, int height )
 		
 		// Render the title
 		pixbuf = pango_get_pixbuf( markup, text, font, fgcolor, bgcolor, olcolor, pad, align, family,
-			style, weight, size, outline, rotate, width_crop, width_fit,
+			style, weight, size, outline, rotate, width_type, width_value,
 			aspect_ratio );
 
 		if ( pixbuf != NULL )
@@ -769,7 +779,9 @@ static void pango_draw_background( GdkPixbuf *pixbuf, rgba_color bg )
 	}
 }
 
-static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font, rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family, int style, int weight, int size, int outline, int rotate, int width_crop, int width_fit, double aspect_ratio )
+static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const char *font,
+	rgba_color fg, rgba_color bg, rgba_color ol, int pad, int align, char* family, int style,
+	int weight, int size, int outline, int rotate, int width_type, int width_value, double aspect_ratio )
 {
 	PangoContext *context = pango_ft2_font_map_create_context( fontmap );
 	PangoLayout *layout = pango_layout_new( context );
@@ -794,7 +806,15 @@ static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const 
 
 	pango_font_description_set_weight( desc, ( PangoWeight ) weight  );
 
-	pango_layout_set_width( layout, -1 ); // set wrapping constraints
+	// set wrapping constraints
+	if ( width_value && ( WIDTH_TYPE_WRAP_WORD == width_type
+		|| WIDTH_TYPE_WRAP_CHAR == width_type || WIDTH_TYPE_WRAP_WORDCHAR == width_type ) )
+	{
+		pango_layout_set_width( layout,  PANGO_SCALE * width_value );
+		pango_layout_set_wrap( layout,  ( PangoWrapMode ) ( width_type - WIDTH_TYPE_WRAP_WORD ) );
+	}
+	else
+		pango_layout_set_width( layout, -1 );
 	pango_layout_set_font_description( layout, desc );
 	pango_layout_set_alignment( layout, ( PangoAlignment ) align  );
 	if ( markup != NULL && strcmp( markup, "" ) != 0 )
@@ -882,17 +902,18 @@ static GdkPixbuf *pango_get_pixbuf( const char *markup, const char *text, const 
 		y = rect.y;
 	}
 
-	// limit width
-	if ( width_crop && w > width_crop)
-		w = width_crop;
-	else if (width_fit && w > width_fit)
+	// limit width, i.e. crop it
+	if ( WIDTH_TYPE_CROP == width_type && w > width_value )
+		w = width_value;
+	// limit squeeze, i.e. fit it
+	else if ( WIDTH_TYPE_FIT == width_type && w > width_value )
 	{
 		double n_x, n_y;
 		PangoRectangle rect;
 		PangoMatrix m_layout = PANGO_MATRIX_INIT, m_offset = PANGO_MATRIX_INIT;
 
-		pango_matrix_scale( &m_layout, width_fit / (double)w, 1.0 );
-		pango_matrix_scale( &m_offset, width_fit / (double)w, 1.0 );
+		pango_matrix_scale( &m_layout, width_value / (double)w, 1.0 );
+		pango_matrix_scale( &m_offset, width_value / (double)w, 1.0 );
 
 		pango_context_set_base_gravity( context, PANGO_GRAVITY_AUTO );
 		pango_context_set_matrix( context, &m_layout );

--- a/src/modules/gtk2/producer_pango.yml
+++ b/src/modules/gtk2/producer_pango.yml
@@ -235,21 +235,25 @@ parameters:
     mutable: yes
     widget: spinner
 
-  - identifier: width_crop
-    title: Width to crop
+  - identifier: width_value
+    title: Value of width used by width_type limiting
     type: integer
-    description: >
-      Limit width of rendered image.
     default: 0
     readonly: no
     mutable: yes
     widget: spinner
 
-  - identifier: width_fit
-    title: Fit width
+  - identifier: width_type
+    title: Type of width limiting
     type: integer
     description: >
-      Scale pango layout to fit specified width.
+      Width limiting types (width value specified by width_value)
+         0 - none
+         1 - crop width of pango canvas
+         2 - fit - scale down width of pango canvas if it widther then value specified (width_value)
+         3 - wrap word
+         4 - wrap char
+         5 - wrap word/char
     default: 0
     readonly: no
     mutable: yes

--- a/src/modules/gtk2/producer_pango.yml
+++ b/src/modules/gtk2/producer_pango.yml
@@ -258,3 +258,13 @@ parameters:
     readonly: no
     mutable: yes
     widget: spinner
+
+  - identifier: line_spacing
+    title: Sets lines spacing
+    type: integer
+    description: >
+      Sets the amount of spacing between the lines of the layout.
+    default: 0
+    readonly: no
+    mutable: yes
+    widget: spinner

--- a/src/modules/gtk2/producer_pango.yml
+++ b/src/modules/gtk2/producer_pango.yml
@@ -167,6 +167,7 @@ parameters:
     values:
       - normal
       - italic
+      - oblique
     default: normal
     readonly: no
     mutable: yes

--- a/src/modules/gtk2/producer_pango.yml
+++ b/src/modules/gtk2/producer_pango.yml
@@ -268,3 +268,24 @@ parameters:
     readonly: no
     mutable: yes
     widget: spinner
+
+  - identifier: stretch
+    title: Font stretch
+    type: integer
+    description: >
+      The stretch feature of pango's font description. Possible values:
+        1 - ULTRA_CONDENSED
+        2 - EXTRA_CONDENSED
+        3 - CONDENSED
+        4 - SEMI_CONDENSED
+        5 - NORMAL
+        6 - SEMI_EXPANDED
+        7 - EXPANDED
+        8 - EXTRA_EXPANDED
+        9 - ULTRA_EXPANDED
+    minimum: 0
+    maximum: 9
+    default: 4
+    readonly: no
+    mutable: yes
+    widget: spinner


### PR DESCRIPTION
Attached patches extend functionality of pango producer.

**Implement fontmap reloading**

Fontset used by pango producer loaded once. That behavior prevents using new fonts till process used pango producer been restarted. Provided patch implement reloading fontmap by signal to pango producer.

**Rework fit/crop feature and implement pango wrapping support**

That changes discussed at https://sourceforge.net/p/mlt/mailman/message/34868962/

**Implement oblique font style handling**
**Implement line spacing of pango**
**Implement stretch parameter for pango producer**

This patches extend functions of pango producer by using native pango features....