### PR TITLE
Makefiles: fix SDL detection through pkg-config; don't fail distclean if already clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.o
 *.so
 *.so.*
+*.dll
+*.def
 config.mak
 config.h
 config.log

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ all clean:
 	done
 
 distclean:
-	rm mlt-config packages.dat; \
+	rm -f mlt-config packages.dat
 	list='$(SUBDIRS)'; \
 	for subdir in $$list; do \
 		$(MAKE) -C $$subdir $@ || exit 1; \
-	done; \
-	rm config.mak;
+	done
+	echo > config.mak
 
 dist-clean: distclean
 

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -108,7 +108,7 @@ distclean:	clean
 		rm -f .depend
 
 clean:	
-		rm -f $(OBJS) $(TARGET) $(NAME) $(SONAME)
+		rm -f $(OBJS) $(TARGET) $(NAME) $(SONAME) libmlt.def
 
 install:
 	install -d $(DESTDIR)$(libdir)

--- a/src/melt/Makefile
+++ b/src/melt/Makefile
@@ -11,7 +11,7 @@ SRCS := $(OBJS:.o=.c)
 
 ifeq ($(targetos), MinGW)
 ifeq (, $(findstring MELT_NOSDL, $(CFLAGS)))
-ifeq (, $(shell pkg-config --exists sdl))
+ifeq (, $(shell pkg-config --exists sdl && echo yes))
 CFLAGS += $(shell  sdl-config --cflags)
 LDFLAGS += $(shell sdl-config --libs)
 else

--- a/src/mlt++/Makefile
+++ b/src/mlt++/Makefile
@@ -66,7 +66,7 @@ depend:	$(SRCS)
 	$(CXX) -MM $(CXXFLAGS) $^ 1>.depend
 
 clean:
-	$(RM) $(OBJS) $(TARGET) $(NAME) $(SONAME)
+	$(RM) $(OBJS) $(TARGET) $(NAME) $(SONAME) libmlt++.def
 
 distclean:	clean
 

--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -10,7 +10,8 @@ all clean depend:
 	done
 
 distclean:
-	rm -f consumers.dat filters.dat producers.dat transitions.dat make.inc; \
+	rm -f consumers.dat filters.dat producers.dat transitions.dat
+	echo > make.inc
 	list='$(SUBDIRS)'; \
 	for subdir in $$list; do \
 		if [ -f $$subdir/Makefile -a ! -f disable-$$subdir -a ! -f $$subdir/deprecated ] ; \

--- a/src/modules/avformat/Makefile
+++ b/src/modules/avformat/Makefile
@@ -66,8 +66,8 @@ install: all
 	install -m 644 consumer_avformat.yml "$(DESTDIR)$(mltdatadir)/avformat"
 
 uninstall:
-	rm "$(DESTDIR)$(moduledir)/libmltavformat$(LIBSUF)" 2> /dev/null || true
-	rm "$(DESTDIR)$(moduledir)/libmltffmpeg$(LIBSUF)" 2> /dev/null || true
+	rm -f "$(DESTDIR)$(moduledir)/libmltavformat$(LIBSUF)"
+	rm -f "$(DESTDIR)$(moduledir)/libmltffmpeg$(LIBSUF)"
 	rm -rf "$(DESTDIR)$(mltdatadir)/avformat"
 
 ifneq ($(wildcard .depend),)

--- a/src/modules/decklink/Makefile
+++ b/src/modules/decklink/Makefile
@@ -50,7 +50,7 @@ install: all
 	install -m 644 *.yml "$(DESTDIR)$(mltdatadir)/decklink"
 
 uninstall:
-	rm "$(DESTDIR)$(moduledir)/libmltdecklink$(LIBSUF)" 2> /dev/null || true
+	rm -f "$(DESTDIR)$(moduledir)/libmltdecklink$(LIBSUF)"
 	rm -rf "$(DESTDIR)$(mltdatadir)/decklink"
 
 ifneq ($(wildcard .depend),)

--- a/src/modules/jackrack/Makefile
+++ b/src/modules/jackrack/Makefile
@@ -65,7 +65,7 @@ install: all
 	[ -f $(BLACKLIST) ] && install -m 644 $(BLACKLIST) "$(DESTDIR)$(mltdatadir)/jackrack" || true
 
 uninstall:
-	rm "$(DESTDIR)$(moduledir)/libmltjackrack$(LIBSUF)" 2> /dev/null || true
+	rm -f "$(DESTDIR)$(moduledir)/libmltjackrack$(LIBSUF)"
 	rm -rf "$(DESTDIR)$(mltdatadir)/jackrack"
 
 ifneq ($(wildcard .depend),)

--- a/src/modules/ndi/Makefile
+++ b/src/modules/ndi/Makefile
@@ -32,7 +32,7 @@ install: all
 #	install -m 644 *.yml "$(DESTDIR)$(mltdatadir)/ndi"
 
 uninstall:
-	rm "$(DESTDIR)$(moduledir)/libmltndi$(LIBSUF)" 2> /dev/null || true
+	rm -f "$(DESTDIR)$(moduledir)/libmltndi$(LIBSUF)"
 	rm -rf "$(DESTDIR)$(mltdatadir)/ndi"
 
 ifneq ($(wildcard .depend),)

--- a/src/modules/rtaudio/Makefile
+++ b/src/modules/rtaudio/Makefile
@@ -60,7 +60,7 @@ install: all
 	install -m 644 *.yml "$(DESTDIR)$(mltdatadir)/rtaudio"
 
 uninstall:
-	rm "$(DESTDIR)$(moduledir)/libmltrtaudio$(LIBSUF)" 2> /dev/null || true
+	rm -f "$(DESTDIR)$(moduledir)/libmltrtaudio$(LIBSUF)"
 	rm -rf "$(DESTDIR)$(mltdatadir)/rtaudio"
 
 ifneq ($(wildcard .depend),)

--- a/src/modules/sox/Makefile
+++ b/src/modules/sox/Makefile
@@ -34,7 +34,7 @@ install: all
 	install -m 644 filter_sox_effect.yml "$(DESTDIR)$(mltdatadir)/sox"
 
 uninstall:
-	rm "$(DESTDIR)$(moduledir)/libmltsox$(LIBSUF)" 2> /dev/null || true
+	rm -f "$(DESTDIR)$(moduledir)/libmltsox$(LIBSUF)"
 	rm -rf "$(DESTDIR)$(mltdatadir)/sox"
 
 ifneq ($(wildcard .depend),)


### PR DESCRIPTION
Hello,
I'm on a new run for Kdenlive windows builds with MXE.
1) SDL detection was failing since last time, corrected.
2) Building unreleased code from a git clone I had to run distclean, but that failed if already clean...
Thanks for the hard work!
Vincent