### PR TITLE
Compilation fixes

### DIFF
--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -30,12 +30,10 @@
 #include <sys/param.h>
 #endif
 
-#if defined(__GLIBC__) || defined(__APPLE__) || (__FreeBSD_version >= 900506)
-#  if __GLIBC_MINOR__ >= 26 && !defined(__APPLE__)
-#    include <locale.h>
-#  else
-#    include <xlocale.h>
-#  endif
+#if defined(__GLIBC__) && !defined(__APPLE__)
+#  include <locale.h>
+#elif defined(__APPLE__) || (__FreeBSD_version >= 900506)
+#  include <xlocale.h>
 #else
 typedef char* locale_t;
 #endif

--- a/src/modules/plus/ebur128/ebur128.c
+++ b/src/modules/plus/ebur128/ebur128.c
@@ -690,7 +690,7 @@ int ebur128_set_channel(ebur128_state* st,
   }
   if (value == EBUR128_DUAL_MONO &&
       (st->channels != 1 || channel_number != 0)) {
-    fprintf(stderr, "EBUR128_DUAL_MONO only works with mono files!\n");
+    /*fprintf(stderr, "EBUR128_DUAL_MONO only works with mono files!\n");*/
     return 1;
   }
   st->d->channel_map[channel_number] = value;


### PR DESCRIPTION
Hello,
I had 2 build errors:
- one on ubuntu artful: glibc 2.26 seems not properly handled, and anyway glibc devs claim that xlocale.h should never had been used... if I understand correctly?
- one in mingw cross-build: stderr is not available in libebur; maybe something missing in linker command, but as all other fprintf are commented out why not this one?