### PR TITLE
Disable WASAPI in 32bit Windows build.

### DIFF
--- a/src/modules/rtaudio/Makefile
+++ b/src/modules/rtaudio/Makefile
@@ -22,8 +22,10 @@ LDFLAGS += -framework CoreAudio -framework CoreFoundation
 else ifeq ($(targetos), MinGW)
 CXXFLAGS += -D__WINDOWS_DS__
 LDFLAGS += -lole32 -ldsound -lwinmm
+ifdef ARCH_X86_64
 CXXFLAGS += -D__WINDOWS_WASAPI__
 LDFLAGS += -lksuser
+endif
 # For ASIO when ready to try that:
 #OBJS += asio.o asiodrivers.o asiolist.o iasiothiscallresolver.o
 #CXXFLAGS +=-D__WINDOWS_ASIO__


### PR DESCRIPTION
WASAPI is supported in Vista and newer.