### PR TITLE
mlt_property.h: Replace include xlocale.h by locale.h

### DIFF
--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -31,7 +31,7 @@
 #endif
 
 #if defined(__GLIBC__) || defined(__APPLE__) || (__FreeBSD_version >= 900506)
-#include <xlocale.h>
+#include <locale.h>
 #else
 typedef char* locale_t;
 #endif


### PR DESCRIPTION
xlocale.h was removed in glibc 2.26

I could test glibc case only. If it won't work for other environments, please consider this patch as ping.