### PR TITLE
Fixing GCC warnings

### DIFF
--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -162,6 +162,10 @@ extern mlt_channel_layout mlt_channel_layout_default( int channels );
   y = ((263*r + 516*g + 100*b) >> 10) + 16;\
   u = ((-152*r - 300*g + 450*b) >> 10) + 128;\
   v = ((450*r - 377*g - 73*b) >> 10) + 128;
+/** This macro scales RGB into the YUV gamut - uv is scaled by 224/255 (y unused). */
+#define RGB2UV_601_SCALED(r, g, b, u, v)\
+  u = ((-152*r - 300*g + 450*b) >> 10) + 128;\
+  v = ((450*r - 377*g - 73*b) >> 10) + 128;
 
 /** This macro scales YUV up into the full gamut of the RGB color space. */
 #define YUV2RGB_601_SCALED( y, u, v, r, g, b ) \

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1648,7 +1648,7 @@ static void *consumer_thread( void *arg )
 	if ( enc_ctx->video_st ) {
 		converted_avframe = alloc_picture( enc_ctx->video_st->codec->pix_fmt, width, height );
 		if ( !converted_avframe ) {
-			mlt_log_error( MLT_CONSUMER_SERVICE( consumer ), "failed to allocate video AVFrame\n", filename );
+			mlt_log_error( MLT_CONSUMER_SERVICE( consumer ), "failed to allocate video AVFrame\n" );
 			mlt_events_fire( properties, "consumer-fatal-error", NULL );
 			goto on_fatal_error;
 		}

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -735,7 +735,7 @@ protected:
 							if( c < m_inChannels )
 							{
 								*dst = *src;
-								*src++;
+								src++;
 							}
 							else
 							{
@@ -746,7 +746,7 @@ protected:
 						for( c = 0; c < m_inChannels - m_outChannels; c++ )
 						{
 							// Drop samples if there are more in channels than out channels.
-							*src++;
+							src++;
 						}
 					}
 					pcm = outBuff;

--- a/src/modules/vmfx/filter_chroma.c
+++ b/src/modules/vmfx/filter_chroma.c
@@ -49,9 +49,9 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 	uint8_t r = ( key_val >> 24 ) & 0xff;
 	uint8_t g = ( key_val >> 16 ) & 0xff;
 	uint8_t b = ( key_val >>  8 ) & 0xff;
-	uint8_t y, u, v;
+	uint8_t u, v;
 
-	RGB2YUV_601_SCALED( r, g, b, y, u, v );
+	RGB2UV_601_SCALED( r, g, b, u, v );
 
 	*format = mlt_image_yuv422;
 	if ( mlt_frame_get_image( frame, image, format, width, height, writable ) == 0 )

--- a/src/modules/vmfx/filter_chroma_hold.c
+++ b/src/modules/vmfx/filter_chroma_hold.c
@@ -49,9 +49,9 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 	uint8_t r = ( key_val >> 24 ) & 0xff;
 	uint8_t g = ( key_val >> 16 ) & 0xff;
 	uint8_t b = ( key_val >>  8 ) & 0xff;
-	uint8_t y, u, v;
+	uint8_t u, v;
 
-	RGB2YUV_601_SCALED( r, g, b, y, u, v );
+	RGB2UV_601_SCALED( r, g, b, u, v );
 
 	*format = mlt_image_yuv422;
 	if ( mlt_frame_get_image( frame, image, format, width, height, writable ) == 0 )


### PR DESCRIPTION
Hello,
I'm in the process of cleaning the compile warnings we get by building MLT.
Some trivial changes...
the 1st commit in decklink module looks as a bug to me, but I don't have the hardware to test
the 2nd is mostly cosmetic, to avoid missing real issues

then the 3rd, 4th and 5th are targeting recent FFmpeg API.
This is a work in progress as consumer part is still unfixed, but before spending more time on it I would like to know what you think of it.
Handling "codec" to "codecpar" transition makes it difficult to support LibAv < 57.5 (2015/08): is it acceptable to drop older versions, or I should I use a macro to avoid making the switch too ugly?