### PR TITLE
Set 'progressive', 'top_field_first' property

### DIFF
--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -392,6 +392,7 @@ protected:
 			return false;
 		}
 		mlt_properties_set_int( properties, "top_field_first", m_displayMode->GetFieldDominance() == bmdUpperFieldFirst );
+		mlt_properties_set_int( properties, "progressive", m_displayMode->GetFieldDominance() == bmdProgressiveFrame );
 
 		// Set the keyer
 		if ( m_deckLinkKeyer && ( m_isKeyer = mlt_properties_get_int( properties, "keyer" ) ) )

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -545,17 +545,13 @@ protected:
 				}
 				if ( !m_isKeyer )
 				{
-					unsigned char *arg[3] = { image, buffer };
-					ssize_t size = stride * height;
+					unsigned char *arg[3] = { image, buffer, ( unsigned char* )( ssize_t )( stride * height )};
 
 					// Normal non-keyer playout - needs byte swapping
 					if ( !m_sliced_swab )
-						swab2( arg[0], arg[1], size );
+						swab2( arg[0], arg[1], ( ssize_t )arg[2] );
 					else
-					{
-						arg[2] = (unsigned char*)size;
 						mlt_slices_run_fifo( 0, swab_sliced, arg);
-					}
 				}
 				else if ( !mlt_properties_get_int( MLT_FRAME_PROPERTIES( frame ), "test_image" ) )
 				{

--- a/src/modules/ndi/consumer_ndi.c
+++ b/src/modules/ndi/consumer_ndi.c
@@ -151,30 +151,13 @@ static void* consumer_ndi_feeder( void* p )
 
 				if ( !m_isKeyer )
 				{
-					unsigned char *arg[3] = { image, buffer };
-					ssize_t size = stride * height;
-
-					// convert lower field first to top field first
-					if ( !progressive )
-					{
-						for ( int i = 0; i < width; i++)
-						{
-							buffer[ 2 * i + 0 ] = 128;
-							buffer[ 2 * i + 1 ] = 16;
-						}
-
-						arg[1] += stride;
-						size -= stride;
-					}
+					unsigned char *arg[3] = { image, buffer, ( unsigned char* )( uint64_t )( stride * height ) };
 
 					// Normal non-keyer playout - needs byte swapping
 					if ( !self->sliced_swab )
-						swab2( arg[0], arg[1], size );
+						swab2( arg[0], arg[1], ( size_t ) arg[2] );
 					else
-					{
-						arg[2] = (unsigned char*)size;
 						mlt_slices_run_fifo( 0, swab_sliced, arg);
-					}
 				}
 				else if ( !mlt_properties_get_int( MLT_FRAME_PROPERTIES( frame ), "test_image" ) )
 				{
@@ -182,14 +165,6 @@ static void* consumer_ndi_feeder( void* p )
 					int y = height + 1;
 					uint32_t* s = (uint32_t*) image;
 					uint32_t* d = (uint32_t*) buffer;
-
-					if ( !progressive )
-					{
-						// Correct field order
-						height--;
-						y--;
-						d += width;
-					}
 
 					// Need to relocate alpha channel RGBA => ARGB
 					while ( --y )
@@ -279,6 +254,11 @@ static int consumer_ndi_start( mlt_consumer consumer )
 	mlt_log_debug( MLT_CONSUMER_SERVICE( consumer ), "%s: entering\n", __FUNCTION__ );
 
 	mlt_properties properties = MLT_CONSUMER_PROPERTIES( consumer );
+
+	// Set progressive/interlacing properties
+	mlt_profile profile = mlt_service_profile( MLT_CONSUMER_SERVICE( consumer ) );
+	mlt_properties_set_int( properties, "top_field_first", !profile->progressive );
+	mlt_properties_set_int( properties, "progressive", profile->progressive );
 
 	consumer_ndi_t* self = ( consumer_ndi_t* )consumer->child;
 


### PR DESCRIPTION
attached set unifies setting 'progressive', 'top_field_first' property for NDI consumer, drop field order changing and set 'progressive' property of decklink consumer