### PR TITLE
Revert 'sdl consumer:Fix potential deadlock' a04e6d9c35f052567b50d28b…

### DIFF
--- a/src/modules/sdl/consumer_sdl.c
+++ b/src/modules/sdl/consumer_sdl.c
@@ -282,6 +282,11 @@ int consumer_stop( mlt_consumer parent )
 		self->joined = 1;
 		self->running = 0;
 
+#ifndef _WIN32
+		if ( self->thread )
+#endif
+			pthread_join( self->thread, NULL );
+
 		// internal cleanup
 		if ( self->sdl_overlay != NULL )
 			SDL_FreeYUVOverlay( self->sdl_overlay );
@@ -301,10 +306,7 @@ int consumer_stop( mlt_consumer parent )
 			SDL_Quit( );
 			pthread_mutex_unlock( &mlt_sdl_mutex );
 		}
-#ifndef _WIN32
-		if ( self->thread )
-#endif
-			pthread_join( self->thread, NULL );
+
 	}
 
 	return 0;


### PR DESCRIPTION
…94edb322bd28f6f9 to fix Flowblade crashes

The pull request reverts this commit: https://github.com/mltframework/mlt/commit/a04e6d9c35f052567b50d28b94edb322bd28f6f9

The commit makes Flowblade crash constantly and reverting it regains former steady functionality.