### PR TITLE
pixbuf producer csv files support

### DIFF
--- a/src/modules/gtk2/producer_pixbuf.yml
+++ b/src/modules/gtk2/producer_pixbuf.yml
@@ -41,6 +41,11 @@ parameters:
         
         If filename contains the string "<svg", then pixbuf tries to load the 
         filename as inline SVG XML, which is convenient for melt commands.
+
+        If filename extension is .csv (format is: picture_filename;ttl), then pixbuf
+        reads pictures and corresponding ttl from it, which is convenient
+        for generating a slideshow with different image duration; in this case main ttl
+        property is ignored.
     readonly: no
     argument: yes
     required: yes


### PR DESCRIPTION
I updated gtk2 pixbuf producer in order to read description of slideshow from a csv file.
Format of csv file is "filename;ttl"; example:
image0.png;50
image1.png;40

image0.png will be shown for 50 frames, image1.png will be shown for 40 frames; repeat if loop=1
producer ttl property will be ignored; loop works.