### PR TITLE
Use Movit CFLAGS even when building *.c files

### DIFF
--- a/src/modules/opengl/Makefile
+++ b/src/modules/opengl/Makefile
@@ -29,8 +29,9 @@ CPPOBJS += transition_movit_luma.o
 CPPOBJS += transition_movit_mix.o
 CPPOBJS += transition_movit_overlay.o
 
-CXXFLAGS := -Wno-deprecated $(CFLAGS) $(CXXFLAGS)
-CXXFLAGS += $(shell pkg-config --cflags movit 2> /dev/null)
+CFLAGS += -Wno-deprecated
+CFLAGS += $(shell pkg-config --cflags movit 2> /dev/null)
+CXXFLAGS += $(CFLAGS)
 
 SHADERDIR = $(shell pkg-config --variable=shaderdir movit)
 CXXFLAGS += -DSHADERDIR=\"$(SHADERDIR)\"


### PR DESCRIPTION
This is the same as the Vid.Stab fix.