### PR TITLE
Fix FreeType header inclusion

### DIFF
--- a/src/modules/gtk2/producer_pango.c
+++ b/src/modules/gtk2/producer_pango.c
@@ -25,7 +25,8 @@
 #include <string.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <pango/pangoft2.h>
-#include <freetype.h>
+#include <ft2build.h>
+#include FT_FREETYPE_H
 #include <iconv.h>
 #include <pthread.h>
 #include <ctype.h>


### PR DESCRIPTION
As stated in freetype.h:

  Please always use macros to include FreeType header files.
  Example:
    #include <ft2build.h>
    #include FT_FREETYPE_H

This also fixes the build on FreeBSD.