### PR TITLE
fix mlt linux compile with ndi version 2017-01-06 @ r72018

### DIFF
--- a/src/modules/ndi/producer_ndi.c
+++ b/src/modules/ndi/producer_ndi.c
@@ -114,7 +114,7 @@ static void* producer_ndi_feeder( void* p )
 	NDIlib_recv_create_t recv_create_desc =
 	{
 		ndi_srcs[ i ],
-		NDIlib_recv_color_format_UYVY_BGRA,
+		NDIlib_recv_color_format_e_UYVY_BGRA,
 		NDIlib_recv_bandwidth_highest,
 		true
 	};


### PR DESCRIPTION
md5 9d1ebc495f603989cf0061a3d761b4f2  "NewTek NDI SDK (Linux).zip"