### PR TITLE
module: opencv: Remove deleted cv::Tracker::create()

### DIFF
--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -109,13 +109,17 @@ static void analyze( mlt_filter filter, cv::Mat cvFrame, private_data* data, int
         {
 		// Build tracker
 		data->algo = mlt_properties_get( filter_properties, "algo" );
-                if ( !data->algo || *data->algo == '\0' || !strcmp(data->algo, "KCF" ))
-                {
+		if ( !data->algo || *data->algo == '\0' || !strcmp(data->algo, "KCF" ) )
+		{
 			data->tracker = cv::TrackerKCF::create();
 		}
-		else if (!strcmp(data->algo, "MIL" ))
+		else if ( !strcmp(data->algo, "MIL" ) )
 		{
 			data->tracker = cv::TrackerMIL::create();
+		}
+		else if ( !strcmp(data->algo, "TLD" ) )
+		{
+			data->tracker = cv::TrackerTLD::create();
 		}
 		else
 		{

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -111,11 +111,15 @@ static void analyze( mlt_filter filter, cv::Mat cvFrame, private_data* data, int
 		data->algo = mlt_properties_get( filter_properties, "algo" );
                 if ( data->algo == NULL || !strcmp(data->algo, "" ) )
                 {
-			data->tracker = cv::Tracker::create( "KCF" );
+			data->tracker = cv::TrackerKCF::create();
+		}
+		else if (!strcmp(data->algo, "MIL" ))
+		{
+			data->tracker = cv::TrackerMIL::create();
 		}
 		else
-                {
-			data->tracker = cv::Tracker::create( data->algo );
+		{
+			data->tracker = cv::TrackerBoosting::create();
 		}
 
 		// Discard previous results

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -109,7 +109,7 @@ static void analyze( mlt_filter filter, cv::Mat cvFrame, private_data* data, int
         {
 		// Build tracker
 		data->algo = mlt_properties_get( filter_properties, "algo" );
-                if ( data->algo == NULL || !strcmp(data->algo, "" ) )
+                if ( !data->algo || *data->algo == '\0' || !strcmp(data->algo, "KCF" ))
                 {
 			data->tracker = cv::TrackerKCF::create();
 		}
@@ -249,7 +249,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 	{
 		analyze( filter, cvFrame, data, *width, *height, position - data->producer_in, data->producer_length );
 	}
-	
+
 	if ( blur > 0 )
 	{
 		switch ( mlt_properties_get_int( filter_properties, "blur_type" ) )


### PR DESCRIPTION
This static method is no longer present in OpenCV API, this workaround should fix compilation against OpenCV 3.3.0 and newer
Doxygen documentations :
v3.2: http://docs.opencv.org/3.2.0/d0/d0a/classcv_1_1Tracker.html
The old Tracker::create(char*) function seems to only support
- "MIL" – TrackerMIL
- "BOOSTING" – TrackerBoosting
So we manually check these.

v3.3: http://docs.opencv.org/3.3.0/d0/d0a/classcv_1_1Tracker.html