### PR TITLE
Improve surround support in RtAudio on Windows.

### DIFF
--- a/src/modules/rtaudio/Makefile
+++ b/src/modules/rtaudio/Makefile
@@ -22,6 +22,8 @@ LDFLAGS += -framework CoreAudio -framework CoreFoundation
 else ifeq ($(targetos), MinGW)
 CXXFLAGS += -D__WINDOWS_DS__
 LDFLAGS += -lole32 -ldsound -lwinmm
+CXXFLAGS += -D__WINDOWS_WASAPI__
+LDFLAGS += -lksuser
 # For ASIO when ready to try that:
 #OBJS += asio.o asiodrivers.o asiolist.o iasiothiscallresolver.o
 #CXXFLAGS +=-D__WINDOWS_ASIO__

--- a/src/modules/rtaudio/RtAudio.cpp
+++ b/src/modules/rtaudio/RtAudio.cpp
@@ -3683,6 +3683,7 @@ static const char* getAsioErrorString( ASIOError result )
 #include <avrt.h>
 #include <mmdeviceapi.h>
 #include <functiondiscoverykeys_devpkey.h>
+#include <math.h>
 
 //=============================================================================
 


### PR DESCRIPTION
These changes fix 6 channel support on Windows.

Example test:
# melt.exe ChID-BLITS-EBU.mp4 -consumer rtaudio channels=6
Previously that command would fail. Now it works on my Windows 10 system.

Tested on Windows and Linux.