### PR TITLE
Fix rotoscoping crash

### DIFF
--- a/src/modules/plusgpl/filter_rotoscoping.c
+++ b/src/modules/plusgpl/filter_rotoscoping.c
@@ -369,7 +369,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
                 blur( map, *width, *height, feather, mlt_properties_get_int( unique, "feather_passes" ) );
 
             int bpp;
-            size = mlt_image_format_size( *format, *width, *height, &bpp );
+            size = mlt_image_format_size( *format, *width, *height - 1, &bpp ); // mlt_image_format_size increments height!
             uint8_t *p = *image;
             uint8_t *q = *image + size;
 


### PR DESCRIPTION
mlt_image_format_size surprisingly increases height by 1 line, which causes memory copy out of source range.

This is the short-term minimal fix.

After a rapid look through the code, it seems to me that this extra line is unexpected in most places where this function is called.
Do you remember what it is for? Then would should add a comment...
Don't you think it would be better to remove this height change in the function, and adjust the few places where it is necessary? This could create regressions, in MLT but also in software calling it...