### PR TITLE
Add filter_swresample.

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -505,8 +505,8 @@ MLT_6.6.0 {
 
 MLT_6.8.0 {
   global:
-    mlt_chan_cfg_name;
-    mlt_chan_cfg_id;
-    mlt_chan_cfg_channels;
-    mlt_chan_cfg_default;
+    mlt_channel_layout_name;
+    mlt_channel_layout_id;
+    mlt_channel_layout_channels;
+    mlt_channel_layout_default;
 } MLT_6.6.0;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -502,3 +502,11 @@ MLT_6.6.0 {
     mlt_log_timings_now;
     mlt_service_disconnect_all_producers;
 } MLT_6.4.0;
+
+MLT_6.8.0 {
+  global:
+    mlt_chan_cfg_name;
+    mlt_chan_cfg_id;
+    mlt_chan_cfg_channels;
+    mlt_chan_cfg_default;
+} MLT_6.6.0;

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -719,6 +719,7 @@ mlt_frame mlt_consumer_get_frame( mlt_consumer self )
 		mlt_properties_set( frame_properties, "deinterlace_method", mlt_properties_get( properties, "deinterlace_method" ) );
 		mlt_properties_set_int( frame_properties, "consumer_tff", mlt_properties_get_int( properties, "top_field_first" ) );
 		mlt_properties_set( frame_properties, "consumer_color_trc", mlt_properties_get( properties, "color_trc" ) );
+		mlt_properties_set( frame_properties, "consumer_chan_cfg", mlt_properties_get( properties, "chan_cfg" ) );
 	}
 
 	// Return the frame

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -719,7 +719,7 @@ mlt_frame mlt_consumer_get_frame( mlt_consumer self )
 		mlt_properties_set( frame_properties, "deinterlace_method", mlt_properties_get( properties, "deinterlace_method" ) );
 		mlt_properties_set_int( frame_properties, "consumer_tff", mlt_properties_get_int( properties, "top_field_first" ) );
 		mlt_properties_set( frame_properties, "consumer_color_trc", mlt_properties_get( properties, "color_trc" ) );
-		mlt_properties_set( frame_properties, "consumer_chan_cfg", mlt_properties_get( properties, "chan_cfg" ) );
+		mlt_properties_set( frame_properties, "consumer_channel_layout", mlt_properties_get( properties, "channel_layout" ) );
 	}
 
 	// Return the frame

--- a/src/framework/mlt_consumer.h
+++ b/src/framework/mlt_consumer.h
@@ -43,6 +43,8 @@
  * \properties \em drop_max the maximum number of consecutively dropped frames, defaults to 5
  * \properties \em frequency the audio sample rate to use in Hertz, defaults to 48000
  * \properties \em channels the number of audio channels to use, defaults to 2
+ * \properties \em channel_layout the layout of the audio channels, defaults to auto.
+ * other options include: mono, stereo, 5.1, 7.1, etc.
  * \properties \em real_time the asynchronous behavior: 1 (default) for asynchronous
  * with frame dropping, -1 for asynchronous without frame dropping, 0 to disable (synchronous)
  * \properties \em test_card the name of a resource to use as the test card, defaults to

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -1228,3 +1228,128 @@ int mlt_image_format_planes( mlt_image_format format, int width, int height, voi
 
 	return 0;
 }
+
+/** Get the short name for a channel configuration.
+ *
+ * You do not need to deallocate the returned string.
+ * \public \member of mlt_frame_s
+ * \param cfg a channel configuration enum
+ * \return a string for the name of the channel configuration
+ */
+
+const char * mlt_chan_cfg_name( mlt_chan_cfg cfg )
+{
+	switch ( cfg )
+	{
+		case mlt_chan_auto:           return "auto";
+		case mlt_chan_independent:    return "independent";
+		case mlt_chan_mono:           return "mono";
+		case mlt_chan_stereo:         return "stereo";
+		case mlt_chan_2p1:            return "2.1";
+		case mlt_chan_3p0:            return "3.0";
+		case mlt_chan_3p0_back:       return "3.0(back)";
+		case mlt_chan_3p1:            return "3.1";
+		case mlt_chan_4p0:            return "4.0";
+		case mlt_chan_4p1:            return "4.1";
+		case mlt_chan_quad_back:      return "quad(back)";
+		case mlt_chan_quad_side:      return "quad(side)";
+		case mlt_chan_5p0:            return "5.0";
+		case mlt_chan_5p1:            return "5.1";
+		case mlt_chan_5p0_back:       return "5.0(back)";
+		case mlt_chan_5p1_back:       return "5.1(back)";
+		case mlt_chan_6p0:            return "6.0";
+		case mlt_chan_6p0_front:      return "6.0(front)";
+		case mlt_chan_hexagonal:      return "hexagonal";
+		case mlt_chan_6p1:            return "6.1";
+		case mlt_chan_6p1_back:       return "6.1(back)";
+		case mlt_chan_6p1_front:      return "6.1(front)";
+		case mlt_chan_7p0:            return "7.0";
+		case mlt_chan_7p0_front:      return "7.0(front)";
+		case mlt_chan_7p1:            return "7.1";
+		case mlt_chan_7p1_wide_side:  return "7.1(wide-side)";
+		case mlt_chan_7p1_wide_back:  return "7.1(wide-back)";
+	}
+	return "invalid";
+}
+
+/** Get the id of channel configuration from short name.
+ *
+ * \public \memberof mlt_frame_s
+ * \param name the channel configuration short name
+ * \return a channel configuration
+ */
+
+mlt_chan_cfg mlt_chan_cfg_id( const char * name )
+{
+	if( name )
+	{
+		mlt_chan_cfg c;
+		for( c = mlt_chan_auto; c <= mlt_chan_7p1_wide_back; c++ )
+		{
+			const char * v = mlt_chan_cfg_name( c );
+			if( !strcmp( v, name ) )
+				return c;
+		}
+	}
+	return mlt_chan_auto;
+}
+
+/** Get the number of channels for a channel configuration.
+ *
+ * \public \memberof mlt_frame_s
+ * \param cfg a channel configuration enum
+ * \return the number of channels for the channel configuration
+ */
+
+int mlt_chan_cfg_channels( mlt_chan_cfg cfg )
+{
+	switch ( cfg )
+	{
+		case mlt_chan_auto:           return 0;
+		case mlt_chan_independent:    return 0;
+		case mlt_chan_mono:           return 1;
+		case mlt_chan_stereo:         return 2;
+		case mlt_chan_2p1:            return 3;
+		case mlt_chan_3p0:            return 3;
+		case mlt_chan_3p0_back:       return 3;
+		case mlt_chan_4p0:            return 4;
+		case mlt_chan_3p1:            return 4;
+		case mlt_chan_quad_back:      return 4;
+		case mlt_chan_quad_side:      return 4;
+		case mlt_chan_5p0:            return 5;
+		case mlt_chan_5p0_back:       return 5;
+		case mlt_chan_4p1:            return 5;
+		case mlt_chan_5p1:            return 6;
+		case mlt_chan_5p1_back:       return 6;
+		case mlt_chan_6p0:            return 6;
+		case mlt_chan_6p0_front:      return 6;
+		case mlt_chan_hexagonal:      return 6;
+		case mlt_chan_6p1:            return 7;
+		case mlt_chan_6p1_back:       return 7;
+		case mlt_chan_6p1_front:      return 7;
+		case mlt_chan_7p0:            return 7;
+		case mlt_chan_7p0_front:      return 7;
+		case mlt_chan_7p1:            return 8;
+		case mlt_chan_7p1_wide_side:  return 8;
+		case mlt_chan_7p1_wide_back:  return 8;
+	}
+	return 0;
+}
+
+/** Get a default channel configuration for a given number of channels.
+ *
+ * \public \memberof mlt_frame_s
+ * \param channels the number of channels
+ * \return the default channel configuration
+ */
+
+mlt_chan_cfg mlt_chan_cfg_default( int channels )
+{
+	mlt_chan_cfg c;
+	for( c = mlt_chan_mono; c <= mlt_chan_7p1_wide_back; c++ )
+	{
+		if( mlt_chan_cfg_channels( c ) == channels )
+			return c;
+	}
+	return mlt_chan_independent;
+}

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -1237,37 +1237,37 @@ int mlt_image_format_planes( mlt_image_format format, int width, int height, voi
  * \return a string for the name of the channel configuration
  */
 
-const char * mlt_chan_cfg_name( mlt_chan_cfg cfg )
+const char * mlt_channel_layout_name( mlt_channel_layout layout )
 {
-	switch ( cfg )
+	switch ( layout )
 	{
-		case mlt_chan_auto:           return "auto";
-		case mlt_chan_independent:    return "independent";
-		case mlt_chan_mono:           return "mono";
-		case mlt_chan_stereo:         return "stereo";
-		case mlt_chan_2p1:            return "2.1";
-		case mlt_chan_3p0:            return "3.0";
-		case mlt_chan_3p0_back:       return "3.0(back)";
-		case mlt_chan_3p1:            return "3.1";
-		case mlt_chan_4p0:            return "4.0";
-		case mlt_chan_4p1:            return "4.1";
-		case mlt_chan_quad_back:      return "quad(back)";
-		case mlt_chan_quad_side:      return "quad(side)";
-		case mlt_chan_5p0:            return "5.0";
-		case mlt_chan_5p1:            return "5.1";
-		case mlt_chan_5p0_back:       return "5.0(back)";
-		case mlt_chan_5p1_back:       return "5.1(back)";
-		case mlt_chan_6p0:            return "6.0";
-		case mlt_chan_6p0_front:      return "6.0(front)";
-		case mlt_chan_hexagonal:      return "hexagonal";
-		case mlt_chan_6p1:            return "6.1";
-		case mlt_chan_6p1_back:       return "6.1(back)";
-		case mlt_chan_6p1_front:      return "6.1(front)";
-		case mlt_chan_7p0:            return "7.0";
-		case mlt_chan_7p0_front:      return "7.0(front)";
-		case mlt_chan_7p1:            return "7.1";
-		case mlt_chan_7p1_wide_side:  return "7.1(wide-side)";
-		case mlt_chan_7p1_wide_back:  return "7.1(wide-back)";
+		case mlt_channel_auto:           return "auto";
+		case mlt_channel_independent:    return "independent";
+		case mlt_channel_mono:           return "mono";
+		case mlt_channel_stereo:         return "stereo";
+		case mlt_channel_2p1:            return "2.1";
+		case mlt_channel_3p0:            return "3.0";
+		case mlt_channel_3p0_back:       return "3.0(back)";
+		case mlt_channel_3p1:            return "3.1";
+		case mlt_channel_4p0:            return "4.0";
+		case mlt_channel_4p1:            return "4.1";
+		case mlt_channel_quad_back:      return "quad";
+		case mlt_channel_quad_side:      return "quad(side)";
+		case mlt_channel_5p0:            return "5.0(side)";
+		case mlt_channel_5p1:            return "5.1(side)";
+		case mlt_channel_5p0_back:       return "5.0";
+		case mlt_channel_5p1_back:       return "5.1";
+		case mlt_channel_6p0:            return "6.0";
+		case mlt_channel_6p0_front:      return "6.0(front)";
+		case mlt_channel_hexagonal:      return "hexagonal";
+		case mlt_channel_6p1:            return "6.1";
+		case mlt_channel_6p1_back:       return "6.1(back)";
+		case mlt_channel_6p1_front:      return "6.1(front)";
+		case mlt_channel_7p0:            return "7.0";
+		case mlt_channel_7p0_front:      return "7.0(front)";
+		case mlt_channel_7p1:            return "7.1";
+		case mlt_channel_7p1_wide_side:  return "7.1(wide-side)";
+		case mlt_channel_7p1_wide_back:  return "7.1(wide)";
 	}
 	return "invalid";
 }
@@ -1279,19 +1279,19 @@ const char * mlt_chan_cfg_name( mlt_chan_cfg cfg )
  * \return a channel configuration
  */
 
-mlt_chan_cfg mlt_chan_cfg_id( const char * name )
+mlt_channel_layout mlt_channel_layout_id( const char * name )
 {
 	if( name )
 	{
-		mlt_chan_cfg c;
-		for( c = mlt_chan_auto; c <= mlt_chan_7p1_wide_back; c++ )
+		mlt_channel_layout c;
+		for( c = mlt_channel_auto; c <= mlt_channel_7p1_wide_back; c++ )
 		{
-			const char * v = mlt_chan_cfg_name( c );
+			const char * v = mlt_channel_layout_name( c );
 			if( !strcmp( v, name ) )
 				return c;
 		}
 	}
-	return mlt_chan_auto;
+	return mlt_channel_auto;
 }
 
 /** Get the number of channels for a channel configuration.
@@ -1301,37 +1301,37 @@ mlt_chan_cfg mlt_chan_cfg_id( const char * name )
  * \return the number of channels for the channel configuration
  */
 
-int mlt_chan_cfg_channels( mlt_chan_cfg cfg )
+int mlt_channel_layout_channels( mlt_channel_layout layout )
 {
-	switch ( cfg )
+	switch ( layout )
 	{
-		case mlt_chan_auto:           return 0;
-		case mlt_chan_independent:    return 0;
-		case mlt_chan_mono:           return 1;
-		case mlt_chan_stereo:         return 2;
-		case mlt_chan_2p1:            return 3;
-		case mlt_chan_3p0:            return 3;
-		case mlt_chan_3p0_back:       return 3;
-		case mlt_chan_4p0:            return 4;
-		case mlt_chan_3p1:            return 4;
-		case mlt_chan_quad_back:      return 4;
-		case mlt_chan_quad_side:      return 4;
-		case mlt_chan_5p0:            return 5;
-		case mlt_chan_5p0_back:       return 5;
-		case mlt_chan_4p1:            return 5;
-		case mlt_chan_5p1:            return 6;
-		case mlt_chan_5p1_back:       return 6;
-		case mlt_chan_6p0:            return 6;
-		case mlt_chan_6p0_front:      return 6;
-		case mlt_chan_hexagonal:      return 6;
-		case mlt_chan_6p1:            return 7;
-		case mlt_chan_6p1_back:       return 7;
-		case mlt_chan_6p1_front:      return 7;
-		case mlt_chan_7p0:            return 7;
-		case mlt_chan_7p0_front:      return 7;
-		case mlt_chan_7p1:            return 8;
-		case mlt_chan_7p1_wide_side:  return 8;
-		case mlt_chan_7p1_wide_back:  return 8;
+		case mlt_channel_auto:           return 0;
+		case mlt_channel_independent:    return 0;
+		case mlt_channel_mono:           return 1;
+		case mlt_channel_stereo:         return 2;
+		case mlt_channel_2p1:            return 3;
+		case mlt_channel_3p0:            return 3;
+		case mlt_channel_3p0_back:       return 3;
+		case mlt_channel_4p0:            return 4;
+		case mlt_channel_3p1:            return 4;
+		case mlt_channel_quad_back:      return 4;
+		case mlt_channel_quad_side:      return 4;
+		case mlt_channel_5p0:            return 5;
+		case mlt_channel_5p0_back:       return 5;
+		case mlt_channel_4p1:            return 5;
+		case mlt_channel_5p1:            return 6;
+		case mlt_channel_5p1_back:       return 6;
+		case mlt_channel_6p0:            return 6;
+		case mlt_channel_6p0_front:      return 6;
+		case mlt_channel_hexagonal:      return 6;
+		case mlt_channel_6p1:            return 7;
+		case mlt_channel_6p1_back:       return 7;
+		case mlt_channel_6p1_front:      return 7;
+		case mlt_channel_7p0:            return 7;
+		case mlt_channel_7p0_front:      return 7;
+		case mlt_channel_7p1:            return 8;
+		case mlt_channel_7p1_wide_side:  return 8;
+		case mlt_channel_7p1_wide_back:  return 8;
 	}
 	return 0;
 }
@@ -1343,13 +1343,13 @@ int mlt_chan_cfg_channels( mlt_chan_cfg cfg )
  * \return the default channel configuration
  */
 
-mlt_chan_cfg mlt_chan_cfg_default( int channels )
+mlt_channel_layout mlt_channel_layout_default( int channels )
 {
-	mlt_chan_cfg c;
-	for( c = mlt_chan_mono; c <= mlt_chan_7p1_wide_back; c++ )
+	mlt_channel_layout c;
+	for( c = mlt_channel_mono; c <= mlt_channel_7p1_wide_back; c++ )
 	{
-		if( mlt_chan_cfg_channels( c ) == channels )
+		if( mlt_channel_layout_channels( c ) == channels )
 			return c;
 	}
-	return mlt_chan_independent;
+	return mlt_channel_independent;
 }

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -152,6 +152,10 @@ extern int mlt_audio_format_size( mlt_audio_format format, int samples, int chan
 extern void mlt_frame_write_ppm( mlt_frame frame );
 extern int mlt_image_format_planes( mlt_image_format format, int width, int height, void* data, unsigned char *planes[4], int strides[4]);
 extern mlt_image_format mlt_image_format_id( const char * name );
+extern const char * mlt_chan_cfg_name( mlt_chan_cfg cfg );
+extern mlt_chan_cfg mlt_chan_cfg_id( const char * name );
+extern int mlt_chan_cfg_channels( mlt_chan_cfg cfg );
+extern mlt_chan_cfg mlt_chan_cfg_default( int channels );
 
 /** This macro scales RGB into the YUV gamut - y is scaled by 219/255 and uv by 224/255. */
 #define RGB2YUV_601_SCALED(r, g, b, y, u, v)\

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -152,10 +152,10 @@ extern int mlt_audio_format_size( mlt_audio_format format, int samples, int chan
 extern void mlt_frame_write_ppm( mlt_frame frame );
 extern int mlt_image_format_planes( mlt_image_format format, int width, int height, void* data, unsigned char *planes[4], int strides[4]);
 extern mlt_image_format mlt_image_format_id( const char * name );
-extern const char * mlt_chan_cfg_name( mlt_chan_cfg cfg );
-extern mlt_chan_cfg mlt_chan_cfg_id( const char * name );
-extern int mlt_chan_cfg_channels( mlt_chan_cfg cfg );
-extern mlt_chan_cfg mlt_chan_cfg_default( int channels );
+extern const char * mlt_channel_layout_name( mlt_channel_layout layout );
+extern mlt_channel_layout mlt_channel_layout_id( const char * name );
+extern int mlt_channel_layout_channels( mlt_channel_layout layout );
+extern mlt_channel_layout mlt_channel_layout_default( int channels );
 
 /** This macro scales RGB into the YUV gamut - y is scaled by 219/255 and uv by 224/255. */
 #define RGB2YUV_601_SCALED(r, g, b, y, u, v)\

--- a/src/framework/mlt_tractor.c
+++ b/src/framework/mlt_tractor.c
@@ -414,6 +414,7 @@ static int producer_get_audio( mlt_frame self, void **buffer, mlt_audio_format *
 	mlt_properties properties = MLT_FRAME_PROPERTIES( self );
 	mlt_frame frame = mlt_frame_pop_audio( self );
 	mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
+	mlt_properties_set( frame_properties, "consumer_chan_cfg", mlt_properties_get( properties, "consumer_chan_cfg" ) );
 	mlt_properties_set( frame_properties, "producer_consumer_fps", mlt_properties_get( properties, "producer_consumer_fps" ) );
 	mlt_frame_get_audio( frame, buffer, format, frequency, channels, samples );
 	mlt_frame_set_audio( self, *buffer, *format, mlt_audio_format_size( *format, *samples, *channels ), NULL );

--- a/src/framework/mlt_tractor.c
+++ b/src/framework/mlt_tractor.c
@@ -414,7 +414,7 @@ static int producer_get_audio( mlt_frame self, void **buffer, mlt_audio_format *
 	mlt_properties properties = MLT_FRAME_PROPERTIES( self );
 	mlt_frame frame = mlt_frame_pop_audio( self );
 	mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
-	mlt_properties_set( frame_properties, "consumer_chan_cfg", mlt_properties_get( properties, "consumer_chan_cfg" ) );
+	mlt_properties_set( frame_properties, "consumer_channel_layout", mlt_properties_get( properties, "consumer_channel_layout" ) );
 	mlt_properties_set( frame_properties, "producer_consumer_fps", mlt_properties_get( properties, "producer_consumer_fps" ) );
 	mlt_frame_get_audio( frame, buffer, format, frequency, channels, samples );
 	mlt_frame_set_audio( self, *buffer, *format, mlt_audio_format_size( *format, *samples, *channels ), NULL );

--- a/src/framework/mlt_transition.c
+++ b/src/framework/mlt_transition.c
@@ -361,7 +361,7 @@ static int get_image_b( mlt_frame b_frame, uint8_t **image, mlt_image_format *fo
 		mlt_frame_set_aspect_ratio( b_frame, mlt_profile_sar( mlt_service_profile( MLT_TRANSITION_SERVICE(self) ) ) );
 
 	mlt_properties_pass_list( b_props, a_props,
-		"consumer_deinterlace, deinterlace_method, consumer_tff, consumer_color_trc, consumer_chan_cfg" );
+		"consumer_deinterlace, deinterlace_method, consumer_tff, consumer_color_trc, consumer_channel_layout" );
 
 	return mlt_frame_get_image( b_frame, image, format, width, height, writable );
 }

--- a/src/framework/mlt_transition.c
+++ b/src/framework/mlt_transition.c
@@ -361,7 +361,7 @@ static int get_image_b( mlt_frame b_frame, uint8_t **image, mlt_image_format *fo
 		mlt_frame_set_aspect_ratio( b_frame, mlt_profile_sar( mlt_service_profile( MLT_TRANSITION_SERVICE(self) ) ) );
 
 	mlt_properties_pass_list( b_props, a_props,
-		"consumer_deinterlace, deinterlace_method, consumer_tff, consumer_color_trc" );
+		"consumer_deinterlace, deinterlace_method, consumer_tff, consumer_color_trc, consumer_chan_cfg" );
 
 	return mlt_frame_get_image( b_frame, image, format, width, height, writable );
 }

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -67,6 +67,38 @@ typedef enum
 }
 mlt_audio_format;
 
+typedef enum
+{
+	mlt_chan_auto = 0,      /**< MLT will determine the default configuration based on channel number */
+	mlt_chan_independent,   /**< channels are not related */
+	mlt_chan_mono,
+	mlt_chan_stereo,
+	mlt_chan_2p1,
+	mlt_chan_3p0,
+	mlt_chan_3p0_back,
+	mlt_chan_3p1,
+	mlt_chan_4p0,
+	mlt_chan_4p1,
+	mlt_chan_quad_back,
+	mlt_chan_quad_side,
+	mlt_chan_5p0,
+	mlt_chan_5p1,
+	mlt_chan_5p0_back,
+	mlt_chan_5p1_back,
+	mlt_chan_6p0,
+	mlt_chan_6p0_front,
+	mlt_chan_hexagonal,
+	mlt_chan_6p1,
+	mlt_chan_6p1_back,
+	mlt_chan_6p1_front,
+	mlt_chan_7p0,
+	mlt_chan_7p0_front,
+	mlt_chan_7p1,
+	mlt_chan_7p1_wide_side,
+	mlt_chan_7p1_wide_back,
+}
+mlt_chan_cfg;
+
 /** The time string formats */
 
 typedef enum

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -69,35 +69,35 @@ mlt_audio_format;
 
 typedef enum
 {
-	mlt_chan_auto = 0,      /**< MLT will determine the default configuration based on channel number */
-	mlt_chan_independent,   /**< channels are not related */
-	mlt_chan_mono,
-	mlt_chan_stereo,
-	mlt_chan_2p1,
-	mlt_chan_3p0,
-	mlt_chan_3p0_back,
-	mlt_chan_3p1,
-	mlt_chan_4p0,
-	mlt_chan_4p1,
-	mlt_chan_quad_back,
-	mlt_chan_quad_side,
-	mlt_chan_5p0,
-	mlt_chan_5p1,
-	mlt_chan_5p0_back,
-	mlt_chan_5p1_back,
-	mlt_chan_6p0,
-	mlt_chan_6p0_front,
-	mlt_chan_hexagonal,
-	mlt_chan_6p1,
-	mlt_chan_6p1_back,
-	mlt_chan_6p1_front,
-	mlt_chan_7p0,
-	mlt_chan_7p0_front,
-	mlt_chan_7p1,
-	mlt_chan_7p1_wide_side,
-	mlt_chan_7p1_wide_back,
+	mlt_channel_auto = 0,      /**< MLT will determine the default configuration based on channel number */
+	mlt_channel_independent,   /**< channels are not related */
+	mlt_channel_mono,
+	mlt_channel_stereo,
+	mlt_channel_2p1,
+	mlt_channel_3p0,
+	mlt_channel_3p0_back,
+	mlt_channel_3p1,
+	mlt_channel_4p0,
+	mlt_channel_4p1,
+	mlt_channel_quad_back,
+	mlt_channel_quad_side,
+	mlt_channel_5p0,
+	mlt_channel_5p1,
+	mlt_channel_5p0_back,
+	mlt_channel_5p1_back,
+	mlt_channel_6p0,
+	mlt_channel_6p0_front,
+	mlt_channel_hexagonal,
+	mlt_channel_6p1,
+	mlt_channel_6p1_back,
+	mlt_channel_6p1_front,
+	mlt_channel_7p0,
+	mlt_channel_7p0_front,
+	mlt_channel_7p1,
+	mlt_channel_7p1_wide_side,
+	mlt_channel_7p1_wide_back,
 }
-mlt_chan_cfg;
+mlt_channel_layout;
 
 /** The time string formats */
 

--- a/src/modules/avformat/Makefile
+++ b/src/modules/avformat/Makefile
@@ -12,7 +12,8 @@ else
 TARGET = ../libmltavformat$(LIBSUF)
 endif
 
-OBJS = factory.o
+OBJS = common.o \
+       factory.o
 
 ifdef FILTERS
 OBJS += filter_avcolour_space.o \
@@ -39,6 +40,11 @@ endif
 ifdef AVFILTER
 CFLAGS += -DAVFILTER
 OBJS += filter_avfilter.o
+endif
+
+ifdef SWRESAMPLE
+OBJS += filter_swresample.o
+CFLAGS += -DSWRESAMPLE
 endif
 
 SRCS := $(OBJS:.o=.c)

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -1,0 +1,132 @@
+/*
+ * common.h
+ * Copyright (C) 2018 Meltytech, LLC
+ * Author: Brian Matherly <code@brianmatherly.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "common.h"
+
+#include <libavutil/channel_layout.h>
+#include <libavutil/samplefmt.h>
+
+int mlt_to_av_sample_format( mlt_audio_format format )
+{
+	switch( format )
+	{
+	case mlt_audio_none:
+		return AV_SAMPLE_FMT_NONE;
+	case mlt_audio_s16:
+		return AV_SAMPLE_FMT_S16;
+	case mlt_audio_s32:
+		return AV_SAMPLE_FMT_S32P;
+	case mlt_audio_float:
+		return AV_SAMPLE_FMT_FLTP;
+	case mlt_audio_s32le:
+		return AV_SAMPLE_FMT_S32;
+	case mlt_audio_f32le:
+		return AV_SAMPLE_FMT_FLT;
+	case mlt_audio_u8:
+		return AV_SAMPLE_FMT_U8;
+	}
+	mlt_log_error( NULL, "[avformat] Unknown audio format: %d\n", format );
+	return AV_SAMPLE_FMT_NONE;
+}
+
+int64_t mlt_to_av_chan_layout( mlt_chan_cfg cfg )
+{
+	switch( cfg )
+	{
+		case mlt_chan_auto:
+		case mlt_chan_independent:
+			mlt_log_error( NULL, "[avformat] No matching channel layout: %s\n", mlt_chan_cfg_name( cfg ) );
+			return 0;
+		case mlt_chan_mono:           return AV_CH_LAYOUT_MONO;
+		case mlt_chan_stereo:         return AV_CH_LAYOUT_STEREO;
+		case mlt_chan_2p1:            return AV_CH_LAYOUT_2POINT1;
+		case mlt_chan_3p0:            return AV_CH_LAYOUT_SURROUND;
+		case mlt_chan_3p0_back:       return AV_CH_LAYOUT_2_1;
+		case mlt_chan_3p1:            return AV_CH_LAYOUT_3POINT1;
+		case mlt_chan_4p0:            return AV_CH_LAYOUT_4POINT0;
+		case mlt_chan_quad_back:      return AV_CH_LAYOUT_QUAD;
+		case mlt_chan_quad_side:      return AV_CH_LAYOUT_2_2;
+		case mlt_chan_5p0:            return AV_CH_LAYOUT_5POINT0;
+		case mlt_chan_5p0_back:       return AV_CH_LAYOUT_5POINT0_BACK;
+		case mlt_chan_4p1:            return AV_CH_LAYOUT_4POINT1;
+		case mlt_chan_5p1:            return AV_CH_LAYOUT_5POINT1;
+		case mlt_chan_5p1_back:       return AV_CH_LAYOUT_5POINT1_BACK;
+		case mlt_chan_6p0:            return AV_CH_LAYOUT_6POINT0;
+		case mlt_chan_6p0_front:      return AV_CH_LAYOUT_6POINT0_FRONT;
+		case mlt_chan_hexagonal:      return AV_CH_LAYOUT_HEXAGONAL;
+		case mlt_chan_6p1:            return AV_CH_LAYOUT_6POINT1;
+		case mlt_chan_6p1_back:       return AV_CH_LAYOUT_6POINT1_BACK;
+		case mlt_chan_6p1_front:      return AV_CH_LAYOUT_6POINT1_FRONT;
+		case mlt_chan_7p0:            return AV_CH_LAYOUT_7POINT0;
+		case mlt_chan_7p0_front:      return AV_CH_LAYOUT_7POINT0_FRONT;
+		case mlt_chan_7p1:            return AV_CH_LAYOUT_7POINT1;
+		case mlt_chan_7p1_wide_side:  return AV_CH_LAYOUT_7POINT1_WIDE;
+		case mlt_chan_7p1_wide_back:  return AV_CH_LAYOUT_7POINT1_WIDE_BACK;
+	}
+	mlt_log_error( NULL, "[avformat] Unknown channel configuration: %d\n", cfg );
+	return 0;
+}
+
+mlt_chan_cfg av_chan_layout_to_mlt( int64_t layout )
+{
+	switch( layout )
+	{
+		case 0:                              return mlt_chan_independent;
+		case AV_CH_LAYOUT_MONO:              return mlt_chan_mono;
+		case AV_CH_LAYOUT_STEREO:            return mlt_chan_stereo;
+		case AV_CH_LAYOUT_STEREO_DOWNMIX:    return mlt_chan_stereo;
+		case AV_CH_LAYOUT_2POINT1:           return mlt_chan_2p1;
+		case AV_CH_LAYOUT_SURROUND:          return mlt_chan_3p0;
+		case AV_CH_LAYOUT_2_1:               return mlt_chan_3p0_back;
+		case AV_CH_LAYOUT_3POINT1:           return mlt_chan_3p1;
+		case AV_CH_LAYOUT_4POINT0:           return mlt_chan_4p0;
+		case AV_CH_LAYOUT_QUAD:              return mlt_chan_quad_back;
+		case AV_CH_LAYOUT_2_2:               return mlt_chan_quad_side;
+		case AV_CH_LAYOUT_5POINT0:           return mlt_chan_5p0;
+		case AV_CH_LAYOUT_5POINT0_BACK:      return mlt_chan_5p0_back;
+		case AV_CH_LAYOUT_4POINT1:           return mlt_chan_4p1;
+		case AV_CH_LAYOUT_5POINT1:           return mlt_chan_5p1;
+		case AV_CH_LAYOUT_5POINT1_BACK:      return mlt_chan_5p1_back;
+		case AV_CH_LAYOUT_6POINT0:           return mlt_chan_6p0;
+		case AV_CH_LAYOUT_6POINT0_FRONT:     return mlt_chan_6p0_front;
+		case AV_CH_LAYOUT_HEXAGONAL:         return mlt_chan_hexagonal;
+		case AV_CH_LAYOUT_6POINT1:           return mlt_chan_6p1;
+		case AV_CH_LAYOUT_6POINT1_BACK:      return mlt_chan_6p1_back;
+		case AV_CH_LAYOUT_6POINT1_FRONT:     return mlt_chan_6p1_front;
+		case AV_CH_LAYOUT_7POINT0:           return mlt_chan_7p0;
+		case AV_CH_LAYOUT_7POINT0_FRONT:     return mlt_chan_7p0_front;
+		case AV_CH_LAYOUT_7POINT1:           return mlt_chan_7p1;
+		case AV_CH_LAYOUT_7POINT1_WIDE:      return mlt_chan_7p1_wide_side;
+		case AV_CH_LAYOUT_7POINT1_WIDE_BACK: return mlt_chan_7p1_wide_back;
+	}
+	mlt_log_error( NULL, "[avformat] Unknown channel layout: %lu\n", (unsigned long)layout );
+	return mlt_chan_independent;
+}
+
+mlt_chan_cfg get_chan_cfg_or_default( const char* chan_cfg_name, int channels )
+{
+	mlt_chan_cfg chan_cfg = mlt_chan_cfg_id( chan_cfg_name );
+	if( chan_cfg == mlt_chan_auto ||
+		( chan_cfg != mlt_chan_independent && mlt_chan_cfg_channels( chan_cfg ) != channels ) )
+	{
+		chan_cfg = mlt_chan_cfg_default( channels );
+	}
+	return chan_cfg;
+}

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -46,87 +46,87 @@ int mlt_to_av_sample_format( mlt_audio_format format )
 	return AV_SAMPLE_FMT_NONE;
 }
 
-int64_t mlt_to_av_chan_layout( mlt_chan_cfg cfg )
-{
-	switch( cfg )
-	{
-		case mlt_chan_auto:
-		case mlt_chan_independent:
-			mlt_log_error( NULL, "[avformat] No matching channel layout: %s\n", mlt_chan_cfg_name( cfg ) );
-			return 0;
-		case mlt_chan_mono:           return AV_CH_LAYOUT_MONO;
-		case mlt_chan_stereo:         return AV_CH_LAYOUT_STEREO;
-		case mlt_chan_2p1:            return AV_CH_LAYOUT_2POINT1;
-		case mlt_chan_3p0:            return AV_CH_LAYOUT_SURROUND;
-		case mlt_chan_3p0_back:       return AV_CH_LAYOUT_2_1;
-		case mlt_chan_3p1:            return AV_CH_LAYOUT_3POINT1;
-		case mlt_chan_4p0:            return AV_CH_LAYOUT_4POINT0;
-		case mlt_chan_quad_back:      return AV_CH_LAYOUT_QUAD;
-		case mlt_chan_quad_side:      return AV_CH_LAYOUT_2_2;
-		case mlt_chan_5p0:            return AV_CH_LAYOUT_5POINT0;
-		case mlt_chan_5p0_back:       return AV_CH_LAYOUT_5POINT0_BACK;
-		case mlt_chan_4p1:            return AV_CH_LAYOUT_4POINT1;
-		case mlt_chan_5p1:            return AV_CH_LAYOUT_5POINT1;
-		case mlt_chan_5p1_back:       return AV_CH_LAYOUT_5POINT1_BACK;
-		case mlt_chan_6p0:            return AV_CH_LAYOUT_6POINT0;
-		case mlt_chan_6p0_front:      return AV_CH_LAYOUT_6POINT0_FRONT;
-		case mlt_chan_hexagonal:      return AV_CH_LAYOUT_HEXAGONAL;
-		case mlt_chan_6p1:            return AV_CH_LAYOUT_6POINT1;
-		case mlt_chan_6p1_back:       return AV_CH_LAYOUT_6POINT1_BACK;
-		case mlt_chan_6p1_front:      return AV_CH_LAYOUT_6POINT1_FRONT;
-		case mlt_chan_7p0:            return AV_CH_LAYOUT_7POINT0;
-		case mlt_chan_7p0_front:      return AV_CH_LAYOUT_7POINT0_FRONT;
-		case mlt_chan_7p1:            return AV_CH_LAYOUT_7POINT1;
-		case mlt_chan_7p1_wide_side:  return AV_CH_LAYOUT_7POINT1_WIDE;
-		case mlt_chan_7p1_wide_back:  return AV_CH_LAYOUT_7POINT1_WIDE_BACK;
-	}
-	mlt_log_error( NULL, "[avformat] Unknown channel configuration: %d\n", cfg );
-	return 0;
-}
-
-mlt_chan_cfg av_chan_layout_to_mlt( int64_t layout )
+int64_t mlt_to_av_channel_layout( mlt_channel_layout layout )
 {
 	switch( layout )
 	{
-		case 0:                              return mlt_chan_independent;
-		case AV_CH_LAYOUT_MONO:              return mlt_chan_mono;
-		case AV_CH_LAYOUT_STEREO:            return mlt_chan_stereo;
-		case AV_CH_LAYOUT_STEREO_DOWNMIX:    return mlt_chan_stereo;
-		case AV_CH_LAYOUT_2POINT1:           return mlt_chan_2p1;
-		case AV_CH_LAYOUT_SURROUND:          return mlt_chan_3p0;
-		case AV_CH_LAYOUT_2_1:               return mlt_chan_3p0_back;
-		case AV_CH_LAYOUT_3POINT1:           return mlt_chan_3p1;
-		case AV_CH_LAYOUT_4POINT0:           return mlt_chan_4p0;
-		case AV_CH_LAYOUT_QUAD:              return mlt_chan_quad_back;
-		case AV_CH_LAYOUT_2_2:               return mlt_chan_quad_side;
-		case AV_CH_LAYOUT_5POINT0:           return mlt_chan_5p0;
-		case AV_CH_LAYOUT_5POINT0_BACK:      return mlt_chan_5p0_back;
-		case AV_CH_LAYOUT_4POINT1:           return mlt_chan_4p1;
-		case AV_CH_LAYOUT_5POINT1:           return mlt_chan_5p1;
-		case AV_CH_LAYOUT_5POINT1_BACK:      return mlt_chan_5p1_back;
-		case AV_CH_LAYOUT_6POINT0:           return mlt_chan_6p0;
-		case AV_CH_LAYOUT_6POINT0_FRONT:     return mlt_chan_6p0_front;
-		case AV_CH_LAYOUT_HEXAGONAL:         return mlt_chan_hexagonal;
-		case AV_CH_LAYOUT_6POINT1:           return mlt_chan_6p1;
-		case AV_CH_LAYOUT_6POINT1_BACK:      return mlt_chan_6p1_back;
-		case AV_CH_LAYOUT_6POINT1_FRONT:     return mlt_chan_6p1_front;
-		case AV_CH_LAYOUT_7POINT0:           return mlt_chan_7p0;
-		case AV_CH_LAYOUT_7POINT0_FRONT:     return mlt_chan_7p0_front;
-		case AV_CH_LAYOUT_7POINT1:           return mlt_chan_7p1;
-		case AV_CH_LAYOUT_7POINT1_WIDE:      return mlt_chan_7p1_wide_side;
-		case AV_CH_LAYOUT_7POINT1_WIDE_BACK: return mlt_chan_7p1_wide_back;
+		case mlt_channel_auto:
+		case mlt_channel_independent:
+			mlt_log_error( NULL, "[avformat] No matching channel layout: %s\n", mlt_channel_layout_name( layout ) );
+			return 0;
+		case mlt_channel_mono:           return AV_CH_LAYOUT_MONO;
+		case mlt_channel_stereo:         return AV_CH_LAYOUT_STEREO;
+		case mlt_channel_2p1:            return AV_CH_LAYOUT_2POINT1;
+		case mlt_channel_3p0:            return AV_CH_LAYOUT_SURROUND;
+		case mlt_channel_3p0_back:       return AV_CH_LAYOUT_2_1;
+		case mlt_channel_3p1:            return AV_CH_LAYOUT_3POINT1;
+		case mlt_channel_4p0:            return AV_CH_LAYOUT_4POINT0;
+		case mlt_channel_quad_back:      return AV_CH_LAYOUT_QUAD;
+		case mlt_channel_quad_side:      return AV_CH_LAYOUT_2_2;
+		case mlt_channel_5p0:            return AV_CH_LAYOUT_5POINT0;
+		case mlt_channel_5p0_back:       return AV_CH_LAYOUT_5POINT0_BACK;
+		case mlt_channel_4p1:            return AV_CH_LAYOUT_4POINT1;
+		case mlt_channel_5p1:            return AV_CH_LAYOUT_5POINT1;
+		case mlt_channel_5p1_back:       return AV_CH_LAYOUT_5POINT1_BACK;
+		case mlt_channel_6p0:            return AV_CH_LAYOUT_6POINT0;
+		case mlt_channel_6p0_front:      return AV_CH_LAYOUT_6POINT0_FRONT;
+		case mlt_channel_hexagonal:      return AV_CH_LAYOUT_HEXAGONAL;
+		case mlt_channel_6p1:            return AV_CH_LAYOUT_6POINT1;
+		case mlt_channel_6p1_back:       return AV_CH_LAYOUT_6POINT1_BACK;
+		case mlt_channel_6p1_front:      return AV_CH_LAYOUT_6POINT1_FRONT;
+		case mlt_channel_7p0:            return AV_CH_LAYOUT_7POINT0;
+		case mlt_channel_7p0_front:      return AV_CH_LAYOUT_7POINT0_FRONT;
+		case mlt_channel_7p1:            return AV_CH_LAYOUT_7POINT1;
+		case mlt_channel_7p1_wide_side:  return AV_CH_LAYOUT_7POINT1_WIDE;
+		case mlt_channel_7p1_wide_back:  return AV_CH_LAYOUT_7POINT1_WIDE_BACK;
 	}
-	mlt_log_error( NULL, "[avformat] Unknown channel layout: %lu\n", (unsigned long)layout );
-	return mlt_chan_independent;
+	mlt_log_error( NULL, "[avformat] Unknown channel configuration: %d\n", layout );
+	return 0;
 }
 
-mlt_chan_cfg get_chan_cfg_or_default( const char* chan_cfg_name, int channels )
+mlt_channel_layout av_channel_layout_to_mlt( int64_t layout )
 {
-	mlt_chan_cfg chan_cfg = mlt_chan_cfg_id( chan_cfg_name );
-	if( chan_cfg == mlt_chan_auto ||
-		( chan_cfg != mlt_chan_independent && mlt_chan_cfg_channels( chan_cfg ) != channels ) )
+	switch( layout )
 	{
-		chan_cfg = mlt_chan_cfg_default( channels );
+		case 0:                              return mlt_channel_independent;
+		case AV_CH_LAYOUT_MONO:              return mlt_channel_mono;
+		case AV_CH_LAYOUT_STEREO:            return mlt_channel_stereo;
+		case AV_CH_LAYOUT_STEREO_DOWNMIX:    return mlt_channel_stereo;
+		case AV_CH_LAYOUT_2POINT1:           return mlt_channel_2p1;
+		case AV_CH_LAYOUT_SURROUND:          return mlt_channel_3p0;
+		case AV_CH_LAYOUT_2_1:               return mlt_channel_3p0_back;
+		case AV_CH_LAYOUT_3POINT1:           return mlt_channel_3p1;
+		case AV_CH_LAYOUT_4POINT0:           return mlt_channel_4p0;
+		case AV_CH_LAYOUT_QUAD:              return mlt_channel_quad_back;
+		case AV_CH_LAYOUT_2_2:               return mlt_channel_quad_side;
+		case AV_CH_LAYOUT_5POINT0:           return mlt_channel_5p0;
+		case AV_CH_LAYOUT_5POINT0_BACK:      return mlt_channel_5p0_back;
+		case AV_CH_LAYOUT_4POINT1:           return mlt_channel_4p1;
+		case AV_CH_LAYOUT_5POINT1:           return mlt_channel_5p1;
+		case AV_CH_LAYOUT_5POINT1_BACK:      return mlt_channel_5p1_back;
+		case AV_CH_LAYOUT_6POINT0:           return mlt_channel_6p0;
+		case AV_CH_LAYOUT_6POINT0_FRONT:     return mlt_channel_6p0_front;
+		case AV_CH_LAYOUT_HEXAGONAL:         return mlt_channel_hexagonal;
+		case AV_CH_LAYOUT_6POINT1:           return mlt_channel_6p1;
+		case AV_CH_LAYOUT_6POINT1_BACK:      return mlt_channel_6p1_back;
+		case AV_CH_LAYOUT_6POINT1_FRONT:     return mlt_channel_6p1_front;
+		case AV_CH_LAYOUT_7POINT0:           return mlt_channel_7p0;
+		case AV_CH_LAYOUT_7POINT0_FRONT:     return mlt_channel_7p0_front;
+		case AV_CH_LAYOUT_7POINT1:           return mlt_channel_7p1;
+		case AV_CH_LAYOUT_7POINT1_WIDE:      return mlt_channel_7p1_wide_side;
+		case AV_CH_LAYOUT_7POINT1_WIDE_BACK: return mlt_channel_7p1_wide_back;
 	}
-	return chan_cfg;
+	mlt_log_error( NULL, "[avformat] Unknown channel layout: %lu\n", (unsigned long)layout );
+	return mlt_channel_independent;
+}
+
+mlt_channel_layout get_channel_layout_or_default( const char* name, int channels )
+{
+	mlt_channel_layout layout = mlt_channel_layout_id( name );
+	if( layout == mlt_channel_auto ||
+		( layout != mlt_channel_independent && mlt_channel_layout_channels( layout ) != channels ) )
+	{
+		layout = mlt_channel_layout_default( channels );
+	}
+	return layout;
 }

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -24,8 +24,8 @@
 #include <framework/mlt.h>
 
 int mlt_to_av_sample_format( mlt_audio_format format );
-int64_t mlt_to_av_chan_layout( mlt_chan_cfg cfg );
-mlt_chan_cfg av_chan_layout_to_mlt( int64_t layout );
-mlt_chan_cfg get_chan_cfg_or_default( const char* chan_cfg_name, int channels );
+int64_t mlt_to_av_channel_layout( mlt_channel_layout layout );
+mlt_channel_layout av_channel_layout_to_mlt( int64_t layout );
+mlt_channel_layout get_channel_layout_or_default( const char* name, int channels );
 
 #endif // COMMON_H

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -1,0 +1,31 @@
+/*
+ * common.h
+ * Copyright (C) 2018 Meltytech, LLC
+ * Author: Brian Matherly <code@brianmatherly.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <framework/mlt.h>
+
+int mlt_to_av_sample_format( mlt_audio_format format );
+int64_t mlt_to_av_chan_layout( mlt_chan_cfg cfg );
+mlt_chan_cfg av_chan_layout_to_mlt( int64_t layout );
+mlt_chan_cfg get_chan_cfg_or_default( const char* chan_cfg_name, int channels );
+
+#endif // COMMON_H

--- a/src/modules/avformat/configure
+++ b/src/modules/avformat/configure
@@ -53,6 +53,7 @@ else
 	export devices=true
 	export vdpau=false
 	export avfilter=true
+	export swresample=false
 	pkg-config x11 > /dev/null 2>&1
 	export x11=$?
 
@@ -150,6 +151,13 @@ else
 				avfilter=false
 			fi
 		fi
+		if $(pkg-config libswresample${avformat_suffix}); then
+			swresample=true
+			echo "CFLAGS+=$(pkg-config --cflags libswresample${avformat_suffix})" >> config.mak
+			echo "LDFLAGS+=$(pkg-config --libs libswresample${avformat_suffix})" >> config.mak
+		else
+			echo " - libswresample not found, disabling some features"
+		fi
 		if [ "$vdpau" = "true" ]
 		then
 			printf "#include <libavcodec/vdpau.h>\n int main(){ VdpBitstreamBuffer test; test.struct_version; return 0;}" | $CC $(pkg-config --cflags libavformat${avformat_suffix}) -I"$shared_ffmpeg/include" $CFLAGS -c -x c -  >/dev/null 2>&1
@@ -166,6 +174,7 @@ else
 	[ "$filters" = "true" ] && echo "FILTERS=1" >> config.mak
 	[ "$devices" = "true" ] && echo "DEVICES=1" >> config.mak
 	[ "$avfilter" = "true" ] && echo "AVFILTER=1" >> config.mak
+	[ "$swresample" = "true" ] && echo "SWRESAMPLE=1" >> config.mak
 	exit 0
 
 fi

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1539,14 +1539,14 @@ static void *consumer_thread( void *arg )
 		// single track
 		if ( !is_multi )
 		{
-			mlt_chan_cfg chan_cfg = mlt_chan_cfg_id( mlt_properties_get( properties, "chan_cfg" ) );
-			if( chan_cfg == mlt_chan_auto ||
-				chan_cfg == mlt_chan_independent ||
-				mlt_chan_cfg_channels( chan_cfg ) != enc_ctx->channels )
+			mlt_channel_layout layout = mlt_channel_layout_id( mlt_properties_get( properties, "channel_layout" ) );
+			if( layout == mlt_channel_auto ||
+				layout == mlt_channel_independent ||
+				mlt_channel_layout_channels( layout ) != enc_ctx->channels )
 			{
-				chan_cfg = mlt_chan_cfg_default( enc_ctx->channels );
+				layout = mlt_channel_layout_default( enc_ctx->channels );
 			}
-			enc_ctx->audio_st[0] = add_audio_stream( consumer, enc_ctx->oc, audio_codec, enc_ctx->channels, mlt_to_av_chan_layout( chan_cfg ) );
+			enc_ctx->audio_st[0] = add_audio_stream( consumer, enc_ctx->oc, audio_codec, enc_ctx->channels, mlt_to_av_channel_layout( layout ) );
 			enc_ctx->total_channels = enc_ctx->channels;
 		}
 	}

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -452,7 +452,7 @@ static void apply_properties( void *obj, mlt_properties properties, int flags )
 			( opt_name[0] == 'a' && ( flags & AV_OPT_FLAG_AUDIO_PARAM ) ) ) )
 			opt = av_opt_find( obj, ++opt_name, NULL, flags, flags );
 		// Apply option if found
-		if ( opt )
+		if ( opt &&  strcmp( opt_name, "channel_layout" ) )
 			av_opt_set( obj, opt_name, mlt_properties_get_value( properties, i), 0 );
 	}
 }
@@ -597,7 +597,7 @@ static AVStream *add_audio_stream( mlt_consumer consumer, AVFormatContext *oc, A
 		if ( thread_count >= 0 )
 			c->thread_count = thread_count;
 #endif
-	
+
 		if (oc->oformat->flags & AVFMT_GLOBALHEADER) 
 			c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 		
@@ -1629,7 +1629,7 @@ static void *consumer_thread( void *arg )
 				goto on_fatal_error;
 			}
 		}
-	
+
 	}
 
 	// Last check - need at least one stream

--- a/src/modules/avformat/factory.c
+++ b/src/modules/avformat/factory.c
@@ -27,6 +27,7 @@
 extern mlt_consumer consumer_avformat_init( mlt_profile profile, char *file );
 extern mlt_filter filter_avcolour_space_init( void *arg );
 extern mlt_filter filter_avdeinterlace_init( void *arg );
+extern mlt_filter filter_swresample_init( mlt_profile profile, char *arg );
 extern mlt_filter filter_swscale_init( mlt_profile profile, char *arg );
 extern mlt_producer producer_avformat_init( mlt_profile profile, const char *service, char *file );
 extern mlt_filter filter_avfilter_init( mlt_profile, mlt_service_type, const char*, char* );
@@ -126,6 +127,10 @@ static void *create_service( mlt_profile profile, mlt_service_type type, const c
 		return filter_avdeinterlace_init( arg );
 	if ( !strcmp( id, "swscale" ) )
 		return filter_swscale_init( profile, arg );
+#endif
+#ifdef SWRESAMPLE
+	if ( !strcmp( id, "swresample" ) )
+		return filter_swresample_init( profile, arg );
 #endif
 	return NULL;
 }
@@ -427,5 +432,8 @@ MLT_REPOSITORY
 	}
 	mlt_properties_close( blacklist );
 #endif // AVFILTER
+#endif
+#ifdef SWRESAMPLE
+	MLT_REGISTER( filter_type, "swresample", create_service );
 #endif
 }

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -18,6 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "common.h"
+
 #include <framework/mlt.h>
 #include <stdlib.h>
 #include <string.h>
@@ -61,30 +63,6 @@ static void property_changed( mlt_service owner, mlt_filter filter, char *name )
 				break;
 			}
 		}
-	}
-}
-
-static int mlt_to_av_audio_format( mlt_audio_format format )
-{
-	switch( format )
-	{
-	case mlt_audio_none:
-		return AV_SAMPLE_FMT_NONE;
-	case mlt_audio_s16:
-		return AV_SAMPLE_FMT_S16;
-	case mlt_audio_s32:
-		return AV_SAMPLE_FMT_S32P;
-	case mlt_audio_float:
-		return AV_SAMPLE_FMT_FLTP;
-	case mlt_audio_s32le:
-		return AV_SAMPLE_FMT_S32;
-	case mlt_audio_f32le:
-		return AV_SAMPLE_FMT_FLT;
-	case mlt_audio_u8:
-		return AV_SAMPLE_FMT_U8;
-	default:
-		mlt_log_error(NULL, "[filter_avfilter] Unknown audio format: %d\n", format );
-		return AV_SAMPLE_FMT_NONE;
 	}
 }
 
@@ -166,7 +144,7 @@ static void init_audio_filtergraph( mlt_filter filter, mlt_audio_format format, 
 	pdata->format = format;
 
 	// Set up formats
-	sample_fmts[0] = mlt_to_av_audio_format( format );
+	sample_fmts[0] = mlt_to_av_sample_format( format );
 	sample_rates[0] = frequency;
 	channel_counts[0] = channels;
 	channel_layouts[0] = av_get_default_channel_layout( channels );
@@ -422,9 +400,10 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	if( pdata->avfilter_graph )
 	{
 		// Set up the input frame
+		mlt_chan_cfg chan_cfg = get_chan_cfg_or_default( mlt_properties_get( MLT_FRAME_PROPERTIES(frame), "chan_cfg" ) , *channels );
 		pdata->avinframe->sample_rate = *frequency;
-		pdata->avinframe->format = mlt_to_av_audio_format( *format );
-		pdata->avinframe->channel_layout = av_get_default_channel_layout( *channels );
+		pdata->avinframe->format = mlt_to_av_sample_format( *format );
+		pdata->avinframe->channel_layout = mlt_to_av_chan_layout( chan_cfg );
 		pdata->avinframe->channels = *channels;
 		pdata->avinframe->nb_samples = *samples;
 		pdata->avinframe->pts = samplepos;

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -400,10 +400,10 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	if( pdata->avfilter_graph )
 	{
 		// Set up the input frame
-		mlt_chan_cfg chan_cfg = get_chan_cfg_or_default( mlt_properties_get( MLT_FRAME_PROPERTIES(frame), "chan_cfg" ) , *channels );
+		mlt_channel_layout layout = get_channel_layout_or_default( mlt_properties_get( MLT_FRAME_PROPERTIES(frame), "channel_layout" ) , *channels );
 		pdata->avinframe->sample_rate = *frequency;
 		pdata->avinframe->format = mlt_to_av_sample_format( *format );
-		pdata->avinframe->channel_layout = mlt_to_av_chan_layout( chan_cfg );
+		pdata->avinframe->channel_layout = mlt_to_av_channel_layout( layout );
 		pdata->avinframe->channels = *channels;
 		pdata->avinframe->nb_samples = *samples;
 		pdata->avinframe->pts = samplepos;

--- a/src/modules/avformat/filter_swresample.c
+++ b/src/modules/avformat/filter_swresample.c
@@ -1,0 +1,323 @@
+/*
+ * filter_swresample.c -- convert from one format/ configuration to another
+ * Copyright (C) 2018 Meltytech, LLC
+ * Author: Brian Matherly <code@brianmatherly.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "common.h"
+
+#include <framework/mlt.h>
+
+#include <libswresample/swresample.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/opt.h>
+#include <libavutil/samplefmt.h>
+
+typedef struct
+{
+	SwrContext* ctx;
+	uint8_t** in_buffers;
+	uint8_t** out_buffers;
+	mlt_audio_format in_format;
+	mlt_audio_format out_format;
+	int in_frequency;
+	int out_frequency;
+	int in_channels;
+	int out_channels;
+	mlt_chan_cfg in_chan_cfg;
+	mlt_chan_cfg out_chan_cfg;
+} private_data;
+
+static int audio_plane_count( mlt_audio_format format, int channels )
+{
+	switch ( format )
+	{
+		case mlt_audio_none:  return 0;
+		case mlt_audio_s16:   return 1;
+		case mlt_audio_s32le: return 1;
+		case mlt_audio_s32:   return channels;
+		case mlt_audio_f32le: return 1;
+		case mlt_audio_float: return channels;
+		case mlt_audio_u8:    return 1;
+	}
+	return 0;
+}
+
+static int audio_plane_size( mlt_audio_format format, int samples, int channels )
+{
+	switch ( format )
+	{
+		case mlt_audio_none:  return 0;
+		case mlt_audio_s16:   return samples * channels * sizeof( int16_t );
+		case mlt_audio_s32le: return samples * channels * sizeof( int32_t );
+		case mlt_audio_s32:   return samples * sizeof( int32_t );
+		case mlt_audio_f32le: return samples * channels * sizeof( float );
+		case mlt_audio_float: return samples * sizeof( float );
+		case mlt_audio_u8:    return samples * channels;
+	}
+	return 0;
+}
+
+static void audio_format_planes( mlt_audio_format format, int samples, int channels, uint8_t* buffer, uint8_t** planes )
+{
+	int plane_count = audio_plane_count( format, channels );
+	size_t plane_size = audio_plane_size( format, samples, channels );
+	for( int p = 0; p < plane_count; p++ )
+	{
+		planes[p] = buffer + ( p * plane_size );
+	}
+}
+
+static void collapse_channels( mlt_audio_format format, int channels, int allocated_samples, int used_samples, uint8_t* buffer )
+{
+	int plane_count = audio_plane_count( format, channels );
+	if( plane_count > 1 && allocated_samples != used_samples )
+	{
+		size_t src_plane_size = audio_plane_size( format, allocated_samples, channels );
+		size_t dst_plane_size = audio_plane_size( format, used_samples, channels );
+		for( int p = 0; p < plane_count; p++ )
+		{
+			uint8_t* src = buffer + ( p * src_plane_size );
+			uint8_t* dst = buffer + ( p * dst_plane_size );
+			memmove( dst, src, dst_plane_size );
+		}
+	}
+}
+
+static int configure_swr_context( mlt_filter filter )
+{
+	private_data* pdata = (private_data*)filter->child;
+	int error = 0;
+
+	mlt_log_debug( MLT_FILTER_SERVICE(filter), "%d(%s) %s %dHz -> %d(%s) %s %dHz\n",
+				   pdata->in_channels, mlt_chan_cfg_name( pdata->in_chan_cfg ), mlt_audio_format_name( pdata->in_format ), pdata->in_frequency, pdata->out_channels, mlt_chan_cfg_name( pdata->out_chan_cfg ), mlt_audio_format_name( pdata->out_format ), pdata->out_frequency );
+
+	swr_free( &pdata->ctx );
+	pdata->ctx = swr_alloc();
+	if( !pdata->ctx )
+	{
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Cannot allocate context\n" );
+		return 1;
+	}
+
+	// Configure format, frequency and channels.
+	av_opt_set_int( pdata->ctx, "osf", mlt_to_av_sample_format( pdata->out_format ), 0 );
+	av_opt_set_int( pdata->ctx, "osr", pdata->out_frequency, 0 );
+	av_opt_set_int( pdata->ctx, "och", pdata->out_channels, 0);
+	av_opt_set_int( pdata->ctx, "isf", mlt_to_av_sample_format( pdata->in_format ), 0 );
+	av_opt_set_int( pdata->ctx, "isr", pdata->in_frequency,  0 );
+	av_opt_set_int( pdata->ctx, "ich", pdata->in_channels, 0 );
+
+	if( pdata->in_chan_cfg != mlt_chan_independent && pdata->out_chan_cfg != mlt_chan_independent )
+	{
+		// Use standard channel layout and matrix for known channel configurations.
+		av_opt_set_int( pdata->ctx, "ocl", mlt_to_av_chan_layout( pdata->out_chan_cfg ), 0 );
+		av_opt_set_int( pdata->ctx, "icl", mlt_to_av_chan_layout( pdata->in_chan_cfg ), 0 );
+	}
+	else
+	{
+		// Use a custom channel layout and matrix for independent channels.
+		// This matrix will simply map input channels to output channels in order.
+		// If input channels > output channels, channels will be dropped.
+		// If input channels < output channels, silent channels will be added.
+		int64_t custom_in_layout = 0;
+		int64_t custom_out_layout = 0;
+		double* matrix = av_mallocz_array( pdata->in_channels * pdata->out_channels, sizeof(double) );
+		int stride = pdata->in_channels;
+
+		for( int i = 0; i < pdata->in_channels; i++ )
+		{
+			custom_in_layout = (custom_in_layout << 1) | 0x01;
+		}
+		for( int i = 0; i < pdata->out_channels; i++ )
+		{
+			custom_out_layout = (custom_out_layout << 1) | 0x01;
+			if( i <= pdata->in_channels )
+			{
+				double* matrix_row = matrix + (stride * i);
+				matrix_row[i] = 1.0;
+			}
+		}
+		av_opt_set_int( pdata->ctx, "ocl", custom_out_layout, 0 );
+		av_opt_set_int( pdata->ctx, "icl", custom_in_layout, 0 );
+		error = swr_set_matrix( pdata->ctx, matrix, stride );
+		av_free( matrix );
+		if( error != 0 )
+		{
+			swr_free( &pdata->ctx );
+			mlt_log_error( MLT_FILTER_SERVICE(filter), "Unable to create custom matrix\n" );
+			return error;
+		}
+	}
+
+	error = swr_init( pdata->ctx );
+	if( error != 0 )
+	{
+		swr_free( &pdata->ctx );
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Cannot initialize context\n" );
+		return error;
+	}
+
+	// Allocate the channel buffer pointers
+	av_freep( &pdata->in_buffers );
+	pdata->in_buffers = av_mallocz_array( pdata->in_channels, sizeof(uint8_t*) );
+	av_freep( &pdata->out_buffers );
+	pdata->out_buffers = av_mallocz_array( pdata->out_channels, sizeof(uint8_t*) );
+
+	return error;
+}
+
+static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *format, int *frequency, int *channels, int *samples )
+{
+	mlt_filter filter = mlt_frame_pop_audio( frame );
+	private_data* pdata = (private_data*)filter->child;
+	mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
+	mlt_audio_format in_format = *format;
+	mlt_audio_format out_format = *format;
+	int in_frequency = *frequency;
+	int out_frequency = *frequency;
+	int in_channels = *channels;
+	int out_channels = *channels;
+	mlt_chan_cfg in_chan_cfg;
+	mlt_chan_cfg out_chan_cfg;
+
+	// Get the producer's audio
+	int error = mlt_frame_get_audio( frame, buffer, &in_format, &in_frequency, &in_channels, samples );
+	if ( error || in_format == mlt_audio_none || out_format == mlt_audio_none ) return error;
+
+	// Determine the input/output channel layout.
+	in_chan_cfg = get_chan_cfg_or_default( mlt_properties_get( frame_properties, "chan_cfg" ), in_channels );
+	out_chan_cfg = get_chan_cfg_or_default( mlt_properties_get( frame_properties, "consumer_chan_cfg" ), out_channels );
+
+	if( in_format == out_format &&
+		in_frequency == out_frequency &&
+		in_channels == out_channels &&
+		in_chan_cfg == out_chan_cfg )
+	{
+		// No change necessary
+		return error;
+	}
+
+	mlt_service_lock( MLT_FILTER_SERVICE(filter) );
+
+	// Detect configuration change
+	if( !pdata->ctx ||
+		pdata->in_format != in_format ||
+		pdata->out_format != out_format ||
+		pdata->in_frequency != in_frequency ||
+		pdata->out_frequency != out_frequency ||
+		pdata->in_channels != in_channels ||
+		pdata->out_channels != out_channels ||
+		pdata->in_chan_cfg != in_chan_cfg ||
+		pdata->out_chan_cfg != out_chan_cfg )
+	{
+		// Save the configuration
+		pdata->in_format = in_format;
+		pdata->out_format = out_format;
+		pdata->in_frequency = in_frequency;
+		pdata->out_frequency = out_frequency;
+		pdata->in_channels = in_channels;
+		pdata->out_channels = out_channels;
+		pdata->in_chan_cfg = in_chan_cfg;
+		pdata->out_chan_cfg = out_chan_cfg;
+		// Reconfigure the context
+		error = configure_swr_context( filter );
+	}
+
+	if( !error )
+	{
+		int in_samples = *samples;
+		int alloc_samples = in_samples;
+		if( in_frequency != out_frequency )
+		{
+			// Number of output samples will change if sampling frequency changes.
+			alloc_samples = in_samples * out_frequency / in_frequency;
+			// Round up to make sure all available samples are received from swresample.
+			alloc_samples += 1;
+		}
+		int size = mlt_audio_format_size( out_format, alloc_samples, out_channels );
+		uint8_t* out_buffer = mlt_pool_alloc( size );
+
+		audio_format_planes( in_format, in_samples, in_channels, *buffer, pdata->in_buffers );
+		audio_format_planes( out_format, alloc_samples, out_channels, out_buffer, pdata->out_buffers );
+
+		int out_samples = swr_convert( pdata->ctx, pdata->out_buffers, alloc_samples, (const uint8_t**)pdata->in_buffers, in_samples );
+		if( out_samples > 0 )
+		{
+			collapse_channels( out_format, out_channels, alloc_samples, out_samples, out_buffer );
+			mlt_frame_set_audio( frame, out_buffer, out_format, size, mlt_pool_release );
+			*buffer = out_buffer;
+			*samples = out_samples;
+			*format = out_format;
+			*channels = out_channels;
+			mlt_properties_set( frame_properties, "chan_cfg", mlt_chan_cfg_name( pdata->out_chan_cfg ) );
+		}
+		else
+		{
+			mlt_log_error( MLT_FILTER_SERVICE(filter), "swr_convert() failed\n" );
+			error = 1;
+		}
+	}
+
+	mlt_service_unlock( MLT_FILTER_SERVICE(filter) );
+	return error;
+}
+
+static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
+{
+	mlt_frame_push_audio( frame, filter );
+	mlt_frame_push_audio( frame, filter_get_audio );
+	return frame;
+}
+
+static void filter_close( mlt_filter filter )
+{
+	private_data* pdata = (private_data*)filter->child;
+
+	if( pdata )
+	{
+		swr_free( &pdata->ctx );
+		av_freep( &pdata->in_buffers );
+		av_freep( &pdata->out_buffers );
+		free( pdata );
+	}
+	filter->child = NULL;
+	filter->close = NULL;
+	filter->parent.close = NULL;
+	mlt_service_close( &filter->parent );
+}
+
+mlt_filter filter_swresample_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	mlt_filter filter = mlt_filter_new();
+	private_data* pdata = (private_data*)calloc( 1, sizeof(private_data) );
+
+	if( filter && pdata )
+	{
+		memset( pdata, 0, sizeof( *pdata ) );
+		filter->close = filter_close;
+		filter->process = filter_process;
+		filter->child = pdata;
+	}
+	else
+	{
+		mlt_filter_close( filter );
+		free( pdata );
+	}
+
+	return filter;
+}

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -2615,7 +2615,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 		int ret	= 0;
 		int got_audio = 0;
 		AVPacket pkt;
-		mlt_chan_cfg chan_cfg;
+		mlt_channel_layout layout;
 
 		av_init_packet( &pkt );
 		
@@ -2709,11 +2709,11 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 			*frequency = self->audio_codec[ index ]->sample_rate;
 			*format = pick_audio_format( self->audio_codec[ index ]->sample_fmt );
 			sizeof_sample = sample_bytes( self->audio_codec[ index ] );
-			chan_cfg = av_chan_layout_to_mlt( self->audio_codec[ index ]->channel_layout );
+			layout = av_channel_layout_to_mlt( self->audio_codec[ index ]->channel_layout );
 		}
 		else if ( self->audio_index == INT_MAX )
 		{
-			chan_cfg = mlt_chan_independent;
+			layout = mlt_channel_independent;
 			for ( index = 0; index < index_max; index++ )
 				if ( self->audio_codec[ index ] )
 				{
@@ -2723,7 +2723,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 					break;
 				}
 		}
-		mlt_properties_set( MLT_FRAME_PROPERTIES(frame), "chan_cfg", mlt_chan_cfg_name( chan_cfg ) );
+		mlt_properties_set( MLT_FRAME_PROPERTIES(frame), "channel_layout", mlt_channel_layout_name( layout ) );
 
 		// Allocate and set the frame's audio buffer
 		int size = mlt_audio_format_size( *format, *samples, *channels );

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "common.h"
+
 // MLT Header files
 #include <framework/mlt_producer.h>
 #include <framework/mlt_frame.h>
@@ -2613,6 +2615,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 		int ret	= 0;
 		int got_audio = 0;
 		AVPacket pkt;
+		mlt_chan_cfg chan_cfg;
 
 		av_init_packet( &pkt );
 		
@@ -2706,9 +2709,11 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 			*frequency = self->audio_codec[ index ]->sample_rate;
 			*format = pick_audio_format( self->audio_codec[ index ]->sample_fmt );
 			sizeof_sample = sample_bytes( self->audio_codec[ index ] );
+			chan_cfg = av_chan_layout_to_mlt( self->audio_codec[ index ]->channel_layout );
 		}
 		else if ( self->audio_index == INT_MAX )
 		{
+			chan_cfg = mlt_chan_independent;
 			for ( index = 0; index < index_max; index++ )
 				if ( self->audio_codec[ index ] )
 				{
@@ -2718,6 +2723,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 					break;
 				}
 		}
+		mlt_properties_set( MLT_FRAME_PROPERTIES(frame), "chan_cfg", mlt_chan_cfg_name( chan_cfg ) );
 
 		// Allocate and set the frame's audio buffer
 		int size = mlt_audio_format_size( *format, *samples, *channels );

--- a/src/modules/core/loader.ini
+++ b/src/modules/core/loader.ini
@@ -14,7 +14,7 @@ rescaler=movit.resample,swscale,gtkrescale,rescale
 resizer=movit.resize,resize
 
 # audio filters
-channels=audiochannels
+channels=swresample,audiochannels
 resampler=resample
 
 # metadata filters


### PR DESCRIPTION
While resolving comments for https://github.com/mltframework/mlt/pull/295, I realized that I was reinventing a lot of functionality that swresample already does very well. So I decided to take a different approach.

This adds a new audio normalize filter that is aware of the channel configuration and can convert between configurations. Since it uses swresample, it also has the side-effect of converting sample formats and sample frequencies.

In general, it works by adding a new "chan_cfg" property to frames when audio is added (currently only supported in producer_avformat. The user can specify a "chan_cfg" on the consumer and filter_swresample will attempt to convert if they do not match. If the frame or consumer "chan_cfg" property is not set, it will default to "auto" which will pick the most probable configuration for the number of channels (this matches existing functionality).