### PR TITLE
musl libc support

### DIFF
--- a/src/framework/mlt_properties.c
+++ b/src/framework/mlt_properties.c
@@ -713,7 +713,7 @@ int mlt_properties_set( mlt_properties self, const char *name, const char *value
 			// Determine the value
 			if ( isdigit( id[ 0 ] ) )
 			{
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__) || HAVE_STRTOD_L
 				property_list *list = self->local;
 				if ( list->locale )
 					current = strtod_l( id, NULL, list->locale );

--- a/src/framework/mlt_property.c
+++ b/src/framework/mlt_property.c
@@ -278,23 +278,23 @@ static int time_clock_to_frames( mlt_property self, const char *s, double fps, l
 	s = copy;
 	pos = strrchr( s, ':' );
 
-#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32) && !HAVE_STRTOD_L
 	char *orig_localename = NULL;
 	if ( locale )
 	{
 		// Protect damaging the global locale from a temporary locale on another thread.
 		pthread_mutex_lock( &self->mutex );
-		
+
 		// Get the current locale
 		orig_localename = strdup( setlocale( LC_NUMERIC, NULL ) );
-		
+
 		// Set the new locale
 		setlocale( LC_NUMERIC, locale );
 	}
 #endif
 
 	if ( pos ) {
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__) || HAVE_STRTOD_L
 		if ( locale )
 			seconds = strtod_l( pos + 1, NULL, locale );
 		else
@@ -312,7 +312,7 @@ static int time_clock_to_frames( mlt_property self, const char *s, double fps, l
 		}
 	}
 	else {
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__) || HAVE_STRTOD_L
 		if ( locale )
 			seconds = strtod_l( s, NULL, locale );
 		else
@@ -320,7 +320,7 @@ static int time_clock_to_frames( mlt_property self, const char *s, double fps, l
 			seconds = strtod( s, NULL );
 	}
 
-#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32) && !HAVE_STRTOD_L
 	if ( locale ) {
 		// Restore the current locale
 		setlocale( LC_NUMERIC, orig_localename );
@@ -407,7 +407,7 @@ static int time_code_to_frames( mlt_property self, const char *s, double fps )
 static int mlt_property_atoi( mlt_property self, double fps, locale_t locale )
 {
 	const char *value = self->prop_string;
-	
+
 	// Parse a hex color value as #RRGGBB or #AARRGGBB.
 	if ( value[0] == '#' )
 	{
@@ -489,7 +489,7 @@ static double mlt_property_atof( mlt_property self, double fps, locale_t locale 
 		char *end = NULL;
 		double result;
 
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__) || HAVE_STRTOD_L
 		if ( locale )
 			result = strtod_l( value, &end, locale );
 		else
@@ -498,10 +498,10 @@ static double mlt_property_atof( mlt_property self, double fps, locale_t locale 
 		if ( locale ) {
 			// Protect damaging the global locale from a temporary locale on another thread.
 			pthread_mutex_lock( &self->mutex );
-			
+
 			// Get the current locale
 			orig_localename = strdup( setlocale( LC_NUMERIC, NULL ) );
-			
+
 			// Set the new locale
 			setlocale( LC_NUMERIC, locale );
 		}
@@ -511,7 +511,7 @@ static double mlt_property_atof( mlt_property self, double fps, locale_t locale 
 		if ( end && end[0] == '%' )
 			result /= 100.0;
 
-#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32) && !HAVE_STRTOD_L
 		if ( locale ) {
 			// Restore the current locale
 			setlocale( LC_NUMERIC, orig_localename );
@@ -1030,8 +1030,8 @@ static int is_property_numeric( mlt_property self, locale_t locale )
 	{
 		double temp;
 		char *p = NULL;
-		
-#if defined(__GLIBC__) || defined(__APPLE__)
+
+#if defined(__GLIBC__) || defined(__APPLE__) || HAVE_STRTOD_L
 		if ( locale )
 			temp = strtod_l( self->prop_string, &p, locale );
 		else
@@ -1040,10 +1040,10 @@ static int is_property_numeric( mlt_property self, locale_t locale )
 		if ( locale ) {
 			// Protect damaging the global locale from a temporary locale on another thread.
 			pthread_mutex_lock( &self->mutex );
-			
+
 			// Get the current locale
 			orig_localename = strdup( setlocale( LC_NUMERIC, NULL ) );
-			
+
 			// Set the new locale
 			setlocale( LC_NUMERIC, locale );
 		}
@@ -1051,7 +1051,7 @@ static int is_property_numeric( mlt_property self, locale_t locale )
 
 		temp = strtod( self->prop_string, &p );
 
-#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32) && !HAVE_STRTOD_L
 		if ( locale ) {
 			// Restore the current locale
 			setlocale( LC_NUMERIC, orig_localename );
@@ -1535,15 +1535,15 @@ mlt_rect mlt_property_get_rect( mlt_property self, locale_t locale )
 		char *p = NULL;
 		int count = 0;
 
-#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32) && !HAVE_STRTOD_L
 		char *orig_localename = NULL;
 		if ( locale ) {
 			// Protect damaging the global locale from a temporary locale on another thread.
 			pthread_mutex_lock( &self->mutex );
-			
+
 			// Get the current locale
 			orig_localename = strdup( setlocale( LC_NUMERIC, NULL ) );
-			
+
 			// Set the new locale
 			setlocale( LC_NUMERIC, locale );
 		}
@@ -1552,7 +1552,7 @@ mlt_rect mlt_property_get_rect( mlt_property self, locale_t locale )
 		while ( *value )
 		{
 			double temp;
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__) || HAVE_STRTOD_L
 			if ( locale )
 				temp = strtod_l( value, &p, locale );
             else
@@ -1587,7 +1587,7 @@ mlt_rect mlt_property_get_rect( mlt_property self, locale_t locale )
 			count ++;
 		}
 
-#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__GLIBC__) && !defined(__APPLE__) && !defined(_WIN32) && !HAVE_STRTOD_L
 		if ( locale ) {
 			// Restore the current locale
 			setlocale( LC_NUMERIC, orig_localename );

--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -30,7 +30,7 @@
 #include <sys/param.h>
 #endif
 
-#if defined(__GLIBC__) && !defined(__APPLE__)
+#if defined(__GLIBC__) && !defined(__APPLE__) || HAVE_LOCALE_H
 #  include <locale.h>
 #elif defined(__APPLE__) || (__FreeBSD_version >= 900506)
 #  include <xlocale.h>


### PR DESCRIPTION
musl has no macro, so it can not be detected straigthforward.

HAVE_STRTOD_L tells that strdod_l() is available
HAVE_LOCALE_H tells that the header locale.h is available