### PR TITLE
Fix mono channel configuration for ladspa plugins.

### DIFF
--- a/src/modules/jackrack/filter_ladspa.c
+++ b/src/modules/jackrack/filter_ladspa.c
@@ -81,6 +81,7 @@ static jack_rack_t* initialise_jack_rack( mlt_properties properties, int channel
 					// Try to load again with a compatible number of channels.
 					mlt_log_warning( properties, "Not compatible with %d channels. Requesting %d channels instead.\n",
 						channels, request_channels );
+					jack_rack_destroy( jackrack );
 					jackrack = initialise_jack_rack( properties, request_channels );
 				}
 				else


### PR DESCRIPTION
Some plugins only operate on 2 channels. This change will satisfy those plugins when only one channel is requested by the consumer.