### PR TITLE
yuv422p16: please review

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -491,6 +491,8 @@ MLT_6.4.0 {
 
 MLT_6.6.0 {
   global:
+    mlt_image_format_planes;
+    mlt_image_format_id;
     mlt_slices_count_normal;
     mlt_slices_count_rr;
     mlt_slices_count_fifo;

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -486,17 +486,8 @@ static void set_image_format( mlt_consumer self )
 	const char* format = mlt_properties_get( properties, "mlt_image_format" );
 	if ( format )
 	{
-		if ( !strcmp( format, "rgb24" ) )
-			priv->image_format = mlt_image_rgb24;
-		else if ( !strcmp( format, "rgb24a" ) )
-			priv->image_format = mlt_image_rgb24a;
-		else if ( !strcmp( format, "yuv420p" ) )
-			priv->image_format = mlt_image_yuv420p;
-		else if ( !strcmp( format, "none" ) )
-			priv->image_format = mlt_image_none;
-		else if ( !strcmp( format, "glsl" ) )
-			priv->image_format = mlt_image_glsl_texture;
-		else
+		priv->image_format = mlt_image_format_id( format );
+		if (mlt_image_last == priv->image_format )
 			priv->image_format = mlt_image_yuv422;
 	}
 }

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -410,9 +410,34 @@ const char * mlt_image_format_name( mlt_image_format format )
 		case mlt_image_opengl:  return "opengl";
 		case mlt_image_glsl:    return "glsl";
 		case mlt_image_glsl_texture: return "glsl_texture";
+		case mlt_image_yuv422p16: return "yuv422p16";
+		case mlt_image_last:    return "last";
 	}
 	return "invalid";
 }
+
+/** Get the id of image format from short name.
+ *
+ * \public \memberof mlt_frame_s
+ * \param name the image format short name
+ * \return a image format
+ */
+
+mlt_image_format mlt_image_format_id( const char * name )
+{
+	mlt_image_format f;
+
+	for(f = mlt_image_none; f < mlt_image_last; f++)
+	{
+		const char * v = mlt_image_format_name( f );
+		if(!strcmp( v, name ) )
+			return f;
+	}
+
+	return mlt_image_last;
+}
+
+#define UP16(V) ( ( ( (V) + 15 ) / 16 ) * 16 )
 
 /** Get the number of bytes needed for an image.
   *
@@ -445,6 +470,9 @@ int mlt_image_format_size( mlt_image_format format, int width, int height, int *
 		case mlt_image_glsl_texture:
 			if ( bpp ) *bpp = 0;
 			return 4;
+		case mlt_image_yuv422p16:
+			if ( bpp ) *bpp = 2;
+			return height * ( UP16( width * 2 ) + 2 * UP16( width + 1 ) ) ;
 		default:
 			if ( bpp ) *bpp = 0;
 			return 0;
@@ -1132,4 +1160,64 @@ mlt_frame mlt_frame_clone( mlt_frame self, int is_deep )
 	}
 
 	return new_frame;
+}
+
+/** Build a planes pointers of image mapping
+ *
+ * For proper and unified planar image processing, planes sizes and planes pointers should
+ * be provides to processing code.
+ *
+ * \public \memberof mlt_frame_s
+ * \param format the image format
+ * \param width width of the image in pixels
+ * \param height height of the image in pixels
+ * \param[in] data pointer to allocated image
+ * \param[out] planes pointers to plane's pointers will be set
+ * \param[out] strides pointers to plane's strides will be set
+ * \return the number of bytes
+ */
+int mlt_image_format_planes( mlt_image_format format, int width, int height, void* data, unsigned char *planes[4], int strides[4])
+{
+	if ( mlt_image_yuv422p16 == format )
+	{
+		strides[0] = UP16( width * 2 );
+		strides[1] = UP16( width + 1 );
+		strides[2] = UP16( width + 1 );
+		strides[3] = 0;
+
+		planes[0] = (unsigned char*)data;
+		planes[1] = planes[0] + height * strides[0];
+		planes[2] = planes[1] + height * strides[1];
+		planes[3] = 0;
+	}
+	else if ( mlt_image_yuv420p == format )
+	{
+		strides[0] = width;
+		strides[1] = width >> 1;
+		strides[2] = width >> 1;
+		strides[3] = 0;
+
+		planes[0] = (unsigned char*)data;
+		planes[1] = (unsigned char*)data + width * height;
+		planes[2] = (unsigned char*)data + ( 5 * width * height ) / 4;
+		planes[3] = 0;
+	}
+	else
+	{
+		int bpp;
+
+		mlt_image_format_size( format, width, height, &bpp );
+
+		planes[0] = data;
+		planes[1] = 0;
+		planes[2] = 0;
+		planes[3] = 0;
+
+		strides[0] = bpp * width;
+		strides[1] = 0;
+		strides[2] = 0;
+		strides[3] = 0;
+	};
+
+	return 0;
 }

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -150,6 +150,8 @@ extern int mlt_image_format_size( mlt_image_format format, int width, int height
 extern const char * mlt_audio_format_name( mlt_audio_format format );
 extern int mlt_audio_format_size( mlt_audio_format format, int samples, int channels );
 extern void mlt_frame_write_ppm( mlt_frame frame );
+extern int mlt_image_format_planes( mlt_image_format format, int width, int height, void* data, unsigned char *planes[4], int strides[4]);
+extern mlt_image_format mlt_image_format_id( const char * name );
 
 /** This macro scales RGB into the YUV gamut - y is scaled by 219/255 and uv by 224/255. */
 #define RGB2YUV_601_SCALED(r, g, b, y, u, v)\

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -45,7 +45,9 @@ typedef enum
 	mlt_image_yuv420p, /**< 8-bit YUV 4:2:0 planar */
 	mlt_image_opengl,  /**< (deprecated) suitable for OpenGL texture */
 	mlt_image_glsl,    /**< for opengl module internal use only */
-	mlt_image_glsl_texture /**< an OpenGL texture name */
+	mlt_image_glsl_texture, /**< an OpenGL texture name */
+	mlt_image_yuv422p16, /**< planar YUV 4:2:2, 32bpp, (1 Cr & Cb sample per 2x1 Y samples), little-endian */
+	mlt_image_last
 }
 mlt_image_format;
 

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -454,6 +454,8 @@ static enum AVPixelFormat pick_pix_fmt( mlt_image_format img_fmt )
 		return AV_PIX_FMT_RGBA;
 	case mlt_image_yuv420p:
 		return AV_PIX_FMT_YUV420P;
+	case mlt_image_yuv422p16:
+		return AV_PIX_FMT_YUV422P16LE;
 	default:
 		return AV_PIX_FMT_YUYV422;
 	}
@@ -1144,7 +1146,6 @@ static void *consumer_thread( void *arg )
 	// Need two av pictures for converting
 	AVFrame *converted_avframe = NULL;
 	AVFrame *audio_avframe = NULL;
-	AVFrame *video_avframe = NULL;
 
 	// For receiving audio samples back from the fifo
 	uint8_t *audio_buf_1 = av_malloc( AUDIO_ENCODE_BUFFER_SIZE );
@@ -1316,6 +1317,8 @@ static void *consumer_thread( void *arg )
 					img_fmt = mlt_image_rgb24a;
 				else if ( !strcmp( img_fmt_name, "yuv420p" ) )
 					img_fmt = mlt_image_yuv420p;
+				else if ( !strcmp( img_fmt_name, "yuv422p16" ) )
+					img_fmt = mlt_image_yuv422p16;
 			}
 			else
 			{
@@ -1332,7 +1335,6 @@ static void *consumer_thread( void *arg )
 					img_fmt = mlt_image_rgb24;
 				}
 			}
-			video_avframe = alloc_picture( pick_pix_fmt( img_fmt ), width, height );
 		}
 	}
 	if ( audio_codec_id != AV_CODEC_ID_NONE )
@@ -1766,36 +1768,16 @@ static void *consumer_thread( void *arg )
 
 					if ( mlt_properties_get_int( frame_properties, "rendered" ) )
 					{
-						int i = 0;
-						uint8_t *p;
-						uint8_t *q;
-						int stride = mlt_image_format_size( img_fmt, width, 0, NULL );
-
+						AVFrame video_avframe;
 						mlt_frame_get_image( frame, &image, &img_fmt, &img_width, &img_height, 0 );
-						q = image;
 
-						// Convert the mlt frame to an AVPicture
-						if ( img_fmt == mlt_image_yuv420p )
-						{
-							stride = width * height;
-							memcpy( video_avframe->data[0], q, video_avframe->linesize[0] * height );
-							q += stride;
-							memcpy( video_avframe->data[1], q, video_avframe->linesize[1] * height / 2 );
-							q += stride / 4;
-							memcpy( video_avframe->data[2], q, video_avframe->linesize[2] * height / 2 );
-						}
-						else for ( i = 0; i < height; i ++ )
-						{
-							p = video_avframe->data[0] + i * video_avframe->linesize[0];
-							memcpy( p, q, stride );
-							q += stride;
-						}
+						mlt_image_format_planes( img_fmt, width, height, image, video_avframe.data, video_avframe.linesize );
 
 						// Do the colour space conversion
 						int flags = SWS_BICUBIC;
 						struct SwsContext *context = sws_getContext( width, height, pick_pix_fmt( img_fmt ),
 							width, height, c->pix_fmt, flags, NULL, NULL, NULL);
-						sws_scale( context, (const uint8_t* const*) video_avframe->data, video_avframe->linesize, 0, height,
+						sws_scale( context, (const uint8_t* const*) video_avframe.data, video_avframe.linesize, 0, height,
 							converted_avframe->data, converted_avframe->linesize);
 						sws_freeContext( context );
 
@@ -1808,6 +1790,7 @@ static void *consumer_thread( void *arg )
 						     c->pix_fmt == AV_PIX_FMT_ARGB ||
 						     c->pix_fmt == AV_PIX_FMT_BGRA )
 						{
+							uint8_t *p;
 							uint8_t *alpha = mlt_frame_get_alpha_mask( frame );
 							register int n;
 
@@ -2129,9 +2112,6 @@ on_fatal_error:
 	if ( converted_avframe )
 		av_free( converted_avframe->data[0] );
 	av_free( converted_avframe );
-	if ( video_avframe )
-		av_free( video_avframe->data[0] );
-	av_free( video_avframe );
 	av_free( video_outbuf );
 	av_free( audio_avframe );
 	av_free( audio_buf_1 );

--- a/src/modules/core/filter_fieldorder.c
+++ b/src/modules/core/filter_fieldorder.c
@@ -83,12 +83,21 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 			}
 
 			// Shift the entire image down by one line
-			int bpp;
-			int size = mlt_image_format_size( *format, *width, *height, &bpp );
-			uint8_t *new_image = mlt_pool_alloc( size );
-			uint8_t *ptr = new_image + *width * bpp;
-			memcpy( new_image, *image, *width * bpp );
-			memcpy( ptr, *image, *width * ( *height - 1 ) * bpp );
+			int p, strides[4], size;
+			uint8_t *new_planes[4], *old_planes[4], *new_image;
+
+			size = mlt_image_format_size( *format, *width, *height, NULL );
+			new_image = mlt_pool_alloc( size );
+			mlt_image_format_planes( *format, *width, *height, new_image, new_planes, strides );
+			mlt_image_format_planes( *format, *width, *height, *image, old_planes, strides );
+
+			for( p = 0; p < 4; p++ )
+			{
+				if( !new_planes[p] )
+					continue;
+				memcpy( new_planes[p], old_planes[p], strides[p] );
+				memcpy( new_planes[p] + strides[p], old_planes[p], strides[p] * ( *height - 1 ) );
+			}
 
 			// Set the new image
 			mlt_frame_set_image( frame, new_image, size, mlt_pool_release );

--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -26,6 +26,86 @@
 #include <sys/time.h>
 #include "common.h"
 
+#include <framework/mlt_slices.h>
+
+struct copy_lines_sliced_desc
+{
+	BMDPixelFormat in_fmt;
+	mlt_image_format out_fmt;
+	unsigned char *in_buffer, **out_buffers;
+	int in_stride, *out_strides, w, h;
+};
+
+#define READ_PIXELS( a, b, c ) \
+val  = *v210++;  \
+*a++ = ( val & 0x3FF ) << 6; \
+*b++ = ( ( val >> 10 ) & 0x3FF ) << 6;  \
+*c++ = ( ( val >> 20 ) & 0x3FF ) << 6;
+
+static int copy_lines_sliced_proc( int id, int idx, int jobs, void* cookie )
+{
+	int c, H, Y, i;
+	struct copy_lines_sliced_desc *ctx = (struct copy_lines_sliced_desc*)cookie;
+
+	H = ( ctx->h + jobs ) / jobs;
+	Y = idx * H;
+	H = MIN( H, ctx->h - Y );
+
+	if ( ctx->in_fmt == bmdFormat10BitYUV ) // bmdFormat10BitYUV -> mlt_image_yuv422p16
+	{
+		for( i = 0; i < H; i++)
+		{
+			uint32_t val,
+				*v210 = (uint32_t*)(ctx->in_buffer + ( Y + i ) * ctx->in_stride);
+			uint16_t
+				*y = (uint16_t*)(ctx->out_buffers[0] + ( Y + i ) * ctx->out_strides[0]),
+				*u = (uint16_t*)(ctx->out_buffers[1] + ( Y + i ) * ctx->out_strides[1]),
+				*v = (uint16_t*)(ctx->out_buffers[2] + ( Y + i ) * ctx->out_strides[2]);
+
+			for( c = 0; c < ctx->w / 6; c++ )
+			{
+				READ_PIXELS(u, y, v);
+				READ_PIXELS(y, u, y);
+				READ_PIXELS(v, y, u);
+				READ_PIXELS(y, v, y);
+			}
+		}
+	}
+	else // bmdFormat8BitYUV -> mlt_image_yuv422
+	{
+		if ( ctx->out_strides[0] == ctx->in_stride )
+			swab2(ctx->in_buffer + Y * ctx->in_stride,
+				ctx->out_buffers[0] + Y * ctx->out_strides[0],
+				H * ctx->in_stride );
+		else
+			for(i = 0; i < H; i++ )
+				swab2(ctx->in_buffer + ( Y + i )* ctx->in_stride,
+					ctx->out_buffers[0] + ( Y + i ) * ctx->out_strides[0],
+						MIN(ctx->in_stride , ctx->out_strides[0] ) );
+	}
+
+	return 0;
+}
+
+static void copy_lines( BMDPixelFormat in_fmt, unsigned char* in_buffer, int in_stride,
+	mlt_image_format out_fmt, unsigned char* out_buffers[4], int out_strides[4], int w, int h )
+{
+	struct copy_lines_sliced_desc ctx = { .in_fmt = in_fmt, .out_fmt = out_fmt, .in_buffer = in_buffer,
+		.out_buffers = out_buffers, .in_stride = in_stride, .out_strides = out_strides };
+
+	ctx.w = w; ctx.h = h;
+
+	if ( h == 1 )
+		copy_lines_sliced_proc( 0, 0, 1, &ctx );
+	else
+		mlt_slices_run_normal( mlt_slices_count_normal(), copy_lines_sliced_proc, &ctx );
+}
+
+static void fill_line( mlt_image_format out_fmt, unsigned char *in[4], int strides[4], int pattern )
+{
+	// TODO
+}
+
 class DeckLinkProducer
 	: public IDeckLinkInputCallback
 {
@@ -40,6 +120,7 @@ private:
 	int              m_dropped;
 	bool             m_isBuffering;
 	int              m_topFieldFirst;
+	BMDPixelFormat   m_pixel_format;
 	int              m_colorspace;
 	int              m_vancLines;
 	mlt_cache        m_cache;
@@ -206,9 +287,10 @@ public:
 			mlt_log_verbose( getProducer(), "%s format detection\n", doesDetectFormat ? "supports" : "does not support" );
 
 			// Enable video capture
-			BMDPixelFormat pixelFormat = bmdFormat8BitYUV;
+			m_pixel_format = ( mlt_properties_get_int( MLT_PRODUCER_PROPERTIES( getProducer() ), "10" ) )
+				? bmdFormat10BitYUV : bmdFormat8BitYUV;
 			BMDVideoInputFlags flags = doesDetectFormat ? bmdVideoInputEnableFormatDetection : bmdVideoInputFlagDefault;
-			if ( S_OK != m_decklinkInput->EnableVideoInput( displayMode, pixelFormat, flags ) )
+			if ( S_OK != m_decklinkInput->EnableVideoInput( displayMode, m_pixel_format, flags ) )
 				throw "Failed to enable video capture.";
 
 			// Enable audio capture
@@ -331,7 +413,7 @@ public:
 			mlt_properties_set_int( properties, "meta.media.width", profile->width );
 			mlt_properties_set_int( properties, "height", profile->height );
 			mlt_properties_set_int( properties, "meta.media.height", profile->height );
-			mlt_properties_set_int( properties, "format", mlt_image_yuv422 );
+			mlt_properties_set_int( properties, "format", ( m_pixel_format == bmdFormat8BitYUV ) ? mlt_image_yuv422 : mlt_image_yuv422p16 );
 			mlt_properties_set_int( properties, "colorspace", m_colorspace );
 			mlt_properties_set_int( properties, "meta.media.colorspace", m_colorspace );
 			mlt_properties_set_int( properties, "audio_frequency", 48000 );
@@ -436,18 +518,15 @@ public:
 					mlt_properties_set_int( MLT_PRODUCER_PROPERTIES( getProducer() ), "vitc_in", 0 );
 				}
 
-				int size = video->GetRowBytes() * ( video->GetHeight() + m_vancLines );
+				void *buffer;
+				int image_strides[4];
+				unsigned char* image_buffers[4];
+				mlt_image_format fmt = ( m_pixel_format == bmdFormat8BitYUV ) ? mlt_image_yuv422 : mlt_image_yuv422p16;
+				int size = mlt_image_format_size( fmt, video->GetWidth(), video->GetHeight() + m_vancLines, NULL );
 				void* image = mlt_pool_alloc( size );
-				void* buffer = 0;
-				unsigned char* p = (unsigned char*) image;
-				int n = size / 2;
 
-				// Initialize VANC lines to nominal black
-				while ( --n )
-				{
-					*p ++ = 16;
-					*p ++ = 128;
-				}
+				mlt_image_format_planes( fmt, video->GetWidth(), video->GetHeight() + m_vancLines,
+					image, image_buffers, image_strides );
 
 				// Capture VANC
 				if ( m_vancLines > 0 )
@@ -457,10 +536,24 @@ public:
 					{
 						for ( int i = 1; i < m_vancLines + 1; i++ )
 						{
+							unsigned char* out[4] = {
+								image_buffers[0] + (i - 1) * image_strides[0],
+								image_buffers[1] + (i - 1) * image_strides[1],
+								image_buffers[2] + (i - 1) * image_strides[2],
+								image_buffers[3] + (i - 1) * image_strides[3] };
+
 							if ( vanc->GetBufferForVerticalBlankingLine( i, &buffer ) == S_OK )
-								swab2( (char*) buffer, (char*) image + ( i - 1 ) * video->GetRowBytes(), video->GetRowBytes() );
+								copy_lines
+								(
+									m_pixel_format, (unsigned char*)buffer, video->GetRowBytes(),
+									fmt, out, image_strides,
+									video->GetWidth(), 1
+								);
 							else
+							{
+								fill_line( fmt, out, image_strides, 0 );
 								mlt_log_debug( getProducer(), "failed capture vanc line %d\n", i );
+							}
 						}
 						SAFE_RELEASE(vanc);
 					}
@@ -470,8 +563,19 @@ public:
 				video->GetBytes( &buffer );
 				if ( image && buffer )
 				{
-					size =  video->GetRowBytes() * video->GetHeight();
-					swab2( (char*) buffer, (char*) image + m_vancLines * video->GetRowBytes(), size );
+					unsigned char* out[4] = {
+						image_buffers[0] + m_vancLines * image_strides[0],
+						image_buffers[1] + m_vancLines * image_strides[1],
+						image_buffers[2] + m_vancLines * image_strides[2],
+						image_buffers[3] + m_vancLines * image_strides[3] };
+
+					copy_lines
+					(
+						m_pixel_format, (unsigned char*)buffer, video->GetRowBytes(),
+						fmt, (unsigned char**)out, image_strides,
+						video->GetWidth(), video->GetHeight()
+					);
+
 					frame = mlt_frame_init( MLT_PRODUCER_SERVICE( getProducer() ) );
 					mlt_frame_set_image( frame, (uint8_t*) image, size, mlt_pool_release );
 				}

--- a/src/modules/decklink/producer_decklink.yml
+++ b/src/modules/decklink/producer_decklink.yml
@@ -113,3 +113,12 @@ parameters:
       It skips frames that has VITC timecode less then specified.
       After reaching first frame with timecode greater or equal then specified this
       property is reset to zero.
+
+  - identifier: 10
+    title: Enable 10-bit capturing
+    description: Enable capturing in 10-bit native SDI signal
+    type: integer
+    minimum: 0
+    maximum: 1
+    default: 0
+    widget: checkbox


### PR DESCRIPTION
This branch provides handling 10bit capturing.

Regression testing:

```
melt -profile dv_pal decklink:0 10=1 -consumer avformat:/tmp/test1-`date '+%H%M%S'`.mov mlt_image_format=yuv422p16 properties=DV f=mov threads=12

melt -profile dv_pal decklink:0 10=1 -consumer avformat:/tmp/test2-`date '+%H%M%S'`.mov properties=DV f=mov threads=12

melt -profile dv_pal decklink:0 -consumer avformat:/tmp/test3-`date '+%H%M%S'`.mov mlt_image_format=yuv422p16 properties=DV f=mov threads=12

melt -profile dv_pal decklink:0 -consumer avformat:/tmp/test4-`date '+%H%M%S'`.mov properties=DV f=mov threads=12
```

10-bit capturing:

```
melt -profile dv_pal decklink:0 10=1 -consumer avformat:/tmp/test10-`date '+%H%M%S'`.mov mlt_image_format=yuv422p16 properties=ProRes threads=12
```
