### PR TITLE
Implement shared memory producer/consumer

### DIFF
--- a/src/modules/shmem/Makefile
+++ b/src/modules/shmem/Makefile
@@ -1,0 +1,40 @@
+CFLAGS += -fPIC -I../.. -Wno-deprecated -Wno-multichar
+LDFLAGS += -L../../framework -lmlt -lpthread
+
+include ../../../config.mak
+#include config.mak
+
+TARGET = ../libmltshmem$(LIBSUF)
+
+OBJS = factory.o consumer_shmem.o producer_shmem.o
+
+SRCS := $(OBJS:.o=.c)
+
+LDFLAGS += $(LIBDL)
+
+all: 	$(TARGET)
+	
+$(TARGET): $(OBJS)
+		$(CC) $(SHFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+
+depend:	$(SRCS)
+		$(CC) -MM $(CFLAGS) $^ 1>.depend
+
+distclean:	clean
+		rm -f .depend
+
+clean:
+		rm -f $(OBJS) $(TARGET)
+
+install: all
+	install -m 755 $(TARGET) "$(DESTDIR)$(moduledir)"
+	install -d "$(DESTDIR)$(mltdatadir)/ndi"
+#	install -m 644 *.yml "$(DESTDIR)$(mltdatadir)/ndi"
+
+uninstall:
+	rm "$(DESTDIR)$(moduledir)/libmltndi$(LIBSUF)" 2> /dev/null || true
+	rm -rf "$(DESTDIR)$(mltdatadir)/ndi"
+
+ifneq ($(wildcard .depend),)
+include .depend
+endif

--- a/src/modules/shmem/configure
+++ b/src/modules/shmem/configure
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ "$help" = "1" ]
+then
+	cat << EOF
+Shared memory producer/consumer has not options.
+
+  This module supported under Linux only now
+EOF
+
+else
+	targetos=$(uname -s)
+	case $targetos in
+	Linux)
+		echo "- SHMEM enabled"
+		rm -f ../disable-shmem
+		;;
+	*)
+		echo "- SHMEM supported on linux only: disabling it"
+		touch ../disable-shmem
+		;;
+	esac
+fi
+
+exit 0

--- a/src/modules/shmem/consumer_shmem.c
+++ b/src/modules/shmem/consumer_shmem.c
@@ -1,0 +1,342 @@
+/*
+ * consumer_shmem.c -- output through shared memory interface
+ * Copyright (C) 2016 Maksym Veremeyenko <verem@m1stereo.tv>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with consumer library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt_producer.h>
+#include <framework/mlt_frame.h>
+#include <framework/mlt_deque.h>
+#include <framework/mlt_factory.h>
+#include <framework/mlt_profile.h>
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <fcntl.h>
+
+#include "factory.h"
+
+typedef struct
+{
+	struct mlt_consumer_s parent;
+	int f_running, f_exit;
+	char* arg;
+	pthread_t th;
+	shmem_xchg_t* shared;
+} consumer_shmem_t;
+
+static void* consumer_shmem_feeder( void* p )
+{
+	int r;
+	mlt_consumer consumer = p;
+	mlt_properties properties = MLT_CONSUMER_PROPERTIES( consumer );
+	consumer_shmem_t* self = ( consumer_shmem_t* )consumer->child;
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s: entering\n", __FUNCTION__ );
+
+	while ( !self->f_exit )
+	{
+		mlt_frame frm = NULL;
+
+		pthread_mutex_lock( &self->shared->lock );
+
+		while ( !self->f_exit && self->shared->queue.len >= SHMEM_QUEUE_SIZE )
+		{
+			struct timespec ts;
+			struct timeval tv;
+			gettimeofday( &tv, NULL );
+
+			tv.tv_usec += 10000LL;
+			ts.tv_nsec = 1000LL * ( tv.tv_usec % 1000000LL );
+			ts.tv_sec = tv.tv_sec + tv.tv_usec / 1000000LL;
+
+			pthread_cond_timedwait( &self->shared->cond, &self->shared->lock, &ts );
+		}
+
+		pthread_mutex_unlock( &self->shared->lock );
+
+		if ( self->f_exit || self->shared->queue.len >= SHMEM_QUEUE_SIZE )
+			continue;
+
+		frm = mlt_consumer_rt_frame( consumer );
+		if ( frm )
+		{
+			shmem_frame_t shf;
+			void *src, *dst;
+			mlt_properties fprops = MLT_FRAME_PROPERTIES( frm );
+
+			shf.width = 0;
+			shf.height = 0;
+			shf.shmid.image = 0;
+			shf.shmid.alpha = 0;
+			shf.shmid.audio = 0;
+
+			shf.frequency = mlt_properties_get_int( fprops, "frequency" );
+
+			shf.channels = mlt_properties_get_int( properties, "channels" )
+				? mlt_properties_get_int( properties, "channels" )
+				: mlt_properties_get_int( fprops, "channels" );
+
+			shf.samples = 0;
+
+			shf.iformat = mlt_properties_get_int( fprops, "keyer" )
+				? mlt_image_rgb24a
+				: mlt_image_yuv422;
+
+			shf.aformat = mlt_audio_s16;
+
+			if ( mlt_properties_get_int( fprops, "rendered" ) &&
+				!mlt_frame_get_image( frm, (uint8_t **)&src, &shf.iformat, &shf.width, &shf.height, 0 ) )
+			{
+				mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s:%d: width=%d, height=%d\n",
+					__FUNCTION__, __LINE__, shf.width, shf.height );
+
+				// find if it is already shared memory attached
+				r = shmem_block_lookup(src);
+				if ( r > 0 )
+				{
+					// set image to NULL
+					mlt_frame_set_image( frm, NULL, 0, NULL );
+
+					// save shared mem id
+					shf.shmid.image = r;
+
+					// detach
+					shmem_block_detach( src );
+				}
+				else
+				{
+					// get image size
+					int image_size = mlt_image_format_size( shf.iformat, shf.width, shf.height, NULL );
+
+					// create shared block and attach
+					shf.shmid.image = shmem_block_create_attach( image_size, &dst );
+
+					// copy video data
+					memcpy( dst, src, image_size );
+
+					// detach
+					shmem_block_detach( dst );
+				}
+
+				src = mlt_frame_get_alpha( frm );
+				if ( src )
+				{
+					// find if it is already shared memory attached
+					r = shmem_block_lookup(src);
+					if ( r > 0 )
+					{
+						// set image to NULL
+						mlt_frame_set_alpha( frm, NULL, 0, NULL );
+
+						// save shared mem id
+						shf.shmid.alpha = r;
+
+						// detach
+						shmem_block_detach( src );
+					}
+					else
+					{
+						// get image size
+						int alpha_size = shf.width * shf.height;
+
+						// create shared block and attach
+						shf.shmid.alpha = shmem_block_create_attach( alpha_size, &dst );
+
+						// copy video data
+						memcpy( dst, src, alpha_size );
+
+						// detach
+						shmem_block_detach( dst );
+					}
+				}
+
+				if ( !mlt_frame_get_audio( frm, &src, &shf.aformat, &shf.frequency, &shf.channels, &shf.samples ) )
+				{
+					// find if it is already shared memory attached
+					r = shmem_block_lookup(src);
+					if ( r > 0 )
+					{
+						// set audio to NULL
+						mlt_frame_set_audio( frm, NULL, 0, 0, NULL );
+
+						// save shared mem id
+						shf.shmid.audio = r;
+
+						// detach
+						shmem_block_detach( src );
+					}
+					else
+					{
+						// get audio size
+						int audio_size = mlt_audio_format_size( shf.aformat, shf.samples, shf.channels );
+
+						// create shared block and attach
+						shf.shmid.audio = shmem_block_create_attach( audio_size, &dst );
+
+						// copy video data
+						memcpy( dst, src, audio_size );
+
+						// detach
+						shmem_block_detach( dst );
+					}
+				}
+			}
+
+			/* put frame into queue */
+			pthread_mutex_lock( &self->shared->lock );
+			self->shared->queue.frames[ self->shared->queue.len ] = shf;
+			self->shared->queue.len++;
+			mlt_log_debug( consumer, "%s:%d: self->shared->queue.len=%d\n",
+				__FUNCTION__, __LINE__, self->shared->queue.len );
+			pthread_cond_signal( &self->shared->cond );
+			pthread_mutex_unlock( &self->shared->lock );
+		}
+
+		if ( frm )
+		{
+			mlt_events_fire( properties, "consumer-frame-show", frm, NULL );
+			mlt_frame_close( frm );
+		}
+	}
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s: exiting\n", __FUNCTION__ );
+
+	return NULL;
+}
+
+static int consumer_shmem_start( mlt_consumer consumer )
+{
+	int r = 0;
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE( consumer ), "%s: entering\n", __FUNCTION__ );
+
+	consumer_shmem_t* self = ( consumer_shmem_t* )consumer->child;
+
+	if ( !self->f_running )
+	{
+		// set flags
+		self->f_exit = 0;
+
+		pthread_create( &self->th, NULL, consumer_shmem_feeder, consumer );
+
+		// set flags
+		self->f_running = 1;
+	}
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s: exiting\n", __FUNCTION__ );
+
+	return r;
+}
+
+static int consumer_shmem_stop( mlt_consumer consumer )
+{
+	int r = 0;
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s: entering\n", __FUNCTION__ );
+
+	consumer_shmem_t* self = ( consumer_shmem_t* )consumer->child;
+
+	if ( self->f_running )
+	{
+		// rise flags
+		self->f_exit = 1;
+
+		// wait for thread
+		pthread_join( self->th, NULL );
+
+		// hide flags
+		self->f_running = 0;
+	}
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s: exiting\n", __FUNCTION__ );
+
+	return r;
+}
+
+static int consumer_shmem_is_stopped( mlt_consumer consumer )
+{
+	consumer_shmem_t* self = ( consumer_shmem_t* )consumer->child;
+	return !self->f_running;
+}
+
+static void consumer_shmem_close( mlt_consumer consumer )
+{
+	consumer_shmem_t* self = ( consumer_shmem_t* )consumer->child;
+
+	mlt_log_debug( MLT_CONSUMER_SERVICE(consumer), "%s: entering\n", __FUNCTION__ );
+
+	// Stop the consumer
+	mlt_consumer_stop( consumer );
+
+	// Close the parent
+	consumer->close = NULL;
+	mlt_consumer_close( consumer );
+
+	// free context
+	if ( self->arg )
+		free( self->arg );
+
+	free( self );
+
+	mlt_log_debug( NULL, "%s: exiting\n", __FUNCTION__ );
+}
+
+/** Initialise the consumer.
+ */
+mlt_consumer consumer_shmem_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	// allocate/attach to shared region
+	shmem_xchg_t* ctx = shmem_xchg_create(arg);
+	if ( !ctx )
+		return NULL;
+
+	// Allocate the consumer
+	consumer_shmem_t* self = ( consumer_shmem_t* )calloc( 1, sizeof( consumer_shmem_t ) );
+
+	mlt_log_debug( NULL, "%s: entering id=[%s], arg=[%s]\n", __FUNCTION__, id, arg );
+
+	// If allocated
+	if ( self && !mlt_consumer_init( &self->parent, self, profile ) )
+	{
+		mlt_consumer parent = &self->parent;
+
+		// Setup context
+		self->arg = strdup( arg );
+		self->shared = ctx;
+
+		// Setup callbacks
+		parent->close = consumer_shmem_close;
+		parent->start = consumer_shmem_start;
+		parent->stop = consumer_shmem_stop;
+		parent->is_stopped = consumer_shmem_is_stopped;
+
+		mlt_properties properties = MLT_CONSUMER_PROPERTIES( parent );
+		mlt_properties_set( properties, "deinterlace_method", "onefield" );
+
+		return parent;
+	}
+
+	free( self );
+
+	return NULL;
+}

--- a/src/modules/shmem/consumer_shmem.yml
+++ b/src/modules/shmem/consumer_shmem.yml
@@ -1,0 +1,34 @@
+schema_version: 0.2
+type: consumer
+identifier: shmem
+title: Shared memory output
+version: 3
+copyright: Copyright (C) 2016 Meltytech, LLC
+license: LGPL
+language: en
+creator: Maksym Veremeyenko
+tags:
+  - Audio
+  - Video
+description: Write frame to shared memory exchange interface
+
+notes: >
+
+  Shared memory interface allows different processes to exchange
+  a frames between them.
+
+  Usage example:
+
+      melt -profile atsc_1080i_50 jamala.mxf -consumer shmem:/tmp/demo8
+
+  Currently supported under Linux.
+
+parameters:
+  - identifier: target
+    argument: yes
+    title: File
+    type: string
+    description: >
+      Name of exisint file used to build a shared memory key to
+      indentify shared memory region.
+    widget: filesave

--- a/src/modules/shmem/factory.c
+++ b/src/modules/shmem/factory.c
@@ -1,0 +1,256 @@
+/*
+ * factory.c -- -- the factory method interfaces
+ * Copyright (C) 2016 Maksym Veremeyenko <verem@m1stereo.tv>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with consumer library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <string.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <sys/ipc.h>
+#include <sys/types.h>
+#include <sys/shm.h>
+
+#include "factory.h"
+
+static mlt_properties metadata( mlt_service_type type, const char *id, void *data )
+{
+	char file[ PATH_MAX ];
+	snprintf( file, PATH_MAX, "%s/shmem/%s", mlt_environment( "MLT_DATA" ), (char*) data );
+	return mlt_properties_parse_yaml( file );
+}
+
+MLT_REPOSITORY
+{
+	MLT_REGISTER( consumer_type, "shmem", consumer_shmem_init );
+	MLT_REGISTER( producer_type, "shmem", producer_shmem_init );
+
+	MLT_REGISTER_METADATA( consumer_type, "shmem", metadata, "consumer_shmem.yml" );
+	MLT_REGISTER_METADATA( producer_type, "shmem", metadata, "producer_shmem.yml" );
+}
+
+void shmem_xchg_destroy(shmem_xchg_t* ctx, const char* arg)
+{
+	key_t k = -1;
+	int shmid = 0;
+
+	shmdt(ctx);
+
+	if ( arg )
+		k = ftok( arg, SHMEM_FTOK_PROJ_ID );
+	if ( -1 != k )
+		shmid = shmget(k, sizeof( shmem_xchg_t ), 0666 );
+	if ( shmid > 0)
+	{
+		struct shmid_ds ds;
+		shmctl( shmid, IPC_RMID, &ds );
+	}
+}
+
+shmem_xchg_t* shmem_xchg_create(const char* arg)
+{
+	int f_init = 1;
+	key_t k;
+	int shmid;
+	shmem_xchg_t* ctx;
+
+	if ( !arg )
+	{
+		mlt_log_error( NULL, "%s: arg is NULL\n", __FUNCTION__ );
+		return NULL;
+	}
+
+	k = ftok( arg, SHMEM_FTOK_PROJ_ID );
+	if ( -1 == k )
+	{
+		mlt_log_error( NULL, "%s: ftok failed, errno=%d\n", __FUNCTION__, errno );
+		return NULL;
+	}
+	mlt_log_debug( NULL, "%s:%d: key=%d, arg=[%s]\n", __FUNCTION__, __LINE__, k, arg );
+
+	// try to get shared memory region
+	shmid = shmget(k, sizeof( shmem_xchg_t ), IPC_CREAT | IPC_EXCL | 0666 );
+	mlt_log_debug( NULL, "%s:%d: shmid=%d\n", __FUNCTION__, __LINE__, shmid );
+	if ( -1 == shmid )
+	{
+		// if exist, then dont create
+		if ( EEXIST == errno )
+		{
+			shmid = shmget(k, sizeof( shmem_xchg_t ), 0666 );
+			mlt_log_debug( NULL, "%s:%d: shmid=%d\n", __FUNCTION__, __LINE__, shmid );
+		}
+
+		// once more check
+		if ( -1 == shmid )
+		{
+			mlt_log_error( NULL, "%s: shmget failed, errno=%d\n", __FUNCTION__, errno );
+			return NULL;
+		}
+
+		f_init = 0;
+	}
+
+	// attach
+	ctx = (shmem_xchg_t*)shmat( shmid, NULL, 0 );
+	if ( !ctx )
+	{
+		mlt_log_error( NULL, "%s: shmat failed, errno=%d\n", __FUNCTION__, errno );
+		return NULL;
+	}
+
+	// init if needed
+	if ( f_init )
+	{
+		pthread_mutexattr_t mattr;
+		pthread_condattr_t cattr;
+
+		memset(ctx, 0, sizeof( shmem_xchg_t ) );
+
+		pthread_mutexattr_init( &mattr );
+		pthread_mutexattr_setpshared( &mattr, PTHREAD_PROCESS_SHARED );
+		pthread_mutexattr_settype( &mattr, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutex_init( &ctx->lock, &mattr );
+		pthread_mutexattr_destroy( &mattr );
+
+		pthread_condattr_init( &cattr );
+		pthread_condattr_setpshared( &cattr, PTHREAD_PROCESS_SHARED );
+		pthread_cond_init( &ctx->cond, &cattr );
+		pthread_condattr_destroy( &cattr );
+	}
+
+	return ctx;
+}
+
+typedef struct shmem_blocks_desc
+{
+	void* ptr;
+	int shmid;
+	struct shmem_blocks_desc* next;
+} shmem_blocks_t;
+
+static pthread_mutex_t shmem_blocks_lock = PTHREAD_MUTEX_INITIALIZER;
+static shmem_blocks_t* shmem_blocks_list = NULL;
+
+static int shmem_block_find( const void* ptr, int shmid, shmem_blocks_t** pprev, shmem_blocks_t** pcurr )
+{
+	shmem_blocks_t* head = shmem_blocks_list;
+
+	if ( pcurr )
+		*pcurr = NULL;
+	if ( pprev )
+		*pprev = NULL;
+
+	while ( head )
+	{
+		if ( pcurr )
+			*pcurr = head;
+
+		if ( ( ptr && (unsigned char*)ptr == (unsigned char*)head->ptr ) || ( shmid && shmid == head->shmid ) )
+			return 0;
+
+		if ( pprev )
+			*pprev = head;
+		head = head->next;
+	}
+
+	return -ENOENT;
+}
+
+int shmem_block_lookup( const void* arg )
+{
+	int r;
+	shmem_blocks_t* i;
+
+	pthread_mutex_lock( &shmem_blocks_lock );
+
+	r = shmem_block_find( arg, 0, NULL, &i );
+	if ( !r )
+		r = i->shmid;
+
+	pthread_mutex_unlock( &shmem_blocks_lock );
+
+	return r;
+}
+
+int shmem_block_detach( const void *arg )
+{
+	int r;
+	shmem_blocks_t *p, *c;
+
+	pthread_mutex_lock( &shmem_blocks_lock );
+
+	r = shmem_block_find( arg, 0, &p, &c );
+	if ( !r )
+	{
+		if( !p )
+			shmem_blocks_list = c->next;
+		else
+			p->next = c->next;
+		shmdt( c->ptr );
+		r = c->shmid;
+		free( c );
+	}
+
+	pthread_mutex_unlock( &shmem_blocks_lock );
+
+	return r;
+}
+
+void shmem_block_detach_destroy( const void *arg )
+{
+	int r = shmem_block_detach ( arg );
+
+	if ( r > 0 )
+	{
+		struct shmid_ds ds;
+		shmctl( r, IPC_RMID, &ds );
+	}
+}
+
+void* shmem_block_attach( int shmid, size_t* psize )
+{
+	void* ptr = NULL;
+	shmem_blocks_t *c;
+	struct shmid_ds ds;
+
+	c = (shmem_blocks_t*) calloc( 1, sizeof( shmem_blocks_t ) );
+	ptr = c->ptr = shmat( c->shmid = shmid, NULL, 0 );
+
+	pthread_mutex_lock( &shmem_blocks_lock );
+
+	c->next = shmem_blocks_list;
+	shmem_blocks_list = c;
+
+	pthread_mutex_unlock( &shmem_blocks_lock );
+
+	shmctl( shmid, IPC_STAT, &ds );
+	*psize = ds.shm_segsz;
+
+	return ptr;
+}
+
+int shmem_block_create_attach( size_t size, void** pdst )
+{
+	int r;
+
+	r = shmget( IPC_PRIVATE, size, IPC_CREAT );
+
+	*pdst = shmem_block_attach( r, &size );
+
+	return r;
+}

--- a/src/modules/shmem/factory.h
+++ b/src/modules/shmem/factory.h
@@ -1,0 +1,61 @@
+/*
+ * factory.h -- the factory method interfaces
+ * Copyright (C) 2016 Maksym Veremeyenko <verem@m1stereo.tv>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with consumer library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef FACTORY_H
+#define FACTORY_H
+
+#include <pthread.h>
+#include <framework/mlt.h>
+
+typedef struct
+{
+	int width, height;
+	int channels, frequency, samples;
+	mlt_image_format iformat;
+	mlt_audio_format aformat;
+	struct
+	{
+		int audio, image, alpha;
+	} shmid;
+} shmem_frame_t;
+
+#define SHMEM_QUEUE_SIZE 32
+#define SHMEM_FTOK_PROJ_ID 'M'
+
+typedef struct
+{
+	pthread_mutex_t lock;
+	pthread_cond_t cond;
+	struct
+	{
+		int len;
+		shmem_frame_t frames[SHMEM_QUEUE_SIZE];
+	} queue;
+} shmem_xchg_t;
+
+mlt_consumer consumer_shmem_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
+mlt_producer producer_shmem_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
+
+shmem_xchg_t* shmem_xchg_create( const char* arg );
+int shmem_block_lookup( const void* arg );
+int shmem_block_detach( const void *arg );
+void* shmem_block_attach( int shmid, size_t* size );
+int shmem_block_create_attach( size_t size, void** pdst );
+void shmem_block_detach_destroy( const void *arg );
+
+#endif /* FACTORY_H */

--- a/src/modules/shmem/producer_shmem.c
+++ b/src/modules/shmem/producer_shmem.c
@@ -1,0 +1,204 @@
+/*
+ * producer_shmem.c -- input through shared memory interface
+ * Copyright (C) 2016 Maksym Veremeyenko <verem@m1stereo.tv>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with consumer library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt_producer.h>
+#include <framework/mlt_frame.h>
+#include <framework/mlt_deque.h>
+#include <framework/mlt_factory.h>
+#include <framework/mlt_profile.h>
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <fcntl.h>
+
+#include "factory.h"
+
+typedef struct
+{
+	struct mlt_producer_s parent;
+	int f_running, f_exit, f_timeout;
+	char* arg;
+	pthread_t th;
+	shmem_xchg_t* shared;
+} producer_shmem_t;
+
+static int get_audio( mlt_frame frame, int16_t **buffer, mlt_audio_format *format, int *frequency, int *channels, int *samples )
+{
+	void *src;
+	size_t size;
+	mlt_properties fprops = MLT_FRAME_PROPERTIES( frame );
+	shmem_frame_t* pshf = mlt_properties_get_data( fprops, "shf", NULL );
+
+	src = shmem_block_attach( pshf->shmid.audio, &size );
+	mlt_frame_set_audio( frame, (uint8_t*) src, pshf->aformat, size, (mlt_destructor)shmem_block_detach_destroy );
+
+	*buffer = (int16_t *)src;
+	*format = pshf->aformat;
+	*frequency = pshf->frequency;
+	*channels = pshf->channels;
+	*samples = pshf->samples;
+
+	return 0;
+}
+
+static int get_image( mlt_frame frame, uint8_t **buffer, mlt_image_format *format, int *width, int *height, int writable )
+{
+	void *src;
+	size_t size;
+	mlt_properties fprops = MLT_FRAME_PROPERTIES( frame );
+	shmem_frame_t* pshf = mlt_properties_get_data( fprops, "shf", NULL );
+
+	src = shmem_block_attach( pshf->shmid.image, &size );
+	mlt_frame_set_image( frame, (uint8_t*) src, size, (mlt_destructor)shmem_block_detach_destroy );
+
+	*buffer = (uint8_t *)src;
+	*format = pshf->iformat;
+	*width = pshf->width;
+	*height = pshf->height;
+
+	if ( pshf->shmid.alpha )
+	{
+		src = shmem_block_attach( pshf->shmid.alpha, &size );
+		mlt_frame_set_alpha( frame, (uint8_t*) src, size, (mlt_destructor)shmem_block_detach_destroy );
+	}
+
+	return 0;
+}
+
+
+static int get_frame( mlt_producer producer, mlt_frame_ptr pframe, int index )
+{
+	int i, f_present = 0;
+	shmem_frame_t shf;
+	struct timeval now;
+	struct timespec tm;
+	double fps = mlt_producer_get_fps( producer );
+	mlt_position position = mlt_producer_position( producer );
+	producer_shmem_t* self = ( producer_shmem_t* )producer->child;
+	mlt_frame frame;
+
+	// Wait if queue is empty
+	pthread_mutex_lock( &self->shared->lock );
+	while ( !self->f_timeout && !self->shared->queue.len )
+	{
+		// Wait up to twice frame duration
+		gettimeofday( &now, NULL );
+		uint64_t usec = now.tv_sec * 1000000 + now.tv_usec;
+		usec += 2000000LL / fps;
+		tm.tv_sec = usec / 1000000LL;
+		tm.tv_nsec = (usec % 1000000LL) * 1000LL;
+		if ( pthread_cond_timedwait( &self->shared->cond, &self->shared->lock, &tm ) )
+		// Stop waiting if error (timed out)
+			break;
+	}
+	mlt_log_debug( producer, "%s:%d self->shared->queue.len=%d\n",
+		__FUNCTION__, __LINE__, self->shared->queue.len );
+	if ( self->shared->queue.len )
+	{
+		f_present = 1;
+		shf = self->shared->queue.frames[ 0 ];
+		for( i = 0; i < ( SHMEM_QUEUE_SIZE -  1 ); i++ )
+			self->shared->queue.frames[ i ] = self->shared->queue.frames[ i + 1 ];
+		self->shared->queue.len--;
+		pthread_cond_signal( &self->shared->cond );
+	};
+	pthread_mutex_unlock( &self->shared->lock );
+
+	*pframe = frame = mlt_frame_init( MLT_PRODUCER_SERVICE(producer) );
+
+	if ( f_present )
+	{
+		shmem_frame_t* pshf = (shmem_frame_t*) mlt_pool_alloc( sizeof( shmem_frame_t ) );
+
+		*pshf = shf;
+
+		mlt_properties_set_data( MLT_FRAME_PROPERTIES( frame ), "shf", (void *)pshf, 0, mlt_pool_release, NULL );
+
+		// Add audio and video getters
+		if ( shf.shmid.audio )
+			mlt_frame_push_audio( frame, (void*) get_audio );
+		if ( shf.shmid.image )
+			mlt_frame_push_get_image( frame, get_image );
+
+		mlt_frame_set_position( frame, position );
+
+		self->f_timeout = 0;
+	}
+	else
+		self->f_timeout++;
+
+	// Calculate the next timecode
+	mlt_producer_prepare_next( producer );
+
+	return 0;
+}
+
+static void producer_shmem_close( mlt_producer producer )
+{
+	free( producer->child );
+	producer->close = NULL;
+	mlt_producer_close( producer );
+}
+
+/** Initialise the producer.
+ */
+mlt_producer producer_shmem_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	// allocate/attach to shared region
+	shmem_xchg_t* ctx = shmem_xchg_create(arg);
+	if ( !ctx )
+		return NULL;
+
+	// Allocate the consumer
+	producer_shmem_t* self = ( producer_shmem_t* )calloc( 1, sizeof( producer_shmem_t ) );
+
+	mlt_log_debug( NULL, "%s: entering id=[%s], arg=[%s]\n", __FUNCTION__, id, arg );
+
+	// If allocated
+	if ( self && !mlt_producer_init( &self->parent, self ) )
+	{
+		mlt_producer parent = &self->parent;
+		mlt_properties properties = MLT_CONSUMER_PROPERTIES( parent );
+
+		// Setup context
+		self->arg = strdup( arg );
+		self->shared = ctx;
+
+		// Set callbacks
+		parent->close = (mlt_destructor) producer_shmem_close;
+		parent->get_frame = get_frame;
+
+		// These properties effectively make it infinite.
+		mlt_properties_set_int( properties, "length", INT_MAX );
+		mlt_properties_set_int( properties, "out", INT_MAX - 1 );
+		mlt_properties_set( properties, "eof", "loop" );
+
+		return parent;
+	}
+
+	free( self );
+
+	return NULL;
+}

--- a/src/modules/shmem/producer_shmem.yml
+++ b/src/modules/shmem/producer_shmem.yml
@@ -1,0 +1,37 @@
+schema_version: 0.3
+type: producer
+identifier: shmem
+title: Shared memory input
+version: 2
+copyright: Copyright (C) 2016 Meltytech, LLC
+license: LGPL
+language: en
+creator: Maksym Veremeyenko
+tags:
+  - Audio
+  - Video
+description: Read a frame from shared memory interface.
+
+notes: >
+
+  Shared memory interface allows different processes to exchange
+  a frames between them.
+
+  Usage example:
+
+      melt -profile atsc_1080i_50 -producer shmem:/tmp/demo8 -consumer ndi:demo01
+
+  Currently supported under Linux.
+
+parameters:
+  - identifier: resource
+    argument: yes
+    title: File
+    type: string
+    description: |
+      Name of exisint file used to build a shared memory key to
+      indentify shared memory region.
+    readonly: no
+    required: yes
+    mutable: no
+    widget: fileopen # could provide a button to use a file-open dialog 


### PR DESCRIPTION
This patch implement shared memory interface that allow to use multiple processes for MLT.

Usage example:

```
/usr/local/mlt/bin/melt -profile atsc_1080i_50 jamala.mxf -consumer shmem:/tmp/demo8

/usr/local/mlt/bin/melt -profile atsc_1080i_50 -producer shmem:/tmp/demo8 -consumer ndi:demo01
```

File /tmp/demo8 should be existing...

I have also idea to associate **.shm** extension with **shmem** producer
