### PR TITLE
Add generic text filter.

### DIFF
--- a/src/modules/plus/Makefile
+++ b/src/modules/plus/Makefile
@@ -20,6 +20,7 @@ OBJS = consumer_blipflash.o \
 	   filter_lumakey.o \
 	   filter_rgblut.o \
 	   filter_sepia.o \
+	   filter_text.o \
 	   producer_blipflash.o \
 	   producer_count.o \
 	   transition_affine.o

--- a/src/modules/plus/factory.c
+++ b/src/modules/plus/factory.c
@@ -1,6 +1,6 @@
 /*
  * factory.c -- the factory method interfaces
- * Copyright (C) 2003-2015 Meltytech, LLC
+ * Copyright (C) 2003-2018 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,6 +33,7 @@ extern mlt_filter filter_lumakey_init( mlt_profile profile, mlt_service_type typ
 extern mlt_filter filter_invert_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_filter filter_rgblut_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_filter filter_sepia_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
+extern mlt_filter filter_text_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_blipflash_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_count_init( const char *arg );
 extern mlt_transition transition_affine_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
@@ -63,6 +64,7 @@ MLT_REPOSITORY
 	MLT_REGISTER( filter_type, "lumakey", filter_lumakey_init );
 	MLT_REGISTER( filter_type, "rgblut", filter_rgblut_init );
 	MLT_REGISTER( filter_type, "sepia", filter_sepia_init );
+	MLT_REGISTER( filter_type, "text", filter_text_init );
 	MLT_REGISTER( producer_type, "blipflash", producer_blipflash_init );
 	MLT_REGISTER( producer_type, "count", producer_count_init );
 	MLT_REGISTER( transition_type, "affine", transition_affine_init );
@@ -83,6 +85,7 @@ MLT_REPOSITORY
 	MLT_REGISTER_METADATA( filter_type, "lumakey", metadata, "filter_lumakey.yml" );
 	MLT_REGISTER_METADATA( filter_type, "rgblut", metadata, "filter_rgblut.yml" );
 	MLT_REGISTER_METADATA( filter_type, "sepia", metadata, "filter_sepia.yml" );
+	MLT_REGISTER_METADATA( filter_type, "text", metadata, "filter_text.yml" );
 	MLT_REGISTER_METADATA( producer_type, "blipflash", metadata, "producer_blipflash.yml" );
 	MLT_REGISTER_METADATA( producer_type, "count", metadata, "producer_count.yml" );
 	MLT_REGISTER_METADATA( transition_type, "affine", metadata, "transition_affine.yml" );

--- a/src/modules/plus/filter_dynamictext.c
+++ b/src/modules/plus/filter_dynamictext.c
@@ -220,52 +220,6 @@ static void substitute_keywords(mlt_filter filter, char* result, char* value, ml
 	}
 }
 
-static int setup_producer( mlt_filter filter, mlt_producer producer, mlt_frame frame )
-{
-	mlt_properties my_properties = MLT_FILTER_PROPERTIES( filter );
-	mlt_properties producer_properties = MLT_PRODUCER_PROPERTIES( producer );
-	char* dynamic_text = mlt_properties_get( my_properties, "argument" );
-
-	if ( !dynamic_text || !strcmp( "", dynamic_text ) )
-		return 0;
-
-	// Apply keyword substitution before passing the text to the filter.
-	char result[MAX_TEXT_LEN] = "";
-	substitute_keywords( filter, result, dynamic_text, frame );
-	mlt_properties_set( producer_properties, "text", (char*)result );
-
-	// Pass the properties to the pango producer
-	mlt_properties_set( producer_properties, "family", mlt_properties_get( my_properties, "family" ) );
-	mlt_properties_set( producer_properties, "size", mlt_properties_get( my_properties, "size" ) );
-	mlt_properties_set( producer_properties, "weight", mlt_properties_get( my_properties, "weight" ) );
-	mlt_properties_set( producer_properties, "style", mlt_properties_get( my_properties, "style" ) );
-	mlt_properties_set( producer_properties, "fgcolour", mlt_properties_get( my_properties, "fgcolour" ) );
-	mlt_properties_set( producer_properties, "bgcolour", mlt_properties_get( my_properties, "bgcolour" ) );
-	mlt_properties_set( producer_properties, "olcolour", mlt_properties_get( my_properties, "olcolour" ) );
-	mlt_properties_set( producer_properties, "pad", mlt_properties_get( my_properties, "pad" ) );
-	mlt_properties_set( producer_properties, "outline", mlt_properties_get( my_properties, "outline" ) );
-	mlt_properties_set( producer_properties, "align", mlt_properties_get( my_properties, "halign" ) );
-
-	return 1;
-}
-
-static void setup_transition( mlt_frame frame, mlt_filter filter, mlt_transition transition )
-{
-	mlt_properties my_properties = MLT_FILTER_PROPERTIES( filter );
-	mlt_properties transition_properties = MLT_TRANSITION_PROPERTIES( transition );
-	mlt_position position = mlt_filter_get_position( filter, frame );
-	mlt_position length = mlt_filter_get_length2( filter, frame );
-
-	mlt_service_lock( MLT_TRANSITION_SERVICE(transition) );
-	mlt_rect rect = mlt_properties_anim_get_rect( my_properties, "geometry", position, length );
-	mlt_properties_set_rect( transition_properties, "rect", rect );
-	mlt_properties_set( transition_properties, "halign", mlt_properties_get( my_properties, "halign" ) );
-	mlt_properties_set( transition_properties, "valign", mlt_properties_get( my_properties, "valign" ) );
-	mlt_properties_set_int( transition_properties, "out", mlt_properties_get_int( my_properties, "_out" ) );
-	mlt_service_unlock( MLT_TRANSITION_SERVICE(transition) );
-}
-
-
 /** Get the image.
 */
 static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
@@ -273,55 +227,28 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 	int error = 0;
 	mlt_filter filter = mlt_frame_pop_service( frame );
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
-	mlt_producer producer = mlt_properties_get_data( properties, "_producer", NULL );
-	mlt_transition transition = mlt_properties_get_data( properties, "_transition", NULL );
-	mlt_frame b_frame = 0;
-	mlt_position position = 0;
+	char* dynamic_text = mlt_properties_get( properties, "argument" );
+	mlt_filter text_filter = mlt_properties_get_data( properties, "_text_filter", NULL );
+	mlt_properties text_filter_properties = MLT_FILTER_PROPERTIES( text_filter );
 
-	// Configure this filter
-	mlt_service_lock( MLT_FILTER_SERVICE( filter ) );
-	if ( !setup_producer( filter, producer, frame ) ) {
-		mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
+	if ( !dynamic_text || !strcmp( "", dynamic_text ) )
 		return mlt_frame_get_image( frame, image, format, width, height, writable );
-	}
-	setup_transition( frame, filter, transition );
 
-	// Make sure the producer is in the correct position
-	position = mlt_filter_get_position( filter, frame );
-	mlt_producer_seek( producer, position );
+	mlt_service_lock( MLT_FILTER_SERVICE( filter ) );
 
-	// Get the b frame and process with transition if successful
-	if ( mlt_service_get_frame( MLT_PRODUCER_SERVICE( producer ), &b_frame, 0 ) == 0 )
-	{
-		// This lock needs to also protect the producer properties from being
-		// modified in setup_producer() while also being used in mlt_service_get_frame().
-		mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
+	// Apply keyword substitution before passing the text to the filter.
+	char result[MAX_TEXT_LEN] = "";
+	substitute_keywords( filter, result, dynamic_text, frame );
+	mlt_properties_set( text_filter_properties, "argument", (char*)result );
+	mlt_properties_pass_list( text_filter_properties, properties,
+		"geometry family size weight style fgcolour bgcolour olcolour pad halign valign outline" );
+	mlt_filter_process( text_filter, frame );
 
-		// Get the a and b frame properties
-		mlt_properties a_props = MLT_FRAME_PROPERTIES( frame );
-		mlt_properties b_props = MLT_FRAME_PROPERTIES( b_frame );
+	// Get the image
+	*format = mlt_image_rgb24a;
+	error = mlt_frame_get_image( frame, image, format, width, height, writable );
 
-		// Set the b_frame to be in the same position and have same consumer requirements
-		mlt_frame_set_position( b_frame, position );
-		mlt_properties_set_int( b_props, "consumer_deinterlace", mlt_properties_get_int( a_props, "consumer_deinterlace" ) );
-
-		// Apply all filters that are attached to this filter to the b frame
-		mlt_service_apply_filters( MLT_FILTER_SERVICE( filter ), b_frame, 0 );
-
-		// Process the frame
-		mlt_transition_process( transition, frame, b_frame );
-
-		// Get the image
-		*format = mlt_image_rgb24a;
-		error = mlt_frame_get_image( frame, image, format, width, height, writable );
-
-		// Close the temporary frames
-		mlt_frame_close( b_frame );
-	}
-	else
-	{
-		mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
-	}
+	mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
 
 	return error;
 }
@@ -330,12 +257,6 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 */
 static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
 {
-	// Get the properties of the frame
-	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
-
-	// Save the frame out point
-	mlt_properties_set_int( MLT_FILTER_PROPERTIES( filter ), "_out", mlt_properties_get_int( properties, "out" ) );
-
 	// Push the filter on to the stack
 	mlt_frame_push_service( frame, filter );
 
@@ -350,30 +271,17 @@ static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
 mlt_filter filter_dynamictext_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
 {
 	mlt_filter filter = mlt_filter_new();
-	mlt_transition transition = mlt_factory_transition( profile, "affine", NULL );
-	mlt_producer producer = mlt_factory_producer( profile, mlt_environment( "MLT_PRODUCER" ), "qtext:" );
+	mlt_filter text_filter = mlt_factory_filter( profile, "text", NULL );
 
-	// Use pango if qtext is not available.
-	if( !producer )
-		producer = mlt_factory_producer( profile, mlt_environment( "MLT_PRODUCER" ), "pango:" );
+	if( !text_filter )
+		mlt_log_warning( MLT_FILTER_SERVICE(filter), "Unable to create text filter.\n" );
 
-	if( !producer )
-		mlt_log_warning( MLT_FILTER_SERVICE(filter), "QT or GTK modules required for dynamic text.\n" );
-
-	if ( filter && transition && producer )
+	if ( filter && text_filter )
 	{
 		mlt_properties my_properties = MLT_FILTER_PROPERTIES( filter );
 
-		// Register the transition for reuse/destruction
-		mlt_properties_set_int( MLT_TRANSITION_PROPERTIES(transition), "fill", 0 );
-		mlt_properties_set_int( MLT_TRANSITION_PROPERTIES(transition), "b_scaled", 1 );
-		mlt_properties_set_data( my_properties, "_transition", transition, 0, ( mlt_destructor )mlt_transition_close, NULL );
-
-		// Register the producer for reuse/destruction
-		mlt_properties_set_data( my_properties, "_producer", producer, 0, ( mlt_destructor )mlt_producer_close, NULL );
-
-		// Ensure that we loop
-		mlt_properties_set( MLT_PRODUCER_PROPERTIES( producer ), "eof", "loop" );
+		// Register the text filter for reuse/destruction
+		mlt_properties_set_data( my_properties, "_text_filter", text_filter, 0, ( mlt_destructor )mlt_filter_close, NULL );
 
 		// Assign default values
 		mlt_properties_set( my_properties, "argument", arg ? arg: "#timecode#" );
@@ -401,14 +309,9 @@ mlt_filter filter_dynamictext_init( mlt_profile profile, mlt_service_type type, 
 			mlt_filter_close( filter );
 		}
 
-		if( transition )
+		if( text_filter )
 		{
-			mlt_transition_close( transition );
-		}
-
-		if( producer )
-		{
-			mlt_producer_close( producer );
+			mlt_filter_close( text_filter );
 		}
 
 		filter = NULL;

--- a/src/modules/plus/filter_text.c
+++ b/src/modules/plus/filter_text.c
@@ -1,0 +1,207 @@
+/*
+ * filter_text.c -- text overlay filter
+ * Copyright (C) 2018 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void setup_producer( mlt_filter filter, mlt_producer producer, mlt_frame frame )
+{
+	mlt_properties my_properties = MLT_FILTER_PROPERTIES( filter );
+	mlt_properties producer_properties = MLT_PRODUCER_PROPERTIES( producer );
+
+	// Make sure the producer is in the correct position
+	mlt_producer_seek( producer, mlt_filter_get_position( filter, frame ) );
+
+	// Pass the properties to the text producer
+	mlt_properties_set( producer_properties, "text", mlt_properties_get( my_properties, "argument" ) );
+	mlt_properties_set( producer_properties, "family", mlt_properties_get( my_properties, "family" ) );
+	mlt_properties_set( producer_properties, "size", mlt_properties_get( my_properties, "size" ) );
+	mlt_properties_set( producer_properties, "weight", mlt_properties_get( my_properties, "weight" ) );
+	mlt_properties_set( producer_properties, "style", mlt_properties_get( my_properties, "style" ) );
+	mlt_properties_set( producer_properties, "fgcolour", mlt_properties_get( my_properties, "fgcolour" ) );
+	mlt_properties_set( producer_properties, "bgcolour", mlt_properties_get( my_properties, "bgcolour" ) );
+	mlt_properties_set( producer_properties, "olcolour", mlt_properties_get( my_properties, "olcolour" ) );
+	mlt_properties_set( producer_properties, "pad", mlt_properties_get( my_properties, "pad" ) );
+	mlt_properties_set( producer_properties, "outline", mlt_properties_get( my_properties, "outline" ) );
+	mlt_properties_set( producer_properties, "align", mlt_properties_get( my_properties, "halign" ) );
+}
+
+static void setup_transition( mlt_filter filter, mlt_transition transition, mlt_frame frame )
+{
+	mlt_properties my_properties = MLT_FILTER_PROPERTIES( filter );
+	mlt_properties transition_properties = MLT_TRANSITION_PROPERTIES( transition );
+	mlt_position position = mlt_filter_get_position( filter, frame );
+	mlt_position length = mlt_filter_get_length2( filter, frame );
+
+	mlt_service_lock( MLT_TRANSITION_SERVICE(transition) );
+	mlt_rect rect = mlt_properties_anim_get_rect( my_properties, "geometry", position, length );
+	mlt_properties_set_rect( transition_properties, "rect", rect );
+	mlt_properties_set( transition_properties, "halign", mlt_properties_get( my_properties, "halign" ) );
+	mlt_properties_set( transition_properties, "valign", mlt_properties_get( my_properties, "valign" ) );
+	mlt_properties_set_int( transition_properties, "out", mlt_properties_get_int( my_properties, "_out" ) );
+	mlt_service_unlock( MLT_TRANSITION_SERVICE(transition) );
+}
+
+
+/** Get the image.
+*/
+static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
+{
+	int error = 0;
+	mlt_filter filter = mlt_frame_pop_service( frame );
+	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
+	mlt_producer producer = mlt_properties_get_data( properties, "_producer", NULL );
+	mlt_transition transition = mlt_properties_get_data( properties, "_transition", NULL );
+	mlt_frame b_frame = 0;
+	char* argument = mlt_properties_get( properties, "argument" );
+
+	if ( !argument || !strcmp( "", argument ) )
+		return mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	// Configure this filter
+	mlt_service_lock( MLT_FILTER_SERVICE( filter ) );
+	setup_producer( filter, producer, frame );
+	setup_transition( filter, transition, frame );
+
+	// Get the b frame and process with transition if successful
+	if ( mlt_service_get_frame( MLT_PRODUCER_SERVICE( producer ), &b_frame, 0 ) == 0 )
+	{
+		// This lock needs to also protect the producer properties from being
+		// modified in setup_producer() while also being used in mlt_service_get_frame().
+		mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
+
+		// Get the a and b frame properties
+		mlt_properties a_props = MLT_FRAME_PROPERTIES( frame );
+		mlt_properties b_props = MLT_FRAME_PROPERTIES( b_frame );
+
+		// Set the b_frame to be in the same position and have same consumer requirements
+		mlt_frame_set_position( b_frame, mlt_filter_get_position( filter, frame ) );
+		mlt_properties_set_int( b_props, "consumer_deinterlace", mlt_properties_get_int( a_props, "consumer_deinterlace" ) );
+
+		// Apply all filters that are attached to this filter to the b frame
+		mlt_service_apply_filters( MLT_FILTER_SERVICE( filter ), b_frame, 0 );
+
+		// Process the frame
+		mlt_transition_process( transition, frame, b_frame );
+
+		// Get the image
+		*format = mlt_image_rgb24a;
+		error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+		// Close the temporary frames
+		mlt_frame_close( b_frame );
+	}
+	else
+	{
+		mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
+	}
+
+	return error;
+}
+
+/** Filter processing.
+*/
+static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
+{
+	// Get the properties of the frame
+	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
+
+	// Save the frame out point
+	mlt_properties_set_int( MLT_FILTER_PROPERTIES( filter ), "_out", mlt_properties_get_int( properties, "out" ) );
+
+	// Push the filter on to the stack
+	mlt_frame_push_service( frame, filter );
+
+	// Push the get_image on to the stack
+	mlt_frame_push_get_image( frame, filter_get_image );
+
+	return frame;
+}
+
+/** Constructor for the filter.
+*/
+mlt_filter filter_text_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	mlt_filter filter = mlt_filter_new();
+	mlt_transition transition = mlt_factory_transition( profile, "affine", NULL );
+	mlt_producer producer = mlt_factory_producer( profile, mlt_environment( "MLT_PRODUCER" ), "qtext:" );
+
+	// Use pango if qtext is not available.
+	if( !producer )
+		producer = mlt_factory_producer( profile, mlt_environment( "MLT_PRODUCER" ), "pango:" );
+
+	if( !producer )
+		mlt_log_warning( MLT_FILTER_SERVICE(filter), "QT or GTK modules required for text.\n" );
+
+	if ( filter && transition && producer )
+	{
+		mlt_properties my_properties = MLT_FILTER_PROPERTIES( filter );
+
+		// Register the transition for reuse/destruction
+		mlt_properties_set_int( MLT_TRANSITION_PROPERTIES(transition), "fill", 0 );
+		mlt_properties_set_int( MLT_TRANSITION_PROPERTIES(transition), "b_scaled", 1 );
+		mlt_properties_set_data( my_properties, "_transition", transition, 0, ( mlt_destructor )mlt_transition_close, NULL );
+
+		// Register the producer for reuse/destruction
+		mlt_properties_set_data( my_properties, "_producer", producer, 0, ( mlt_destructor )mlt_producer_close, NULL );
+
+		// Ensure that we loop
+		mlt_properties_set( MLT_PRODUCER_PROPERTIES( producer ), "eof", "loop" );
+
+		// Assign default values
+		mlt_properties_set( my_properties, "argument", arg ? arg: "text" );
+		mlt_properties_set( my_properties, "geometry", "0%/0%:100%x100%:100%" );
+		mlt_properties_set( my_properties, "family", "Sans" );
+		mlt_properties_set( my_properties, "size", "48" );
+		mlt_properties_set( my_properties, "weight", "400" );
+		mlt_properties_set( my_properties, "style", "normal" );
+		mlt_properties_set( my_properties, "fgcolour", "0x000000ff" );
+		mlt_properties_set( my_properties, "bgcolour", "0x00000020" );
+		mlt_properties_set( my_properties, "olcolour", "0x00000000" );
+		mlt_properties_set( my_properties, "pad", "0" );
+		mlt_properties_set( my_properties, "halign", "left" );
+		mlt_properties_set( my_properties, "valign", "top" );
+		mlt_properties_set( my_properties, "outline", "0" );
+
+		mlt_properties_set_int( my_properties, "_filter_private", 1 );
+
+		filter->process = filter_process;
+	}
+	else
+	{
+		if( filter )
+		{
+			mlt_filter_close( filter );
+		}
+
+		if( transition )
+		{
+			mlt_transition_close( transition );
+		}
+
+		if( producer )
+		{
+			mlt_producer_close( producer );
+		}
+
+		filter = NULL;
+	}
+	return filter;
+}

--- a/src/modules/plus/filter_text.yml
+++ b/src/modules/plus/filter_text.yml
@@ -1,0 +1,156 @@
+schema_version: 0.1
+type: filter
+identifier: text
+title: Text
+version: 1
+copyright: Meltytech, LLC
+creator: Brian Matherly
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+description: Overlay text onto the video
+
+parameters:
+  - identifier: argument
+    title: Text
+    type: string
+    description: |
+      The text to overlay.
+    required: yes
+    readonly: no
+    default: text
+    widget: text
+
+  - identifier: geometry
+    title: Geometry
+    type: geometry
+    description: A set of X/Y coordinates by which to adjust the text.
+    default: 0%/0%:100%x100%:100
+
+  - identifier: family
+    title: Font family
+    type: string
+    description: >
+      The typeface of the font.
+    default: Sans
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: size
+    title: Font size
+    type: integer
+    description: >
+      The size in pixels of the font. 
+    default: 48
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: style
+    title: Font style
+    type: string
+    description: >
+      The style of the font.
+    values:
+      - normal
+      - italic
+    default: normal
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: weight
+    title: Font weight
+    type: integer
+    description: The weight of the font.
+    minimum: 100
+    maximum: 1000
+    default: 400
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: fgcolour
+    title: Foreground color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x000000ff
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: bgcolour
+    title: Background color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x00000020
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: olcolour
+    title: Outline color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: outline
+    title: Outline Width
+    type: string
+    description: >
+      The width of the outline in pixels.
+    readonly: no
+    default: 0
+    minimum: 0
+    maximum: 3
+    mutable: yes
+    widget: spinner
+
+  - identifier: pad
+    title: Padding
+    type: integer
+    description: >
+      The number of pixels to pad the background rectangle beyond edges of text.
+    readonly: no
+    default: 0
+    mutable: yes
+    widget: spinner
+
+  - identifier: halign
+    title: Horizontal alignment
+    description: >
+      Set the horizontal alignment within the geometry rectangle.
+    type: string
+    default: left
+    values:
+      - left
+      - centre
+      - right
+    mutable: yes
+    widget: combo
+
+  - identifier: valign
+    title: Vertical alignment
+    description: >
+      Set the vertical alignment within the geometry rectangle.
+    type: string
+    default: top
+    values:
+      - top
+      - middle
+      - bottom
+    mutable: yes
+    widget: combo


### PR DESCRIPTION
The text filter can be encapsulated by specialized text filters like
dynamictext to add additional functionality.

I've been sitting on this while I develop the timer filter (which will use filter_text). But I am tired of merging in bug fixes that you have been making. So I hope this can be merged while I continue to work on the timer filter.