### PR TITLE
Add mlt_slices_get_global()

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -492,7 +492,6 @@ MLT_6.4.0 {
 MLT_6.6.0 {
   global:
     mlt_slices_count;
-    mlt_slices_init_pool;
     mlt_slices_get_global;
     mlt_slices_run_normal;
     mlt_slices_run_rr;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -493,4 +493,8 @@ MLT_6.6.0 {
   global:
     mlt_slices_count;
     mlt_slices_init_pool;
+    mlt_slices_get_global;
+    mlt_slices_run_normal;
+    mlt_slices_run_rr;
+    mlt_slices_run_ff;
 } MLT_6.4.0;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -491,7 +491,9 @@ MLT_6.4.0 {
 
 MLT_6.6.0 {
   global:
-    mlt_slices_count;
+    mlt_slices_count_normal;
+    mlt_slices_count_rr;
+    mlt_slices_count_fifo;
     mlt_slices_run_normal;
     mlt_slices_run_rr;
     mlt_slices_run_fifo;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -494,5 +494,5 @@ MLT_6.6.0 {
     mlt_slices_count;
     mlt_slices_run_normal;
     mlt_slices_run_rr;
-    mlt_slices_run_ff;
+    mlt_slices_run_fifo;
 } MLT_6.4.0;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -492,7 +492,6 @@ MLT_6.4.0 {
 MLT_6.6.0 {
   global:
     mlt_slices_count;
-    mlt_slices_get_global;
     mlt_slices_run_normal;
     mlt_slices_run_rr;
     mlt_slices_run_ff;

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -357,7 +357,6 @@ static mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
 /** Get the number of slices.
  *
  * \public \memberof mlt_slices_s
- * \param ctx context pointer
  * \return the number of slices
  */
 

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -349,22 +349,49 @@ static mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
 	return globals[policy];
 }
 
-/** Get the number of slices.
+/** Get the number of slices for the normal scheduling policy.
  *
  * \public \memberof mlt_slices_s
  * \return the number of slices
  */
 
-int mlt_slices_count()
+int mlt_slices_count_normal()
 {
 	mlt_slices slices = mlt_slices_get_global( mlt_policy_normal );
 	if (slices)
 		return slices->count;
-	if ((slices = mlt_slices_get_global( mlt_policy_fifo )))
+	else
+		return 0;
+}
+
+/** Get the number of slices for the round robin scheduling policy.
+ *
+ * \public \memberof mlt_slices_s
+ * \return the number of slices
+ */
+
+int mlt_slices_count_rr()
+{
+	mlt_slices slices = mlt_slices_get_global( mlt_policy_rr );
+	if (slices)
 		return slices->count;
-	if ((slices = mlt_slices_get_global( mlt_policy_rr )))
+	else
+		return 0;
+}
+
+/** Get the number of slices for the fifo scheduling policy.
+ *
+ * \public \memberof mlt_slices_s
+ * \return the number of slices
+ */
+
+int mlt_slices_count_fifo()
+{
+	mlt_slices slices = mlt_slices_get_global( mlt_policy_fifo );
+	if (slices)
 		return slices->count;
-	return 0;
+	else
+		return 0;
 }
 
 void mlt_slices_run_normal(int jobs, mlt_slices_proc proc, void *cookie)

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -308,17 +308,6 @@ void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cooki
 	pthread_mutex_unlock( &ctx->cond_mutex);
 }
 
-/** Initialize a sliced threading context pool
- *
- * \public \memberof mlt_slices_s
- * \deprecated
- * \param threads number of threads to use for job list, 0 for #cpus
- * \param policy scheduling policy of processing threads, -1 for normal
- * \param priority priority value that can be used with the scheduling algorithm, -1 for maximum
- * \param name name of pool of threads
- * \return the context pointer
- */
-
 /** Get a global shared sliced threading context.
  *
  * There are separate contexts for each scheduling policy.

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -323,12 +323,12 @@ void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cooki
  *
  * There are separate contexts for each scheduling policy.
  *
- * \public \memberof mlt_slices_s
+ * \private \memberof mlt_slices_s
  * \param policy the thread scheduling policy needed
  * \return the context pointer
  */
 
-mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
+static mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
 {
 	pthread_mutex_lock( &g_lock );
 	if ( !globals[policy] )
@@ -361,9 +361,16 @@ mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
  * \return the number of slices
  */
 
-int mlt_slices_count(mlt_slices ctx)
+int mlt_slices_count()
 {
-	return ctx->count;
+	mlt_slices slices = mlt_slices_get_global( mlt_policy_normal );
+	if (slices)
+		return slices->count;
+	if ((slices = mlt_slices_get_global( mlt_policy_fifo )))
+		return slices->count;
+	if ((slices = mlt_slices_get_global( mlt_policy_rr )))
+		return slices->count;
+	return 0;
 }
 
 void mlt_slices_run_normal(int jobs, mlt_slices_proc proc, void *cookie)

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -39,6 +39,14 @@
 #define MAX_SLICES 32
 #define ENV_SLICES "MLT_SLICES_COUNT"
 
+typedef enum {
+	mlt_policy_normal,
+	mlt_policy_rr,
+	mlt_policy_fifo,
+	mlt_policy_nb
+}
+mlt_schedule_policy;
+
 static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 static mlt_slices globals[mlt_policy_nb] = {NULL, NULL, NULL};
 

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -333,8 +333,6 @@ static mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
 	pthread_mutex_lock( &g_lock );
 	if ( !globals[policy] )
 	{
-		char *env = getenv( "MLT_GLOBAL_SLICES" );
-		int threads = env ? atoi(env) : 0;
 		int posix_policy;
 		switch (policy) {
 		case mlt_policy_rr:
@@ -346,7 +344,7 @@ static mlt_slices mlt_slices_get_global( mlt_schedule_policy policy )
 		default:
 			posix_policy = SCHED_OTHER;
 		}
-		globals[policy] = mlt_slices_init( threads, posix_policy, -1 );
+		globals[policy] = mlt_slices_init( 0, posix_policy, -1 );
 		mlt_factory_register_for_clean_up( globals[policy], (mlt_destructor) mlt_slices_close );
 	}
 	pthread_mutex_unlock( &g_lock );

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -35,9 +35,7 @@ extern void mlt_slices_close( mlt_slices ctx );
 
 extern void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cookie );
 
-extern int mlt_slices_count( mlt_slices ctx );
-
-extern mlt_slices mlt_slices_get_global( mlt_schedule_policy policy );
+extern int mlt_slices_count();
 
 extern void mlt_slices_run_normal( int jobs, mlt_slices_proc proc, void* cookie );
 

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -25,6 +25,11 @@
 
 #include "mlt_types.h"
 
+/**
+ * \envvar \em MLT_SLICES_COUNT Set the number of slices to use, which
+ * defaults to number of CPUs found.
+ */
+
 struct mlt_slices_s;
 
 typedef int (*mlt_slices_proc)( int id, int idx, int jobs, void* cookie );

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -37,8 +37,6 @@ extern void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void
 
 extern int mlt_slices_count( mlt_slices ctx );
 
-extern mlt_slices mlt_slices_init_pool( int threads, int policy, int priority, const char* name );
-
 extern mlt_slices mlt_slices_get_global( mlt_schedule_policy policy );
 
 extern void mlt_slices_run_normal( int jobs, mlt_slices_proc proc, void* cookie );

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -40,7 +40,11 @@ extern void mlt_slices_close( mlt_slices ctx );
 
 extern void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cookie );
 
-extern int mlt_slices_count();
+extern int mlt_slices_count_normal();
+
+extern int mlt_slices_count_rr();
+
+extern int mlt_slices_count_fifo();
 
 extern void mlt_slices_run_normal( int jobs, mlt_slices_proc proc, void* cookie );
 

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -3,7 +3,7 @@
  * \brief sliced threading processing helper
  * \see mlt_slices_s
  *
- * Copyright (C) 2016 Meltytech, LLC
+ * Copyright (C) 2016-2017 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,8 +23,9 @@
 #ifndef MLT_SLICES_H
 #define MLT_SLICES_H
 
+#include "mlt_types.h"
+
 struct mlt_slices_s;
-typedef struct mlt_slices_s *mlt_slices;                  /**< pointer to Sliced processing context object */
 
 typedef int (*mlt_slices_proc)( int id, int idx, int jobs, void* cookie );
 
@@ -37,5 +38,13 @@ extern void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void
 extern int mlt_slices_count( mlt_slices ctx );
 
 extern mlt_slices mlt_slices_init_pool( int threads, int policy, int priority, const char* name );
+
+extern mlt_slices mlt_slices_get_global( mlt_schedule_policy policy );
+
+extern void mlt_slices_run_normal( int jobs, mlt_slices_proc proc, void* cookie );
+
+extern void mlt_slices_run_rr( int jobs, mlt_slices_proc proc, void* cookie );
+
+extern void mlt_slices_run_fifo( int jobs, mlt_slices_proc proc, void* cookie );
 
 #endif

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -95,16 +95,6 @@ typedef enum
 }
 mlt_whence;
 
-/** Scheduling policies for threads */
-
-typedef enum {
-	mlt_policy_normal,
-	mlt_policy_rr,
-	mlt_policy_fifo,
-	mlt_policy_nb        /**< the number of policies, not an actual policy to be used */
-}
-mlt_schedule_policy;
-
 /** The recognized subclasses of mlt_service */
 
 typedef enum

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -2,7 +2,7 @@
  * \file mlt_types.h
  * \brief Provides forward definitions of all public types
  *
- * Copyright (C) 2003-2016 Meltytech, LLC
+ * Copyright (C) 2003-2017 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -95,6 +95,16 @@ typedef enum
 }
 mlt_whence;
 
+/** Scheduling policies for threads */
+
+typedef enum {
+	mlt_policy_normal,
+	mlt_policy_rr,
+	mlt_policy_fifo,
+	mlt_policy_nb        /**< the number of policies, not an actual policy to be used */
+}
+mlt_schedule_policy;
+
 /** The recognized subclasses of mlt_service */
 
 typedef enum
@@ -166,6 +176,7 @@ typedef struct mlt_repository_s *mlt_repository;        /**< pointer to Reposito
 typedef struct mlt_cache_s *mlt_cache;                  /**< pointer to Cache object */
 typedef struct mlt_cache_item_s *mlt_cache_item;        /**< pointer to CacheItem object */
 typedef struct mlt_animation_s *mlt_animation;          /**< pointer to Property Animation object */
+typedef struct mlt_slices_s *mlt_slices;                /**< pointer to Sliced processing context object */
 
 typedef void ( *mlt_destructor )( void * );             /**< pointer to destructor function */
 typedef char *( *mlt_serialiser )( void *, int length );/**< pointer to serialization function */

--- a/src/modules/frei0r/frei0r_helper.c
+++ b/src/modules/frei0r/frei0r_helper.c
@@ -103,7 +103,7 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 	int slice_count = mlt_properties_get(prop, "threads") ? mlt_properties_get_int(prop, "threads") : -1;
 
 	if (slice_count >= 0)
-		slice_count = mlt_slices_count();
+		slice_count = mlt_slices_count_normal();
 
 	//use as name the width and height
 	int slice_height = *height / (slice_count > 0? slice_count : 1);

--- a/src/modules/frei0r/frei0r_helper.c
+++ b/src/modules/frei0r/frei0r_helper.c
@@ -101,10 +101,10 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 	mlt_service_type type = mlt_service_identify( service );
 	int not_thread_safe = mlt_properties_get_int( prop, "_not_thread_safe" );
 	int slice_count = mlt_properties_get(prop, "threads") ? mlt_properties_get_int(prop, "threads") : -1;
-	mlt_slices slices = NULL;
 
 	if (slice_count >= 0) {
-		if ((slices = mlt_slices_get_global(mlt_policy_normal)))
+		mlt_slices slices = slices = mlt_slices_get_global(mlt_policy_normal);
+		if (slices)
 			slice_count = mlt_slices_count(slices);
 	}
 
@@ -201,7 +201,7 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 		}
 	}
 	if (type==producer_type) {
-		if (slices) {
+		if (slice_count > 0) {
 			struct update_context ctx = {
 				.frei0r = inst,
 				.width = *width,
@@ -211,12 +211,12 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 				.output = dest,
 				.f0r_update = f0r_update
 			};
-			mlt_slices_run(slices, 0, f0r_update_slice, &ctx);
+			mlt_slices_run_normal(slice_count, f0r_update_slice, &ctx);
 		} else {
 			f0r_update ( inst, time, source[0], dest );
 		}
 	} else if (type==filter_type) {
-		if (slices) {
+		if (slice_count > 0) {
 			struct update_context ctx = {
 				.frei0r = inst,
 				.width = *width,
@@ -226,12 +226,12 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 				.output = dest,
 				.f0r_update = f0r_update
 			};
-			mlt_slices_run(slices, 0, f0r_update_slice, &ctx);
+			mlt_slices_run_normal(slice_count, f0r_update_slice, &ctx);
 		} else {
 			f0r_update ( inst, time, source[0], dest );
 		}
 	} else if (type==transition_type && f0r_update2 ) {
-		if (slices) {
+		if (slice_count > 0) {
 			struct update_context ctx = {
 				.frei0r = inst,
 				.width = *width,
@@ -241,7 +241,7 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 				.output = dest,
 				.f0r_update2 = f0r_update2
 			};
-			mlt_slices_run(slices, 0, f0r_update2_slice, &ctx);
+			mlt_slices_run_normal(slice_count, f0r_update2_slice, &ctx);
 		} else {
 			f0r_update2 ( inst, time, source[0], source[1], NULL, dest );
 		}

--- a/src/modules/frei0r/frei0r_helper.c
+++ b/src/modules/frei0r/frei0r_helper.c
@@ -102,11 +102,8 @@ int process_frei0r_item( mlt_service service, double position, double time, mlt_
 	int not_thread_safe = mlt_properties_get_int( prop, "_not_thread_safe" );
 	int slice_count = mlt_properties_get(prop, "threads") ? mlt_properties_get_int(prop, "threads") : -1;
 
-	if (slice_count >= 0) {
-		mlt_slices slices = slices = mlt_slices_get_global(mlt_policy_normal);
-		if (slices)
-			slice_count = mlt_slices_count(slices);
-	}
+	if (slice_count >= 0)
+		slice_count = mlt_slices_count();
 
 	//use as name the width and height
 	int slice_height = *height / (slice_count > 0? slice_count : 1);

--- a/src/modules/ndi/consumer_ndi.c
+++ b/src/modules/ndi/consumer_ndi.c
@@ -43,7 +43,7 @@ typedef struct
 	char* arg;
 	pthread_t th;
 	int count;
-	mlt_slices sliced_swab;
+	int sliced_swab;
 } consumer_ndi_t;
 
 static void* consumer_ndi_feeder( void* p )
@@ -168,7 +168,7 @@ static void* consumer_ndi_feeder( void* p )
 					else
 					{
 						arg[2] = (unsigned char*)size;
-						mlt_slices_run( self->sliced_swab, 0, swab_sliced, arg);
+						mlt_slices_run_fifo( 0, swab_sliced, arg);
 					}
 				}
 				else if ( !mlt_properties_get_int( MLT_FRAME_PROPERTIES( frame ), "test_image" ) )
@@ -279,10 +279,7 @@ static int consumer_ndi_start( mlt_consumer consumer )
 
 	if ( !self->f_running )
 	{
-		if ( !self->sliced_swab && mlt_properties_get( properties, "sliced_swab" )
-			&& mlt_properties_get_int( properties, "sliced_swab" ) )
-			self->sliced_swab = mlt_slices_init_pool(0, SCHED_FIFO,
-				sched_get_priority_max( SCHED_FIFO ), __FILE__ );
+		self->sliced_swab = mlt_properties_get_int( properties, "sliced_swab" );
 
 		// set flags
 		self->f_exit = 0;
@@ -345,9 +342,6 @@ static void consumer_ndi_close( mlt_consumer consumer )
 	// free context
 	if ( self->arg )
 		free( self->arg );
-	if ( self->sliced_swab )
-		mlt_slices_close( self->sliced_swab );
-
 	free( self );
 
 	mlt_log_debug( NULL, "%s: exiting\n", __FUNCTION__ );

--- a/src/modules/ndi/producer_ndi.c
+++ b/src/modules/ndi/producer_ndi.c
@@ -45,7 +45,6 @@ typedef struct
 	char* arg;
 	pthread_t th;
 	int count;
-	mlt_slices sliced_swab;
 	mlt_deque a_queue, v_queue;
 	pthread_mutex_t lock;
 	pthread_cond_t cond;
@@ -330,11 +329,6 @@ static int get_frame( mlt_producer producer, mlt_frame_ptr pframe, int index )
 	// run thread
 	if ( !self->f_running )
 	{
-		if ( !self->sliced_swab && mlt_properties_get( properties, "sliced_swab" )
-			&& mlt_properties_get_int( properties, "sliced_swab" ) )
-			self->sliced_swab = mlt_slices_init_pool(0, SCHED_FIFO,
-				sched_get_priority_max( SCHED_FIFO ), __FILE__ );
-
 		// set flags
 		self->f_exit = 0;
 


### PR DESCRIPTION
This does not remove mlt_slices_init_pool(), but I think we should perhaps do that. Comments welcome,

I chose not to include "idle" as a policy option and split "rt" into "rr" and "fifo" to better closely match POSIX  standard and remove ambiguity (e.g. not clear rt = fifo).

I chose to not put mlt_slices_get_global() into mlt_factory because mlt_factory is mainly used for services, and I just wanted to keep slice-related stuff together.

TODO: 
- ~remove mlt_slices_init_pool()~
- ~convert other services using mlt_slices_init_pool()~
- ~Document environment variables in mlt_slices.h.~
- ~move code mapping mlt_schedule_policy to SCHED_ constants from mlt_slices_get_global() to mlt_slices_init()~ (removing because changing param to mlt_slices_init breaks ABI).
- ~MLT_GLOBAL_SLICES or MLT_GLOBAL_SLICES_COUNT?~ (MLT_SLICES_COUNT as before)
