### PR TITLE
Timestamped logging and timings measurement

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -497,4 +497,5 @@ MLT_6.6.0 {
     mlt_slices_run_normal;
     mlt_slices_run_rr;
     mlt_slices_run_fifo;
+    mlt_log_timings_now;
 } MLT_6.4.0;

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -929,7 +929,7 @@ static void *consumer_read_ahead_thread( void *arg )
 		}
 		else
 		{
-			mlt_log_debug( self, "current %"PRId64" threshold %"PRId64" count %d\n",
+			mlt_log_debug( self, "current %" PRId64 " threshold %" PRId64 " count %d\n",
 				time_current, (int64_t) (time_process / count * 20), count );
 			// Ignore the cost of this frame's time
 			count--;
@@ -958,7 +958,7 @@ static void *consumer_read_ahead_thread( void *arg )
 			if ( time_process / count > frame_duration )
 				skip_next = 1;
 			if ( skip_next )
-				mlt_log_debug( self, "avg usec %"PRId64" (%"PRId64"/%d) duration %d\n",
+				mlt_log_debug( self, "avg usec %" PRId64 " (%" PRId64 "/%d) duration %d\n",
 					time_process/count, time_process, count, frame_duration);
 		}
 	}

--- a/src/framework/mlt_log.c
+++ b/src/framework/mlt_log.c
@@ -23,6 +23,8 @@
 #include "mlt_service.h"
 
 #include <string.h>
+#include <sys/time.h>
+#include <time.h>
 
 static int log_level = MLT_LOG_WARNING;
 
@@ -33,6 +35,23 @@ void default_callback( void* ptr, int level, const char* fmt, va_list vl )
 	
 	if ( level > log_level )
 		return;
+
+	if ( print_prefix && level >= MLT_LOG_VERBOSE )
+	{
+		struct timeval tv;
+		time_t ltime;
+		struct tm *rtime;
+		char buf[32];
+
+		gettimeofday(&tv, NULL);
+		ltime = tv.tv_sec;
+
+		rtime = localtime( &ltime );
+		strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S" , rtime );
+
+		fprintf( stderr, "| %s.%.3d | ", buf, (int)(tv.tv_usec / 1000) );
+	}
+
 	if ( print_prefix && properties )
 	{
 		char *mlt_type = mlt_properties_get( properties, "mlt_type" );
@@ -81,4 +100,18 @@ void mlt_log_set_level( int level )
 void mlt_log_set_callback( void (*new_callback)( void*, int, const char*, va_list ) )
 {
 	callback = new_callback;
+}
+
+int64_t mlt_log_timings_now( void )
+{
+	int64_t r;
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	r = tv.tv_sec;
+
+	r *= 1000000LL;
+	r += tv.tv_usec;
+
+	return r;
 }

--- a/src/framework/mlt_log.h
+++ b/src/framework/mlt_log.h
@@ -23,6 +23,7 @@
 #define MLT_LOG_H
 
 #include <stdarg.h>
+#include <stdint.h>
 
 #define MLT_LOG_QUIET    -8
 
@@ -89,5 +90,17 @@ void mlt_vlog( void *service, int level, const char *fmt, va_list );
 int mlt_log_get_level( void );
 void mlt_log_set_level( int );
 void mlt_log_set_callback( void (*)( void*, int, const char*, va_list ) );
+
+#define mlt_log_timings_begin() \
+{ \
+	int64_t _mlt_log_timings_begin = mlt_log_timings_now(), _mlt_log_timings_end;
+
+#define mlt_log_timings_end(service, msg) \
+	_mlt_log_timings_end = mlt_log_timings_now(); \
+	mlt_log_verbose( service, "%s:%d: T(%s)=%" PRId64 " us\n", \
+		__FUNCTION__, __LINE__, msg, _mlt_log_timings_end - _mlt_log_timings_begin ); \
+}
+
+int64_t mlt_log_timings_now( void );
 
 #endif /* MLT_LOG_H */

--- a/src/framework/mlt_pool.c
+++ b/src/framework/mlt_pool.c
@@ -417,6 +417,6 @@ void mlt_pool_stat( )
 		s = pool->count - mlt_deque_count( pool->stack ); s *= pool->size; used += s;
 	}
 
-	mlt_log_verbose( NULL, "%s: allocated %"PRIu64" bytes, used %"PRIu64" bytes \n",
+	mlt_log_verbose( NULL, "%s: allocated %" PRIu64 " bytes, used %" PRIu64 " bytes \n",
 		__FUNCTION__, allocated, used );
 }

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -196,10 +196,10 @@ mlt_slices mlt_slices_init( int threads, int policy, int priority )
 	pthread_cond_init ( &ctx->cond_var_job, NULL );
 	pthread_cond_init ( &ctx->cond_var_ready, NULL );
 	pthread_attr_init( &tattr );
-    if ( policy < 0 )
-        policy = SCHED_OTHER;
-    if ( priority < 0 )
-        priority = sched_get_priority_max( policy );
+	if ( policy < 0 )
+		policy = SCHED_OTHER;
+	if ( priority < 0 )
+		priority = sched_get_priority_max( policy );
 	pthread_attr_setschedpolicy( &tattr, policy );
 	param.sched_priority = priority;
 	pthread_attr_setschedparam( &tattr, &param );

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1728,7 +1728,7 @@ static void *consumer_thread( void *arg )
 								goto on_fatal_error;
 							}
 							error_count = 0;
-							mlt_log_debug( MLT_CONSUMER_SERVICE( consumer ), "audio stream %d pkt pts %"PRId64" frame_size %d\n",
+							mlt_log_debug( MLT_CONSUMER_SERVICE( consumer ), "audio stream %d pkt pts %" PRId64 " frame_size %d\n",
 								stream->index, pkt.pts, codec->frame_size );
 						}
 						else if ( pkt.size < 0 )

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -1354,6 +1354,8 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 	mlt_profile profile = mlt_service_profile( MLT_PRODUCER_SERVICE( self->parent ) );
 	int result = self->yuv_colorspace;
 
+	mlt_log_timings_begin();
+
 	mlt_log_debug( MLT_PRODUCER_SERVICE(self->parent), "%s @ %dx%d space %d->%d\n",
 		mlt_image_format_name( *format ),
 		width, height, self->yuv_colorspace, profile->colorspace );
@@ -1475,6 +1477,9 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 
 		result = profile->colorspace;
 	}
+
+	mlt_log_timings_end( NULL, __FUNCTION__ );
+
 	return result;
 }
 
@@ -1554,6 +1559,8 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 
 	// Get codec context
 	AVCodecContext *codec_context = stream->codec;
+
+	mlt_log_timings_begin();
 
 	// Get the image cache
 	if ( ! self->image_cache )
@@ -1969,6 +1976,8 @@ exit_get_image:
 	mlt_properties_set_int( properties, "meta.media.top_field_first", self->top_field_first );
 	mlt_properties_set_int( properties, "meta.media.progressive", mlt_properties_get_int( frame_properties, "progressive" ) );
 	mlt_service_unlock( MLT_PRODUCER_SERVICE( producer ) );
+
+	mlt_log_timings_end( NULL, __FUNCTION__ );
 
 	return !got_picture;
 }

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -976,7 +976,7 @@ static void find_first_pts( producer_avformat self, int video_index )
 		if ( ret >= 0 && pkt.stream_index == video_index && ( pkt.flags & AV_PKT_FLAG_KEY ) )
 		{
 			mlt_log_debug( MLT_PRODUCER_SERVICE(self->parent),
-				"first_pts %"PRId64" dts %"PRId64" pts_dts_delta %d\n",
+				"first_pts %" PRId64 " dts %" PRId64 " pts_dts_delta %d\n",
 				pkt.pts, pkt.dts, (int)(pkt.pts - pkt.dts) );
 			if ( pkt.dts != AV_NOPTS_VALUE && pkt.dts < 0 )
 				// Decoding Time Stamps with negative values are reported by ffmpeg code for
@@ -1046,7 +1046,7 @@ static int seek_video( producer_avformat self, mlt_position position,
 				timestamp -= 2 / av_q2d( self->video_time_base );
 			if ( timestamp < 0 )
 				timestamp = 0;
-			mlt_log_debug( MLT_PRODUCER_SERVICE(producer), "seeking timestamp %"PRId64" position " MLT_POSITION_FMT " expected "MLT_POSITION_FMT" last_pos %"PRId64"\n",
+			mlt_log_debug( MLT_PRODUCER_SERVICE(producer), "seeking timestamp %" PRId64 " position " MLT_POSITION_FMT " expected " MLT_POSITION_FMT " last_pos %" PRId64 "\n",
 				timestamp, position, self->video_expected, self->last_position );
 
 			// Seek to the timestamp
@@ -1749,15 +1749,15 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 						int_position = self->last_position + 1;
 				}
 				mlt_log_debug( MLT_PRODUCER_SERVICE(producer),
-					"V pkt.pts %"PRId64" pkt.dts %"PRId64" req_pos %"PRId64" cur_pos %"PRId64" pkt_pos %"PRId64"\n",
+					"V pkt.pts %" PRId64 " pkt.dts %" PRId64 " req_pos %" PRId64 " cur_pos %" PRId64 " pkt_pos %" PRId64 "\n",
 					self->pkt.pts, self->pkt.dts, req_position, self->current_position, int_position );
 
 				// Make a dumb assumption on streams that contain wild timestamps
 				if ( llabs( req_position - int_position ) > 999 )
 				{
 					mlt_log_verbose( MLT_PRODUCER_SERVICE(producer), " WILD TIMESTAMP: "
-						"pkt.pts=[%"PRId64"], pkt.dts=[%"PRId64"], req_position=[%"PRId64"], "
-						"current_position=[%"PRId64"], int_position=[%"PRId64"], pts=[%"PRId64"] \n",
+						"pkt.pts=[%" PRId64 "], pkt.dts=[%" PRId64 "], req_position=[%" PRId64 "], "
+						"current_position=[%" PRId64 "], int_position=[%" PRId64 "], pts=[%" PRId64 "] \n",
 						self->pkt.pts, self->pkt.dts, req_position,
 						self->current_position, int_position, pts );
 					int_position = req_position;
@@ -1821,7 +1821,7 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 				{
 					ret = -1;
 				}
-				mlt_log_debug( MLT_PRODUCER_SERVICE(producer), " got_pic %d key %d ret %d pkt_pos %"PRId64"\n",
+				mlt_log_debug( MLT_PRODUCER_SERVICE(producer), " got_pic %d key %d ret %d pkt_pos %" PRId64 "\n",
 							   got_picture, self->pkt.flags & AV_PKT_FLAG_KEY, ret, int_position );
 			}
 
@@ -2478,7 +2478,7 @@ static int decode_audio( producer_avformat self, int *ignore, AVPacket pkt, int 
 		int64_t req_pts =      llrint( timecode / timebase );
 
 		mlt_log_debug( MLT_PRODUCER_SERVICE(self->parent),
-			"A pkt.pts %"PRId64" pkt.dts %"PRId64" req_pos %"PRId64" cur_pos %"PRId64" pkt_pos %"PRId64"\n",
+			"A pkt.pts %" PRId64 " pkt.dts %" PRId64 " req_pos %" PRId64 " cur_pos %" PRId64 " pkt_pos %" PRId64 "\n",
 			pkt.pts, pkt.dts, req_position, self->current_position, int_position );
 
 		if ( self->seekable || int_position > 0 )

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -25,6 +25,7 @@
 #include <framework/mlt_deque.h>
 #include <framework/mlt_factory.h>
 #include <framework/mlt_cache.h>
+#include <framework/mlt_slices.h>
 
 // ffmpeg Header files
 #include <libavformat/avformat.h>
@@ -1246,6 +1247,105 @@ static int pick_av_pixel_format( int *pix_fmt )
 	return 0;
 }
 
+struct sliced_pix_fmt_conv_t
+{
+	int width, height, slice_w;
+	AVFrame *frame;
+	AVPicture *output;
+	enum AVPixelFormat src_format, dst_format;
+	const AVPixFmtDescriptor *src_desc, *dst_desc;
+	int flags, src_colorspace, dst_colorspace, src_full_range, dst_full_range;
+};
+
+static int sliced_h_pix_fmt_conv_proc( int id, int idx, int jobs, void* cookie )
+{
+	uint8_t *out[4];
+	const uint8_t *in[4];
+	int in_stride[4], out_stride[4];
+	int src_v_chr_pos = -513, dst_v_chr_pos = -513, ret, i, slice_x, slice_w, w, h, mul, field, slices, interlaced = 0;
+
+	struct SwsContext *sws;
+	struct sliced_pix_fmt_conv_t* ctx = ( struct sliced_pix_fmt_conv_t* )cookie;
+
+	interlaced = ctx->frame->interlaced_frame;
+	field = ( interlaced ) ? ( idx & 1 ) : 0;
+	idx = ( interlaced ) ? ( idx / 2 ) : idx;
+	slices = ( interlaced ) ? ( jobs / 2 ) : jobs;
+	mul = ( interlaced ) ? 2 : 1;
+	h = ctx->height >> !!interlaced;
+	slice_w = ctx->slice_w;
+	slice_x = slice_w * idx;
+	slice_w = FFMIN( slice_w, ctx->width - slice_x );
+
+	if ( AV_PIX_FMT_YUV420P == ctx->src_format )
+		src_v_chr_pos = ( !interlaced ) ? 128 : ( !field ) ? 64 : 192;
+
+	if ( AV_PIX_FMT_YUV420P == ctx->dst_format )
+		dst_v_chr_pos = ( !interlaced ) ? 128 : ( !field ) ? 64 : 192;
+
+	mlt_log_debug( NULL, "%s:%d: [id=%d, idx=%d, jobs=%d], interlaced=%d, field=%d, slices=%d, mul=%d, h=%d, slice_w=%d, slice_x=%d ctx->src_desc=[log2_chroma_h=%d, log2_chroma_w=%d], src_v_chr_pos=%d, dst_v_chr_pos=%d\n",
+		__FUNCTION__, __LINE__, id, idx, jobs, interlaced, field, slices, mul, h, slice_w, slice_x, ctx->src_desc->log2_chroma_h, ctx->src_desc->log2_chroma_w, src_v_chr_pos, dst_v_chr_pos );
+
+	if ( slice_w <= 0 )
+		return 0;
+
+	sws = sws_alloc_context();
+
+	av_opt_set_int( sws, "srcw", slice_w, 0 );
+	av_opt_set_int( sws, "srch", h, 0 );
+	av_opt_set_int( sws, "src_format", ctx->src_format, 0 );
+	av_opt_set_int( sws, "dstw", slice_w, 0 );
+	av_opt_set_int( sws, "dsth", h, 0 );
+	av_opt_set_int( sws, "dst_format", ctx->dst_format, 0 );
+	av_opt_set_int( sws, "sws_flags", ctx->flags | SWS_FULL_CHR_H_INP, 0 );
+
+	av_opt_set_int( sws, "src_h_chr_pos", -513, 0 );
+	av_opt_set_int( sws, "src_v_chr_pos", src_v_chr_pos, 0 );
+	av_opt_set_int( sws, "dst_h_chr_pos", -513, 0 );
+	av_opt_set_int( sws, "dst_v_chr_pos", dst_v_chr_pos, 0 );
+
+	if ( ( ret = sws_init_context( sws, NULL, NULL ) ) < 0 )
+	{
+		mlt_log_error( NULL, "%s:%d: sws_init_context failed, ret=%d\n", __FUNCTION__, __LINE__, ret );
+		sws_freeContext( sws );
+		return 0;
+	}
+
+	set_luma_transfer( sws, ctx->src_colorspace, ctx->dst_colorspace, ctx->src_full_range, ctx->dst_full_range );
+
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 0, 100)
+#define PIX_DESC_BPP(DESC) (DESC.step_minus1 + 1)
+#else
+#define PIX_DESC_BPP(DESC) (DESC.step)
+#endif
+
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 32, 100)
+#define AV_PIX_FMT_FLAG_PLANAR PIX_FMT_PLANAR
+#endif
+	for( i = 0; i < 4; i++ )
+	{
+		int in_offset = (AV_PIX_FMT_FLAG_PLANAR & ctx->src_desc->flags)
+			 ? ( ( 1 == i || 2 == i ) ? ( slice_x >> ctx->src_desc->log2_chroma_w ) : slice_x )
+			 : ( ( i ) ? 0 : slice_x * PIX_DESC_BPP(ctx->src_desc->comp[0]) );
+
+		int out_offset = (AV_PIX_FMT_FLAG_PLANAR & ctx->dst_desc->flags)
+			 ? ( ( 1 == i || 2 == i ) ? ( slice_x >> ctx->dst_desc->log2_chroma_w ) : slice_x )
+			 : ( ( i ) ? 0 : slice_x * PIX_DESC_BPP(ctx->dst_desc->comp[0]) );
+
+		in_stride[i]  = ctx->frame->linesize[i] * mul;
+		out_stride[i] = ctx->output->linesize[i] * mul;
+
+		in[i] =  ctx->frame->data[i] + ctx->frame->linesize[i] * field + in_offset;
+		out[i] = ctx->output->data[i] + ctx->output->linesize[i] * field + out_offset;
+	}
+
+	sws_scale( sws, in, in_stride, 0, h, out, out_stride );
+
+	sws_freeContext( sws );
+
+	return 0;
+}
+
 // returns resulting YUV colorspace
 static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffer, int pix_fmt,
 	mlt_image_format *format, int width, int height, uint8_t **alpha )
@@ -1332,20 +1432,48 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 	}
 	else
 	{
-#if defined(FFUDIV) && (LIBAVFORMAT_VERSION_INT >= ((55<<16)+(48<<8)+100))
-		struct SwsContext *context = sws_getContext( width, height, src_pix_fmt,
-			width, height, AV_PIX_FMT_YUYV422, flags | SWS_FULL_CHR_H_INP, NULL, NULL, NULL);
-#else
-		struct SwsContext *context = sws_getContext( width, height, pix_fmt,
-			width, height, AV_PIX_FMT_YUYV422, flags | SWS_FULL_CHR_H_INP, NULL, NULL, NULL);
-#endif
+		int i, c;
 		AVPicture output;
-		avpicture_fill( &output, buffer, AV_PIX_FMT_YUYV422, width, height );
-		if ( !set_luma_transfer( context, self->yuv_colorspace, profile->colorspace, self->full_luma, 0 ) )
-			result = profile->colorspace;
-		sws_scale( context, (const uint8_t* const*) frame->data, frame->linesize, 0, height,
-			output.data, output.linesize);
-		sws_freeContext( context );
+		struct sliced_pix_fmt_conv_t ctx =
+		{
+			.flags = flags,
+			.width = width,
+			.height = height,
+			.frame = frame,
+			.output = &output,
+			.dst_format = AV_PIX_FMT_YUYV422,
+			.src_colorspace = self->yuv_colorspace,
+			.dst_colorspace = profile->colorspace,
+			.src_full_range = self->full_luma,
+			.dst_full_range = 0,
+		};
+#if defined(FFUDIV) && (LIBAVFORMAT_VERSION_INT >= ((55<<16)+(48<<8)+100))
+		ctx.src_format = src_pix_fmt;
+#else
+		ctx.src_format = pix_fmt;
+#endif
+		ctx.src_desc = av_pix_fmt_desc_get( ctx.src_format );
+		ctx.dst_desc = av_pix_fmt_desc_get( ctx.dst_format );
+
+		avpicture_fill( ctx.output, buffer, ctx.dst_format, width, height );
+
+		if ( !getenv("MLT_AVFORMAT_SLICED_PIXFMT_DISABLE") )
+			ctx.slice_w = ( width < 1000 )
+				? ( 256 >> frame->interlaced_frame )
+				: ( 512 >> frame->interlaced_frame );
+		else
+			ctx.slice_w = width;
+
+		c = ( width + ctx.slice_w - 1 ) / ctx.slice_w;
+		c *= frame->interlaced_frame ? 2 : 1;
+
+		if ( !getenv("MLT_AVFORMAT_SLICED_PIXFMT_DISABLE") )
+			mlt_slices_run_normal( c, sliced_h_pix_fmt_conv_proc, &ctx );
+		else
+			for ( i = 0 ; i < c; i++ )
+				sliced_h_pix_fmt_conv_proc( i, i, c, &ctx );
+
+		result = profile->colorspace;
 	}
 	return result;
 }

--- a/src/modules/linsys/sdi_generator.c
+++ b/src/modules/linsys/sdi_generator.c
@@ -349,9 +349,9 @@ static int sdi_init(char *device_video, char *device_audio, uint8_t blanking, ml
 	}
 
 	if (info.blanking) {
-		printf("SDI frame size: %"PRIu64"\n", sdi_frame_size);
+		printf("SDI frame size: %" PRIu64 "\n", sdi_frame_size);
 	} else {
-		printf("Frame size for active video: %"PRIu64"\n", sdi_frame_size);
+		printf("Frame size for active video: %" PRIu64 "\n", sdi_frame_size);
 	}
 
 	/**

--- a/src/modules/plusgpl/consumer_cbrts.c
+++ b/src/modules/plusgpl/consumer_cbrts.c
@@ -408,7 +408,7 @@ static double measure_bitrate( consumer_cbrts self, uint64_t pcr, int drop )
 			muxrate /= (double) ( pcr - self->previous_pcr ) / SCR_HZ;
 		else
 			muxrate /= ( ( (double) ( 1ULL << 33 ) - 1 ) * 300 - self->previous_pcr + pcr ) / SCR_HZ;
-		mlt_log_debug( NULL, "measured TS bitrate %.1f bits/sec PCR %"PRIu64"\n", muxrate, pcr );
+		mlt_log_debug( NULL, "measured TS bitrate %.1f bits/sec PCR %" PRIu64 "\n", muxrate, pcr );
 	}
 
 	return muxrate;
@@ -724,7 +724,7 @@ static int output_cbr( consumer_cbrts self, uint64_t input_rate, uint64_t output
 	uint64_t input_counter = 0;
 	uint64_t last_input_counter;
 
-	mlt_log_debug( NULL, "%s: n %i output_counter %"PRIu64" input_rate %"PRIu64"\n", __FUNCTION__, n, self->output_counter, input_rate );
+	mlt_log_debug( NULL, "%s: n %i output_counter %" PRIu64 " input_rate %" PRIu64 "\n", __FUNCTION__, n, self->output_counter, input_rate );
 	while ( self->thread_running && n-- && result >= 0 )
 	{
 		uint8_t *packet = mlt_deque_pop_front( self->tsp_packets );
@@ -736,7 +736,7 @@ static int output_cbr( consumer_cbrts self, uint64_t input_rate, uint64_t output
 		{
 			if ( !warned )
 			{
-				mlt_log_warning( MLT_CONSUMER_SERVICE( &self->parent ), "muxrate too low %"PRIu64" > %"PRIu64"\n", input_rate, output_rate );
+				mlt_log_warning( MLT_CONSUMER_SERVICE( &self->parent ), "muxrate too low %" PRIu64 " > %" PRIu64 "\n", input_rate, output_rate );
 				warned = 1;
 			}
 


### PR DESCRIPTION
This pull request (it nest https://github.com/mltframework/mlt/pull/189) makes debugging of some performance depended task much easy - it add timing information to log messages and provides a method for measuring time of execution of some part of code.

Main changes comes in https://github.com/mltframework/mlt/commit/eafb820bc6888ed05e584f2bf63d149e1e295720
