### PR TITLE
Fix Qt version check in configure script

### DIFF
--- a/src/modules/qt/configure
+++ b/src/modules/qt/configure
@@ -61,7 +61,7 @@ else
 
 	echo > config.mak
 
-	if $(echo $qt_version | awk '{if ($0 + 0 > 5.6) exit 0; else exit 1;}')
+	if $(echo $qt_version | awk '{split($0, a, "."); if (a[1] >= 5 && a[2] > 6) exit 0; else exit 1;}')
 	then
 		echo "USE_CPP11=1" >> config.mak
 	fi


### PR DESCRIPTION
The existing script uses awk to convert the version number to a float,
then compares that to 5.6.  I have Qt 5.11 installed; numerically,
5.11 < 5.6, so it thinks I have an old version of Qt.  Fix this by
splitting by "." and comparing the version components individually.