### PR TITLE
Fix melt crash

### DIFF
--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -778,7 +778,7 @@ void drawKdenliveTitle( producer_ktitle self, mlt_frame frame, mlt_image_format 
 		self->current_height = height;
 
 		uint8_t *alpha = NULL;
-		if ( self->has_alpha && ( alpha = mlt_frame_get_alpha_mask( frame ) ) )
+		if ( ( alpha = mlt_frame_get_alpha( frame ) ) )
 		{
 			self->current_alpha = (uint8_t*) mlt_pool_alloc( width * height );
 			memcpy( self->current_alpha, alpha, width * height );


### PR DESCRIPTION
I don't have the knowledge of the codebase to fully understand what I'm doing, but this patch fixes a melt crash for me that I could reproduce with both the latest melt version distributed with Ubuntu, and built from GitHub master branch (see this gist for a gdb backtrace: https://gist.github.com/aadamowski/00c2774e56840297b02e7a4b87ef6472).

I looked at the recent history of `kdenlivetitle_wrapper.cpp` and noticed that the change applied in commit deb80d294f5979af792e7e09cc467bd8788e646f (revert of incorrect fix) hasn't been applied to both the places affected by the original incorrect fix. This commit applies the revert to the missing spot.