### PR TITLE
Handle key with colon in YAML.

### DIFF
--- a/src/framework/mlt_properties.c
+++ b/src/framework/mlt_properties.c
@@ -1519,6 +1519,12 @@ static int parse_yaml( yaml_parser context, const char *namevalue )
 	unsigned int indent = ltrim( &name );
 	mlt_properties properties = mlt_deque_peek_back( context->stack );
 
+	// Skip over colons in the key. Key/value separator must be ": ".
+	while ( ptr && ptr[1] != ' ' && ptr[1] != '\0' )
+	{
+		ptr = strchr( ptr + 1, ':' );
+	}
+
 	// Ascending one more levels in the tree
 	if ( indent < context->level )
 	{


### PR DESCRIPTION
Example: "shotcut:animIn: 68" would parse as:
 "shotcut=animIn: 68"
when it should be:
 "shotut:animIn=68"

This change will look for a colon folowed by a space as a key/value
separator.