### PR TITLE
Review please: Move colorspace convertion to standalone function

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -491,6 +491,8 @@ MLT_6.4.0 {
 
 MLT_6.6.0 {
   global:
+    mlt_image_format_planes;
+    mlt_image_format_id;
     mlt_slices_count_normal;
     mlt_slices_count_rr;
     mlt_slices_count_fifo;

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -486,17 +486,8 @@ static void set_image_format( mlt_consumer self )
 	const char* format = mlt_properties_get( properties, "mlt_image_format" );
 	if ( format )
 	{
-		if ( !strcmp( format, "rgb24" ) )
-			priv->image_format = mlt_image_rgb24;
-		else if ( !strcmp( format, "rgb24a" ) )
-			priv->image_format = mlt_image_rgb24a;
-		else if ( !strcmp( format, "yuv420p" ) )
-			priv->image_format = mlt_image_yuv420p;
-		else if ( !strcmp( format, "none" ) )
-			priv->image_format = mlt_image_none;
-		else if ( !strcmp( format, "glsl" ) )
-			priv->image_format = mlt_image_glsl_texture;
-		else
+		priv->image_format = mlt_image_format_id( format );
+		if ( mlt_image_invalid == priv->image_format )
 			priv->image_format = mlt_image_yuv422;
 	}
 }

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -150,6 +150,8 @@ extern int mlt_image_format_size( mlt_image_format format, int width, int height
 extern const char * mlt_audio_format_name( mlt_audio_format format );
 extern int mlt_audio_format_size( mlt_audio_format format, int samples, int channels );
 extern void mlt_frame_write_ppm( mlt_frame frame );
+extern int mlt_image_format_planes( mlt_image_format format, int width, int height, void* data, unsigned char *planes[4], int strides[4]);
+extern mlt_image_format mlt_image_format_id( const char * name );
 
 /** This macro scales RGB into the YUV gamut - y is scaled by 219/255 and uv by 224/255. */
 #define RGB2YUV_601_SCALED(r, g, b, y, u, v)\

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -45,7 +45,9 @@ typedef enum
 	mlt_image_yuv420p, /**< 8-bit YUV 4:2:0 planar */
 	mlt_image_opengl,  /**< (deprecated) suitable for OpenGL texture */
 	mlt_image_glsl,    /**< for opengl module internal use only */
-	mlt_image_glsl_texture /**< an OpenGL texture name */
+	mlt_image_glsl_texture, /**< an OpenGL texture name */
+	mlt_image_yuv422p16, /**< planar YUV 4:2:2, 32bpp, (1 Cr & Cb sample per 2x1 Y samples), little-endian */
+	mlt_image_invalid
 }
 mlt_image_format;
 

--- a/src/modules/avformat/factory.c
+++ b/src/modules/avformat/factory.c
@@ -23,6 +23,7 @@
 #include <float.h>
 
 #include <framework/mlt.h>
+#include <framework/mlt_slices.h>
 
 extern mlt_consumer consumer_avformat_init( mlt_profile profile, char *file );
 extern mlt_filter filter_avcolour_space_init( void *arg );
@@ -42,6 +43,7 @@ extern mlt_filter filter_avfilter_init( mlt_profile, mlt_service_type, const cha
 #endif
 #include <libavutil/opt.h>
 
+#include "factory.h"
 
 // A static flag used to determine if avformat has been initialised
 static int avformat_initialised = 0;
@@ -436,4 +438,252 @@ MLT_REPOSITORY
 	mlt_properties_close( blacklist );
 #endif // AVFILTER
 #endif
+}
+
+#if LIBSWSCALE_VERSION_INT >= AV_VERSION_INT( 3, 1, 101 )
+struct sliced_pix_fmt_conv_t
+{
+	int slice_w;
+	AVFrame *src_frame, *dst_frame;
+	const AVPixFmtDescriptor *src_desc, *dst_desc;
+	int flags, src_colorspace, dst_colorspace, src_full_range, dst_full_range;
+};
+
+static int sliced_h_pix_fmt_conv_proc( int id, int idx, int jobs, void* cookie )
+{
+	uint8_t *out[4];
+	const uint8_t *in[4];
+	int in_stride[4], out_stride[4];
+	int src_v_chr_pos = -513, dst_v_chr_pos = -513, ret, i, slice_x, slice_w, h, mul, field, slices, interlaced = 0;
+
+	struct SwsContext *sws;
+	struct sliced_pix_fmt_conv_t* ctx = ( struct sliced_pix_fmt_conv_t* )cookie;
+
+	interlaced = ctx->src_frame->interlaced_frame;
+	field = ( interlaced ) ? ( idx & 1 ) : 0;
+	idx = ( interlaced ) ? ( idx / 2 ) : idx;
+	slices = ( interlaced ) ? ( jobs / 2 ) : jobs;
+	mul = ( interlaced ) ? 2 : 1;
+	h = ctx->src_frame->height >> !!interlaced;
+	slice_w = ctx->slice_w;
+	slice_x = slice_w * idx;
+	slice_w = FFMIN( slice_w, ctx->src_frame->width - slice_x );
+
+	if ( AV_PIX_FMT_YUV420P == ctx->src_frame->format )
+		src_v_chr_pos = ( !interlaced ) ? 128 : ( !field ) ? 64 : 192;
+
+	if ( AV_PIX_FMT_YUV420P == ctx->dst_frame->format )
+		dst_v_chr_pos = ( !interlaced ) ? 128 : ( !field ) ? 64 : 192;
+
+	mlt_log_debug( NULL, "%s:%d: [id=%d, idx=%d, jobs=%d], [%s -> %s], interlaced=%d, field=%d, slices=%d, mul=%d, h=%d, slice_w=%d, slice_x=%d ctx->src_desc=[log2_chroma_h=%d, log2_chroma_w=%d], src_v_chr_pos=%d, dst_v_chr_pos=%d\n",
+		__FUNCTION__, __LINE__, id, idx, jobs, av_get_pix_fmt_name( ctx->src_frame->format ), av_get_pix_fmt_name( ctx->dst_frame->format ),
+		interlaced, field, slices, mul, h, slice_w, slice_x, ctx->src_desc->log2_chroma_h, ctx->src_desc->log2_chroma_w, src_v_chr_pos, dst_v_chr_pos );
+
+	if ( slice_w <= 0 )
+		return 0;
+
+	if ( AV_PIX_FMT_RGB24 == ctx->dst_frame->format || AV_PIX_FMT_RGBA == ctx->dst_frame->format )
+		ctx->flags |= SWS_FULL_CHR_H_INT;
+	else if ( AV_PIX_FMT_YUYV422 == ctx->dst_frame->format || AV_PIX_FMT_YUV422P16 == ctx->dst_frame->format )
+		ctx->flags |= SWS_FULL_CHR_H_INP;
+
+	sws = sws_alloc_context();
+
+	av_opt_set_int( sws, "srcw", slice_w, 0 );
+	av_opt_set_int( sws, "srch", h, 0 );
+	av_opt_set_int( sws, "src_format", ctx->src_frame->format, 0 );
+	av_opt_set_int( sws, "dstw", slice_w, 0 );
+	av_opt_set_int( sws, "dsth", h, 0 );
+	av_opt_set_int( sws, "dst_format", ctx->dst_frame->format, 0 );
+	av_opt_set_int( sws, "sws_flags", ctx->flags, 0 );
+
+	av_opt_set_int( sws, "src_h_chr_pos", -513, 0 );
+	av_opt_set_int( sws, "src_v_chr_pos", src_v_chr_pos, 0 );
+	av_opt_set_int( sws, "dst_h_chr_pos", -513, 0 );
+	av_opt_set_int( sws, "dst_v_chr_pos", dst_v_chr_pos, 0 );
+
+	if ( ( ret = sws_init_context( sws, NULL, NULL ) ) < 0 )
+	{
+		mlt_log_error( NULL, "%s:%d: sws_init_context failed, ret=%d\n", __FUNCTION__, __LINE__, ret );
+		sws_freeContext( sws );
+		return 0;
+	}
+
+	avformat_set_luma_transfer( sws, ctx->src_colorspace, ctx->dst_colorspace, ctx->src_full_range, ctx->dst_full_range );
+
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 0, 100)
+#define PIX_DESC_BPP(DESC) (DESC.step_minus1 + 1)
+#else
+#define PIX_DESC_BPP(DESC) (DESC.step)
+#endif
+
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 32, 100)
+#define AV_PIX_FMT_FLAG_PLANAR PIX_FMT_PLANAR
+#endif
+	for( i = 0; i < 4; i++ )
+	{
+		int in_offset = (AV_PIX_FMT_FLAG_PLANAR & ctx->src_desc->flags)
+			 ? ( ( 1 == i || 2 == i ) ? ( slice_x >> ctx->src_desc->log2_chroma_w ) : slice_x )
+			 : ( ( i ) ? 0 : slice_x * PIX_DESC_BPP(ctx->src_desc->comp[0]) );
+
+		int out_offset = (AV_PIX_FMT_FLAG_PLANAR & ctx->dst_desc->flags)
+			 ? ( ( 1 == i || 2 == i ) ? ( slice_x >> ctx->dst_desc->log2_chroma_w ) : slice_x )
+			 : ( ( i ) ? 0 : slice_x * PIX_DESC_BPP(ctx->dst_desc->comp[0]) );
+
+		in_stride[i]  = ctx->src_frame->linesize[i] * mul;
+		out_stride[i] = ctx->dst_frame->linesize[i] * mul;
+
+		in[i] =  ctx->src_frame->data[i] + ctx->src_frame->linesize[i] * field + in_offset;
+		out[i] = ctx->dst_frame->data[i] + ctx->dst_frame->linesize[i] * field + out_offset;
+	}
+
+	sws_scale( sws, in, in_stride, 0, h, out, out_stride );
+
+	sws_freeContext( sws );
+
+	return 0;
+}
+
+int avformat_colorspace_convert
+(
+	AVFrame* src, int src_colorspace, int src_full_range,
+	AVFrame* dst, int dst_colorspace, int dst_full_range,
+	int flags
+)
+{
+	int c, i;
+
+	struct sliced_pix_fmt_conv_t ctx =
+	{
+		.flags = flags,
+		.src_frame = src,
+		.dst_frame = dst,
+		.src_colorspace = src_colorspace,
+		.dst_colorspace = dst_colorspace,
+		.src_full_range = src_full_range,
+		.dst_full_range = dst_full_range,
+	};
+
+	ctx.src_desc = av_pix_fmt_desc_get( ctx.src_frame->format );
+	ctx.dst_desc = av_pix_fmt_desc_get( ctx.dst_frame->format );
+
+	if ( !getenv("MLT_AVFORMAT_SLICED_PIXFMT_DISABLE") )
+		ctx.slice_w = ( src->width < 1000 )
+			? ( 256 >> src->interlaced_frame )
+			: ( 512 >> src->interlaced_frame );
+	else
+		ctx.slice_w = src->width;
+
+	c = ( src->width + ctx.slice_w - 1 ) / ctx.slice_w;
+	c *= src->interlaced_frame ? 2 : 1;
+
+	if ( !getenv("MLT_AVFORMAT_SLICED_PIXFMT_DISABLE") )
+		mlt_slices_run_normal( c, sliced_h_pix_fmt_conv_proc, &ctx );
+	else
+		for ( i = 0 ; i < c; i++ )
+			sliced_h_pix_fmt_conv_proc( i, i, c, &ctx );
+
+	return dst_colorspace;
+}
+#endif
+
+int avformat_map_pixfmt_av2mlt( int f )
+{
+	switch( f )
+	{
+		case AV_PIX_FMT_RGB24: return mlt_image_rgb24;
+		case AV_PIX_FMT_RGBA: return mlt_image_rgb24a;
+		case AV_PIX_FMT_YUYV422: return mlt_image_yuv422;
+		case AV_PIX_FMT_YUV420P: return mlt_image_yuv420p;
+		case AV_PIX_FMT_YUV422P16LE: return mlt_image_yuv422p16;
+
+		default:
+			mlt_log_error( NULL, "%s:%d Invalid av format %s\n",
+				__FILE__, __LINE__,
+				av_get_pix_fmt_name( f ) );
+			break;
+
+	};
+	return mlt_image_invalid;
+}
+
+int avformat_map_pixfmt_mlt2av( int format )
+{
+	int value = AV_PIX_FMT_NONE;
+
+	switch( format )
+	{
+		case mlt_image_rgb24:
+			value = AV_PIX_FMT_RGB24;
+			break;
+		case mlt_image_rgb24a:
+		case mlt_image_opengl:
+			value = AV_PIX_FMT_RGBA;
+			break;
+		case mlt_image_yuv422:
+			value = AV_PIX_FMT_YUYV422;
+			break;
+		case mlt_image_yuv420p:
+			value = AV_PIX_FMT_YUV420P;
+			break;
+		case mlt_image_yuv422p16:
+			value = AV_PIX_FMT_YUV422P16LE;
+			break;
+		default:
+			mlt_log_error( NULL, "%s:%d Invalid mlt format %s\n",
+				__FILE__, __LINE__,
+				mlt_image_format_name( format ) );
+			break;
+	}
+
+	return value;
+}
+
+int avformat_set_luma_transfer( struct SwsContext *context, int src_colorspace,
+	int dst_colorspace, int src_full_range, int dst_full_range )
+{
+	const int *src_coefficients = sws_getCoefficients( SWS_CS_DEFAULT );
+	const int *dst_coefficients = sws_getCoefficients( SWS_CS_DEFAULT );
+	int brightness = 0;
+	int contrast = 1 << 16;
+	int saturation = 1  << 16;
+	int src_range = src_full_range ? 1 : 0;
+	int dst_range = dst_full_range ? 1 : 0;
+
+	switch ( src_colorspace )
+	{
+	case 170:
+	case 470:
+	case 601:
+	case 624:
+		src_coefficients = sws_getCoefficients( SWS_CS_ITU601 );
+		break;
+	case 240:
+		src_coefficients = sws_getCoefficients( SWS_CS_SMPTE240M );
+		break;
+	case 709:
+		src_coefficients = sws_getCoefficients( SWS_CS_ITU709 );
+		break;
+	default:
+		break;
+	}
+	switch ( dst_colorspace )
+	{
+	case 170:
+	case 470:
+	case 601:
+	case 624:
+		dst_coefficients = sws_getCoefficients( SWS_CS_ITU601 );
+		break;
+	case 240:
+		dst_coefficients = sws_getCoefficients( SWS_CS_SMPTE240M );
+		break;
+	case 709:
+		dst_coefficients = sws_getCoefficients( SWS_CS_ITU709 );
+		break;
+	default:
+		break;
+	}
+	return sws_setColorspaceDetails( context, src_coefficients, src_range, dst_coefficients, dst_range,
+		brightness, contrast, saturation );
 }

--- a/src/modules/avformat/factory.h
+++ b/src/modules/avformat/factory.h
@@ -1,0 +1,42 @@
+/*
+ * factory.h -- the factory method interfaces
+ * Copyright (C) 2003-2017 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef FACTORY_H
+#define FACTORY_H
+
+#include <libswscale/swscale.h>
+#include <libavutil/pixdesc.h>
+
+int avformat_set_luma_transfer( struct SwsContext *context, int src_colorspace,
+	int dst_colorspace, int src_full_range, int dst_full_range );
+
+int avformat_map_pixfmt_mlt2av( int format );
+
+int avformat_map_pixfmt_av2mlt( int f );
+
+#if LIBSWSCALE_VERSION_INT >= AV_VERSION_INT( 3, 1, 101 )
+int avformat_colorspace_convert
+(
+	AVFrame* src, int src_colorspace, int src_full_range,
+	AVFrame* dst, int dst_colorspace, int dst_full_range,
+	int flags
+);
+#endif
+
+#endif /* FACTORY_H */

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -25,7 +25,6 @@
 #include <framework/mlt_deque.h>
 #include <framework/mlt_factory.h>
 #include <framework/mlt_cache.h>
-#include <framework/mlt_slices.h>
 
 // ffmpeg Header files
 #include <libavformat/avformat.h>
@@ -53,6 +52,8 @@
 #include <limits.h>
 #include <math.h>
 #include <wchar.h>
+
+#include "factory.h"
 
 #if LIBAVCODEC_VERSION_MAJOR < 55
 #define AV_CODEC_ID_H264    CODEC_ID_H264
@@ -1111,55 +1112,6 @@ static void get_audio_streams_info( producer_avformat self )
 		self->audio_streams, self->audio_max_stream, self->total_channels, self->max_channel );
 }
 
-static int set_luma_transfer( struct SwsContext *context, int src_colorspace,
-	int dst_colorspace, int src_full_range, int dst_full_range )
-{
-	const int *src_coefficients = sws_getCoefficients( SWS_CS_DEFAULT );
-	const int *dst_coefficients = sws_getCoefficients( SWS_CS_DEFAULT );
-	int brightness = 0;
-	int contrast = 1 << 16;
-	int saturation = 1  << 16;
-	int src_range = src_full_range ? 1 : 0;
-	int dst_range = dst_full_range ? 1 : 0;
-
-	switch ( src_colorspace )
-	{
-	case 170:
-	case 470:
-	case 601:
-	case 624:
-		src_coefficients = sws_getCoefficients( SWS_CS_ITU601 );
-		break;
-	case 240:
-		src_coefficients = sws_getCoefficients( SWS_CS_SMPTE240M );
-		break;
-	case 709:
-		src_coefficients = sws_getCoefficients( SWS_CS_ITU709 );
-		break;
-	default:
-		break;
-	}
-	switch ( dst_colorspace )
-	{
-	case 170:
-	case 470:
-	case 601:
-	case 624:
-		dst_coefficients = sws_getCoefficients( SWS_CS_ITU601 );
-		break;
-	case 240:
-		dst_coefficients = sws_getCoefficients( SWS_CS_SMPTE240M );
-		break;
-	case 709:
-		dst_coefficients = sws_getCoefficients( SWS_CS_ITU709 );
-		break;
-	default:
-		break;
-	}
-	return sws_setColorspaceDetails( context, src_coefficients, src_range, dst_coefficients, dst_range,
-		brightness, contrast, saturation );
-}
-
 static mlt_image_format pick_image_format( enum AVPixelFormat pix_fmt )
 {
 	switch ( pix_fmt )
@@ -1247,107 +1199,6 @@ static int pick_av_pixel_format( int *pix_fmt )
 	return 0;
 }
 
-#if LIBSWSCALE_VERSION_INT >= AV_VERSION_INT( 3, 1, 101 )
-struct sliced_pix_fmt_conv_t
-{
-	int width, height, slice_w;
-	AVFrame *frame;
-	AVPicture *output;
-	enum AVPixelFormat src_format, dst_format;
-	const AVPixFmtDescriptor *src_desc, *dst_desc;
-	int flags, src_colorspace, dst_colorspace, src_full_range, dst_full_range;
-};
-
-static int sliced_h_pix_fmt_conv_proc( int id, int idx, int jobs, void* cookie )
-{
-	uint8_t *out[4];
-	const uint8_t *in[4];
-	int in_stride[4], out_stride[4];
-	int src_v_chr_pos = -513, dst_v_chr_pos = -513, ret, i, slice_x, slice_w, w, h, mul, field, slices, interlaced = 0;
-
-	struct SwsContext *sws;
-	struct sliced_pix_fmt_conv_t* ctx = ( struct sliced_pix_fmt_conv_t* )cookie;
-
-	interlaced = ctx->frame->interlaced_frame;
-	field = ( interlaced ) ? ( idx & 1 ) : 0;
-	idx = ( interlaced ) ? ( idx / 2 ) : idx;
-	slices = ( interlaced ) ? ( jobs / 2 ) : jobs;
-	mul = ( interlaced ) ? 2 : 1;
-	h = ctx->height >> !!interlaced;
-	slice_w = ctx->slice_w;
-	slice_x = slice_w * idx;
-	slice_w = FFMIN( slice_w, ctx->width - slice_x );
-
-	if ( AV_PIX_FMT_YUV420P == ctx->src_format )
-		src_v_chr_pos = ( !interlaced ) ? 128 : ( !field ) ? 64 : 192;
-
-	if ( AV_PIX_FMT_YUV420P == ctx->dst_format )
-		dst_v_chr_pos = ( !interlaced ) ? 128 : ( !field ) ? 64 : 192;
-
-	mlt_log_debug( NULL, "%s:%d: [id=%d, idx=%d, jobs=%d], interlaced=%d, field=%d, slices=%d, mul=%d, h=%d, slice_w=%d, slice_x=%d ctx->src_desc=[log2_chroma_h=%d, log2_chroma_w=%d], src_v_chr_pos=%d, dst_v_chr_pos=%d\n",
-		__FUNCTION__, __LINE__, id, idx, jobs, interlaced, field, slices, mul, h, slice_w, slice_x, ctx->src_desc->log2_chroma_h, ctx->src_desc->log2_chroma_w, src_v_chr_pos, dst_v_chr_pos );
-
-	if ( slice_w <= 0 )
-		return 0;
-
-	sws = sws_alloc_context();
-
-	av_opt_set_int( sws, "srcw", slice_w, 0 );
-	av_opt_set_int( sws, "srch", h, 0 );
-	av_opt_set_int( sws, "src_format", ctx->src_format, 0 );
-	av_opt_set_int( sws, "dstw", slice_w, 0 );
-	av_opt_set_int( sws, "dsth", h, 0 );
-	av_opt_set_int( sws, "dst_format", ctx->dst_format, 0 );
-	av_opt_set_int( sws, "sws_flags", ctx->flags | SWS_FULL_CHR_H_INP, 0 );
-
-	av_opt_set_int( sws, "src_h_chr_pos", -513, 0 );
-	av_opt_set_int( sws, "src_v_chr_pos", src_v_chr_pos, 0 );
-	av_opt_set_int( sws, "dst_h_chr_pos", -513, 0 );
-	av_opt_set_int( sws, "dst_v_chr_pos", dst_v_chr_pos, 0 );
-
-	if ( ( ret = sws_init_context( sws, NULL, NULL ) ) < 0 )
-	{
-		mlt_log_error( NULL, "%s:%d: sws_init_context failed, ret=%d\n", __FUNCTION__, __LINE__, ret );
-		sws_freeContext( sws );
-		return 0;
-	}
-
-	set_luma_transfer( sws, ctx->src_colorspace, ctx->dst_colorspace, ctx->src_full_range, ctx->dst_full_range );
-
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 0, 100)
-#define PIX_DESC_BPP(DESC) (DESC.step_minus1 + 1)
-#else
-#define PIX_DESC_BPP(DESC) (DESC.step)
-#endif
-
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 32, 100)
-#define AV_PIX_FMT_FLAG_PLANAR PIX_FMT_PLANAR
-#endif
-	for( i = 0; i < 4; i++ )
-	{
-		int in_offset = (AV_PIX_FMT_FLAG_PLANAR & ctx->src_desc->flags)
-			 ? ( ( 1 == i || 2 == i ) ? ( slice_x >> ctx->src_desc->log2_chroma_w ) : slice_x )
-			 : ( ( i ) ? 0 : slice_x * PIX_DESC_BPP(ctx->src_desc->comp[0]) );
-
-		int out_offset = (AV_PIX_FMT_FLAG_PLANAR & ctx->dst_desc->flags)
-			 ? ( ( 1 == i || 2 == i ) ? ( slice_x >> ctx->dst_desc->log2_chroma_w ) : slice_x )
-			 : ( ( i ) ? 0 : slice_x * PIX_DESC_BPP(ctx->dst_desc->comp[0]) );
-
-		in_stride[i]  = ctx->frame->linesize[i] * mul;
-		out_stride[i] = ctx->output->linesize[i] * mul;
-
-		in[i] =  ctx->frame->data[i] + ctx->frame->linesize[i] * field + in_offset;
-		out[i] = ctx->output->data[i] + ctx->output->linesize[i] * field + out_offset;
-	}
-
-	sws_scale( sws, in, in_stride, 0, h, out, out_stride );
-
-	sws_freeContext( sws );
-
-	return 0;
-}
-#endif
-
 // returns resulting YUV colorspace
 static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffer, int pix_fmt,
 	mlt_image_format *format, int width, int height, uint8_t **alpha )
@@ -1381,6 +1232,36 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 			memcpy( dst, src, FFMIN( width, frame->linesize[3] ) );
 	}
 
+#if LIBSWSCALE_VERSION_INT >= AV_VERSION_INT( 3, 1, 101 )
+	{
+		AVFrame input = *frame;
+		AVFrame output;
+
+		pick_av_pixel_format( &input.format );
+
+		output.format = avformat_map_pixfmt_mlt2av( *format );
+		output.width = width;
+		output.height = height;
+
+#if defined(FFUDIV) && (LIBAVFORMAT_VERSION_INT < ((55<<16)+(48<<8)+100))
+		if ( self->full_luma && *format == mlt_image_yuv420p )
+			output.format = AV_PIX_FMT_YUVJ420P;
+#endif
+
+		mlt_image_format_planes( *format, output.width, output.height, buffer, output.data, output.linesize );
+
+		result = avformat_colorspace_convert
+		(
+			&input,
+				self->yuv_colorspace, // int src_colorspace,
+				self->full_luma, // int src_full_range,
+			&output,
+				profile->colorspace, // int dst_colorspace,
+				( *format == mlt_image_yuv420p ) ? self->full_luma : 0, // int dst_full_range,
+			flags // int flags
+		);
+	}
+#else
 	int src_pix_fmt = pix_fmt;
 	pick_av_pixel_format( &src_pix_fmt );
 	if ( *format == mlt_image_yuv420p )
@@ -1404,7 +1285,7 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 		output.linesize[0] = width;
 		output.linesize[1] = width >> 1;
 		output.linesize[2] = width >> 1;
-		if ( !set_luma_transfer( context, self->yuv_colorspace, profile->colorspace, self->full_luma, self->full_luma ) )
+		if ( !avformat_set_luma_transfer( context, self->yuv_colorspace, profile->colorspace, self->full_luma, self->full_luma ) )
 			result = profile->colorspace;
 		sws_scale( context, (const uint8_t* const*) frame->data, frame->linesize, 0, height,
 			output.data, output.linesize);
@@ -1417,7 +1298,7 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 		AVPicture output;
 		avpicture_fill( &output, buffer, AV_PIX_FMT_RGB24, width, height );
 		// libswscale wants the RGB colorspace to be SWS_CS_DEFAULT, which is = SWS_CS_ITU601.
-		set_luma_transfer( context, self->yuv_colorspace, 601, self->full_luma, 0 );
+		avformat_set_luma_transfer( context, self->yuv_colorspace, 601, self->full_luma, 0 );
 		sws_scale( context, (const uint8_t* const*) frame->data, frame->linesize, 0, height,
 			output.data, output.linesize);
 		sws_freeContext( context );
@@ -1429,58 +1310,12 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 		AVPicture output;
 		avpicture_fill( &output, buffer, AV_PIX_FMT_RGBA, width, height );
 		// libswscale wants the RGB colorspace to be SWS_CS_DEFAULT, which is = SWS_CS_ITU601.
-		set_luma_transfer( context, self->yuv_colorspace, 601, self->full_luma, 0 );
+		avformat_set_luma_transfer( context, self->yuv_colorspace, 601, self->full_luma, 0 );
 		sws_scale( context, (const uint8_t* const*) frame->data, frame->linesize, 0, height,
 			output.data, output.linesize);
 		sws_freeContext( context );
 	}
 	else
-#if LIBSWSCALE_VERSION_INT >= AV_VERSION_INT( 3, 1, 101 )
-	{
-		int i, c;
-		AVPicture output;
-		struct sliced_pix_fmt_conv_t ctx =
-		{
-			.flags = flags,
-			.width = width,
-			.height = height,
-			.frame = frame,
-			.output = &output,
-			.dst_format = AV_PIX_FMT_YUYV422,
-			.src_colorspace = self->yuv_colorspace,
-			.dst_colorspace = profile->colorspace,
-			.src_full_range = self->full_luma,
-			.dst_full_range = 0,
-		};
-#if defined(FFUDIV) && (LIBAVFORMAT_VERSION_INT >= ((55<<16)+(48<<8)+100))
-		ctx.src_format = src_pix_fmt;
-#else
-		ctx.src_format = pix_fmt;
-#endif
-		ctx.src_desc = av_pix_fmt_desc_get( ctx.src_format );
-		ctx.dst_desc = av_pix_fmt_desc_get( ctx.dst_format );
-
-		avpicture_fill( ctx.output, buffer, ctx.dst_format, width, height );
-
-		if ( !getenv("MLT_AVFORMAT_SLICED_PIXFMT_DISABLE") )
-			ctx.slice_w = ( width < 1000 )
-				? ( 256 >> frame->interlaced_frame )
-				: ( 512 >> frame->interlaced_frame );
-		else
-			ctx.slice_w = width;
-
-		c = ( width + ctx.slice_w - 1 ) / ctx.slice_w;
-		c *= frame->interlaced_frame ? 2 : 1;
-
-		if ( !getenv("MLT_AVFORMAT_SLICED_PIXFMT_DISABLE") )
-			mlt_slices_run_normal( c, sliced_h_pix_fmt_conv_proc, &ctx );
-		else
-			for ( i = 0 ; i < c; i++ )
-				sliced_h_pix_fmt_conv_proc( i, i, c, &ctx );
-
-		result = profile->colorspace;
-	}
-#else
 	{
 #if defined(FFUDIV) && (LIBAVFORMAT_VERSION_INT >= ((55<<16)+(48<<8)+100))
 		struct SwsContext *context = sws_getContext( width, height, src_pix_fmt,
@@ -1491,7 +1326,7 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 #endif
 		AVPicture output;
 		avpicture_fill( &output, buffer, AV_PIX_FMT_YUYV422, width, height );
-		if ( !set_luma_transfer( context, self->yuv_colorspace, profile->colorspace, self->full_luma, 0 ) )
+		if ( !avformat_set_luma_transfer( context, self->yuv_colorspace, profile->colorspace, self->full_luma, 0 ) )
 			result = profile->colorspace;
 		sws_scale( context, (const uint8_t* const*) frame->data, frame->linesize, 0, height,
 			output.data, output.linesize);

--- a/src/modules/core/filter_fieldorder.c
+++ b/src/modules/core/filter_fieldorder.c
@@ -75,7 +75,7 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		     mlt_properties_get( properties, "progressive" ) &&
 		     mlt_properties_get_int( properties, "progressive" ) == 0 )
 		{
-			// We only work with non-planar formats
+			// We only work with non-vertical luma/chroma scaled
 			if ( *format == mlt_image_yuv420p )
 			{
 				*format = mlt_image_yuv422;
@@ -83,12 +83,21 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 			}
 
 			// Shift the entire image down by one line
-			int bpp;
-			int size = mlt_image_format_size( *format, *width, *height, &bpp );
-			uint8_t *new_image = mlt_pool_alloc( size );
-			uint8_t *ptr = new_image + *width * bpp;
-			memcpy( new_image, *image, *width * bpp );
-			memcpy( ptr, *image, *width * ( *height - 1 ) * bpp );
+			int p, strides[4], size;
+			uint8_t *new_planes[4], *old_planes[4], *new_image;
+
+			size = mlt_image_format_size( *format, *width, *height, NULL );
+			new_image = mlt_pool_alloc( size );
+			mlt_image_format_planes( *format, *width, *height, new_image, new_planes, strides );
+			mlt_image_format_planes( *format, *width, *height, *image, old_planes, strides );
+
+			for( p = 0; p < 4; p++ )
+			{
+				if( !new_planes[p] )
+					continue;
+				memcpy( new_planes[p], old_planes[p], strides[p] );
+				memcpy( new_planes[p] + strides[p], old_planes[p], strides[p] * ( *height - 1 ) );
+			}
 
 			// Set the new image
 			mlt_frame_set_image( frame, new_image, size, mlt_pool_release );

--- a/src/modules/core/filter_imageconvert.c
+++ b/src/modules/core/filter_imageconvert.c
@@ -293,12 +293,13 @@ static int convert_rgb24a_to_rgb24( uint8_t *rgba, uint8_t *rgb, uint8_t *alpha,
 
 typedef int ( *conversion_function )( uint8_t *yuv, uint8_t *rgba, uint8_t *alpha, int width, int height );
 
-static conversion_function conversion_matrix[5][5] = {
-	{ NULL, convert_rgb24_to_rgb24a, convert_rgb24_to_yuv422, NULL, convert_rgb24_to_rgb24a },
-	{ convert_rgb24a_to_rgb24, NULL, convert_rgb24a_to_yuv422, NULL, NULL },
-	{ convert_yuv422_to_rgb24, convert_yuv422_to_rgb24a, NULL, NULL, convert_yuv422_to_rgb24a },
-	{ NULL, NULL, convert_yuv420p_to_yuv422, NULL, NULL },
-	{ convert_rgb24a_to_rgb24, NULL, convert_rgb24a_to_yuv422, NULL, NULL },
+static conversion_function conversion_matrix[ mlt_image_invalid - 1 ][ mlt_image_invalid - 1 ] = {
+	{ NULL, convert_rgb24_to_rgb24a, convert_rgb24_to_yuv422, NULL, convert_rgb24_to_rgb24a, NULL },
+	{ convert_rgb24a_to_rgb24, NULL, convert_rgb24a_to_yuv422, NULL, NULL, NULL },
+	{ convert_yuv422_to_rgb24, convert_yuv422_to_rgb24a, NULL, NULL, convert_yuv422_to_rgb24a, NULL },
+	{ NULL, NULL, convert_yuv420p_to_yuv422, NULL, NULL, NULL },
+	{ convert_rgb24a_to_rgb24, NULL, convert_rgb24a_to_yuv422, NULL, NULL, NULL },
+	{ NULL, NULL, NULL, NULL, NULL, NULL },
 };
 
 static uint8_t bpp_table[4] = { 3, 4, 2, 0 };

--- a/src/modules/decklink/producer_decklink.yml
+++ b/src/modules/decklink/producer_decklink.yml
@@ -113,3 +113,11 @@ parameters:
       It skips frames that has VITC timecode less then specified.
       After reaching first frame with timecode greater or equal then specified this
       property is reset to zero.
+
+  - identifier: bitdepth
+    title: Bitdepth for capturing
+    description: Enable capturing in 10-bit native SDI signal
+    type: integer
+    values:
+      - 8 # 8-bit data
+      - 10 # 10-bit data


### PR DESCRIPTION
Colorspace convertion has 3 implementation over avformat module, first at consumer, second at producer, third at avcolorspace filter. What do you thing about factorizing this operation into the single function.

I moved color convertion function from producer into standalone code in a hope it could be used for other parts:
https://github.com/max-verem/mlt/commit/4802b3c555dc99b39ab85a44ba809e2957dd6a21

Please review and comment last commit from that pull request...