### PR TITLE
Use Vid.Stab CFLAGS even when building *.c files

### DIFF
--- a/src/modules/vid.stab/Makefile
+++ b/src/modules/vid.stab/Makefile
@@ -12,8 +12,9 @@ OBJS = factory.o \
 CPPOBJS = filter_deshake.o
 CPPOBJS += filter_vidstab.o
 
-CXXFLAGS += -Wno-deprecated $(CFLAGS)
-CXXFLAGS += $(shell pkg-config --cflags vidstab)
+CFLAGS += -Wno-deprecated
+CFLAGS += $(shell pkg-config --cflags vidstab)
+CXXFLAGS += $(CFLAGS)
 
 LDFLAGS += -L../../mlt++ -lmlt++
 LDFLAGS += $(shell pkg-config --libs vidstab)


### PR DESCRIPTION
common.c build is failing as it requires a header from Vid.Stab.