### PR TITLE
Correctly handle negative lift values

### DIFF
--- a/src/modules/plus/filter_lift_gamma_gain.c
+++ b/src/modules/plus/filter_lift_gamma_gain.c
@@ -67,6 +67,11 @@ static void refresh_lut( mlt_filter filter, mlt_frame frame )
 			g += glift * ( 1.0 - g );
 			b += blift * ( 1.0 - b );
 
+			// Clamp negative values
+			r = r < 0.0 ? 0.0 : r;
+			g = g < 0.0 ? 0.0 : g;
+			b = b < 0.0 ? 0.0 : b;
+
 			// Apply gamma
 			r = pow( r, 2.2 / rgamma );
 			g = pow( g, 2.2 / ggamma );

--- a/src/modules/plus/filter_lift_gamma_gain.c
+++ b/src/modules/plus/filter_lift_gamma_gain.c
@@ -68,9 +68,9 @@ static void refresh_lut( mlt_filter filter, mlt_frame frame )
 			b += blift * ( 1.0 - b );
 
 			// Clamp negative values
-			r = CLAMP( r, 0.0, 1.0 );
-			g = CLAMP( g, 0.0, 1.0 );
-			b = CLAMP( b, 0.0, 1.0 );
+			r = MAX( r, 0.0 );
+			g = MAX( g, 0.0 );
+			b = MAX( b, 0.0 );
 
 			// Apply gamma
 			r = pow( r, 2.2 / rgamma );

--- a/src/modules/plus/filter_lift_gamma_gain.c
+++ b/src/modules/plus/filter_lift_gamma_gain.c
@@ -68,9 +68,9 @@ static void refresh_lut( mlt_filter filter, mlt_frame frame )
 			b += blift * ( 1.0 - b );
 
 			// Clamp negative values
-			r = r < 0.0 ? 0.0 : r;
-			g = g < 0.0 ? 0.0 : g;
-			b = b < 0.0 ? 0.0 : b;
+			r = CLAMP( r, 0.0, 1.0 );
+			g = CLAMP( g, 0.0, 1.0 );
+			b = CLAMP( b, 0.0, 1.0 );
 
 			// Apply gamma
 			r = pow( r, 2.2 / rgamma );
@@ -83,9 +83,9 @@ static void refresh_lut( mlt_filter filter, mlt_frame frame )
 			b *= pow( bgain, 1.0 / bgamma );
 
 			// Clamp values
-			r = r < 0.0 ? 0.0 : r > 1.0 ? 1.0 : r;
-			g = g < 0.0 ? 0.0 : g > 1.0 ? 1.0 : g;
-			b = b < 0.0 ? 0.0 : b > 1.0 ? 1.0 : b;
+			r = CLAMP( r, 0.0, 1.0 );
+			g = CLAMP( g, 0.0, 1.0 );
+			b = CLAMP( b, 0.0, 1.0 );
 
 			// Update LUT
 			self->rlut[ i ] = (int)(r * 255.0);


### PR DESCRIPTION
Patch submitted by Dušan Hanuš, a Kdenlive user, allowing the lift/gamma/gain filter to correctly handle negative lift values. I submitted a similar change to Movit's version of the filter that should be merged later today by Steinar.