### PR TITLE
Add metadata to NDI module

### DIFF
--- a/src/modules/ndi/consumer_ndi.yml
+++ b/src/modules/ndi/consumer_ndi.yml
@@ -1,0 +1,24 @@
+schema_version: 0.1
+type: consumer
+identifier: ndi
+title: NDI Output
+creator: Maksym Veremeyenko
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+  - Network
+description: Audio/Video over IP output using NewTek's NDI technology
+parameters:
+  - identifier: argument
+    type: string
+    title: NDI Source name
+    description: Name used for discovery by NDI receivers on the network
+    required: yes
+    mutable: no
+
+  - identifier: meta.attr.*
+    type: string
+    title: NDI Device Metadata
+    required: no
+    mutable: no

--- a/src/modules/ndi/producer_ndi.yml
+++ b/src/modules/ndi/producer_ndi.yml
@@ -1,0 +1,18 @@
+schema_version: 0.1
+type: producer
+identifier: ndi
+title: NDI Input
+creator: Maksym Veremeyenko
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+  - Network
+description: Audio/Video over IP input using NewTek's NDI technology
+parameters:
+  - identifier: argument
+    type: string
+    title: NDI Source name
+    description: Name of the NDI Source to receive
+    required: yes
+    mutable: no


### PR DESCRIPTION
There's currently no metadata for the NDI producer and consumer, and there no visibility for these services in the MLT documentation. This contribution aims to address this, as it would bring the said visibility, but most importantly help users willing to use one of these services.