### PR TITLE
Fix mulit-channel audio.

### DIFF
--- a/src/modules/sdl/consumer_sdl.c
+++ b/src/modules/sdl/consumer_sdl.c
@@ -403,13 +403,11 @@ static int consumer_play_audio( consumer_sdl self, mlt_frame frame, int init_aud
 	int channels = mlt_properties_get_int( properties, "channels" );
 	int dest_channels = channels;
 	int frequency = mlt_properties_get_int( properties, "frequency" );
+	int scrub = mlt_properties_get_int( properties, "scrub_audio" );
 	static int counter = 0;
 
 	int samples = mlt_sample_calculator( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
-	
 	int16_t *pcm;
-	int bytes;
-
 	mlt_frame_get_audio( frame, (void**) &pcm, &afmt, &frequency, &channels, &samples );
 	*duration = ( ( samples * 1000 ) / frequency );
 	pcm += mlt_properties_get_int( properties, "audio_offset" );
@@ -452,39 +450,57 @@ static int consumer_play_audio( consumer_sdl self, mlt_frame frame, int init_aud
 	if ( init_audio == 0 )
 	{
 		mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
-		
-		bytes = samples * dest_channels * sizeof(*pcm);
+		int samples_copied = 0;
+		int dst_stride = dest_channels * sizeof( *pcm );
+
 		pthread_mutex_lock( &self->audio_mutex );
-		while ( self->running && bytes > ( sizeof( self->audio_buffer) - self->audio_avail ) )
-			pthread_cond_wait( &self->audio_cond, &self->audio_mutex );
-		if ( self->running )
+
+		while ( self->running && samples_copied < samples )
 		{
-			if ( mlt_properties_get_double( properties, "_speed" ) == 1 )
+			int sample_space = ( sizeof( self->audio_buffer ) - self->audio_avail ) / dst_stride;
+			while ( self->running && sample_space == 0 )
 			{
-				if ( channels == dest_channels )
+				pthread_cond_wait( &self->audio_cond, &self->audio_mutex );
+				sample_space = ( sizeof( self->audio_buffer ) - self->audio_avail ) / dst_stride;
+			}
+			if ( self->running )
+			{
+				int samples_to_copy = samples - samples_copied;
+				if ( samples_to_copy > sample_space )
 				{
-					memcpy( &self->audio_buffer[ self->audio_avail ], pcm, bytes );
+					samples_to_copy = sample_space;
+				}
+				int dst_bytes = samples_to_copy * dst_stride;
+
+				if ( scrub || mlt_properties_get_double( properties, "_speed" ) == 1 )
+				{
+					if ( channels == dest_channels )
+					{
+						memcpy( &self->audio_buffer[ self->audio_avail ], pcm, dst_bytes );
+						pcm += samples_to_copy * channels;
+					}
+					else
+					{
+						int16_t *dest = (int16_t*) &self->audio_buffer[ self->audio_avail ];
+						int i = samples_to_copy + 1;
+						while ( --i )
+						{
+							memcpy( dest, pcm, dst_stride );
+							pcm += channels;
+							dest += dest_channels;
+						}
+					}
 				}
 				else
 				{
-					int16_t *dest = (int16_t*) &self->audio_buffer[ self->audio_avail ];
-					int i = samples + 1;
-					
-					while ( --i )
-					{
-						memcpy( dest, pcm, dest_channels * sizeof(*pcm) );
-						pcm += channels;
-						dest += dest_channels;
-					}
+					memset( &self->audio_buffer[ self->audio_avail ], 0, dst_bytes );
+					pcm += samples_to_copy * channels;
 				}
+				self->audio_avail += dst_bytes;
+				samples_copied += samples_to_copy;
 			}
-			else
-			{
-				memset( &self->audio_buffer[ self->audio_avail ], 0, bytes );
-			}
-			self->audio_avail += bytes;
+			pthread_cond_broadcast( &self->audio_cond );
 		}
-		pthread_cond_broadcast( &self->audio_cond );
 		pthread_mutex_unlock( &self->audio_mutex );
 	}
 	else

--- a/src/modules/sdl/consumer_sdl.c
+++ b/src/modules/sdl/consumer_sdl.c
@@ -125,6 +125,9 @@ mlt_consumer consumer_sdl_init( mlt_profile profile, mlt_service_type type, cons
 		// Default audio buffer
 		mlt_properties_set_int( self->properties, "audio_buffer", 2048 );
 
+		// Default scrub audio
+		mlt_properties_set_int( self->properties, "scrub_audio", 1 );
+
 		// Ensure we don't join on a non-running object
 		self->joined = 1;
 		

--- a/src/modules/sdl/consumer_sdl.yml
+++ b/src/modules/sdl/consumer_sdl.yml
@@ -48,3 +48,12 @@ parameters:
     mutable: yes
     default: 2048
     minimum: 128
+  - identifier: scrub_audio
+    title: Audio scrubbing
+    type: integer
+    description: If enabled, sound is played even when the speed is not normal.
+    mutable: yes
+    minimum: 0
+    maximum: 1
+    default: 0
+    widget: checkbox

--- a/src/modules/sdl/consumer_sdl.yml
+++ b/src/modules/sdl/consumer_sdl.yml
@@ -55,5 +55,5 @@ parameters:
     mutable: yes
     minimum: 0
     maximum: 1
-    default: 0
+    default: 1
     widget: checkbox

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -128,6 +128,9 @@ mlt_consumer consumer_sdl2_init( mlt_profile profile, mlt_service_type type, con
 		mlt_properties_set( self->properties, "audio_driver", "DirectSound" );
 #endif
 
+		// Default scrub audio
+		mlt_properties_set_int( self->properties, "scrub_audio", 1 );
+
 		// Ensure we don't join on a non-running object
 		self->joined = 1;
 		

--- a/src/modules/sdl2/consumer_sdl2.yml
+++ b/src/modules/sdl2/consumer_sdl2.yml
@@ -61,5 +61,5 @@ parameters:
     mutable: yes
     minimum: 0
     maximum: 1
-    default: 0
+    default: 1
     widget: checkbox

--- a/src/modules/sdl2/consumer_sdl2.yml
+++ b/src/modules/sdl2/consumer_sdl2.yml
@@ -53,3 +53,13 @@ parameters:
     mutable: yes
     default: 2048
     minimum: 128
+
+  - identifier: scrub_audio
+    title: Audio scrubbing
+    type: integer
+    description: If enabled, sound is played even when the speed is not normal.
+    mutable: yes
+    minimum: 0
+    maximum: 1
+    default: 0
+    widget: checkbox


### PR DESCRIPTION
At some framerates, audio with > 6 channels would result in an audio
buffer larger than that allocated for SDL. This change will copy from the
buffer in pieces if it won't all fit at once.