### PR TITLE
Doxygen and  misc. typos fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -116,7 +116,7 @@
 
 2018-05-11  Dan Dennedy <dan@dennedy.org>
 
-  * configure, src/framework/mlt_version.h: Set interm version to 6.9.0
+  * configure, src/framework/mlt_version.h: Set interim version to 6.9.0
 
 2018-05-10  Dan Dennedy <dan@dennedy.org>
 
@@ -171,7 +171,7 @@
   src/modules/rtaudio/consumer_rtaudio.cpp: Improve surround support in RtAudio
   on Windows.  The directsound implementation in RtAudio does not support > 2
   channels. But the WASAPI implementation does. This change will try all
-  available drivers to try to sucessfully open the audio device. If none of the
+  available drivers to try to successfully open the audio device. If none of the
   drivers work with surround, then it will revert to 2 channels.  In the case
   that the module reverts to 2 channels, the requested number of channels will
   still be processed, but only the first two channels will be output.  These
@@ -185,7 +185,7 @@
   src/modules/sdl2/consumer_sdl2_audio.c: Improve surround support in SDL2 on
   Windows.  The directsound implementation in SDL does not support > 2
   channels. But the xaudio2 implementation does. This change will try all
-  available drivers to try to sucessfully open the audio device. If none of the
+  available drivers to try to successfully open the audio device. If none of the
   drivers work with surround, then it will revert to 2 channels.  The user can
   still request a specific driver using the audio_driver parameter.
 
@@ -402,7 +402,7 @@
   src/modules/avformat/filter_avcolour_space.c,
   src/modules/avformat/filter_avdeinterlace.c,
   src/modules/avformat/filter_swscale.c,
-  src/modules/avformat/producer_avformat.c: Stop using deprectated AVPicture
+  src/modules/avformat/producer_avformat.c: Stop using deprecated AVPicture
   API.
 
 2017-09-10  Dan Dennedy <dan@dennedy.org>
@@ -467,7 +467,7 @@
   src/framework/mlt_service.h, src/mlt++/MltService.cpp,
   src/mlt++/MltService.h, src/mlt++/mlt++.vers: Add function to disconnect all
   producers (#226)  * Add function to disconnect all producers  * Add forgotten
-  versionning  * Change logic to avoid consumer disconnection
+  versioning  * Change logic to avoid consumer disconnection
 
 2017-03-27  Vincent Pinon <vpinon@kde.org>
 
@@ -546,7 +546,7 @@
 
   * src/framework/mlt.vers, src/framework/mlt_log.c, src/framework/mlt_log.h,
   src/melt/melt.c, src/modules/avformat/producer_avformat.c: Timestamped
-  logging and timings measurment implemented
+  logging and timings measurement implemented
 
 2017-02-06  Dan Dennedy <dan@dennedy.org>
 
@@ -1752,7 +1752,7 @@
   invalid object so that empty frames can be predeclared without the expense of
   initializing an empty frame only to destroy it all when it is actually
   assigned to a frame.  The const copy constructor duplicates the non-const
-  constructor, but is useful so that frames can be initialized from tempory
+  constructor, but is useful so that frames can be initialized from temporary
   variables.  The copy operator= is necessary so that frames can be stored in
   containers.  Additionally, with this change, Mlt::Frame implements "the big
   three" which is a good practice.
@@ -2196,7 +2196,7 @@
   src/framework/mlt_tractor.c, src/framework/mlt_transition.c,
   src/modules/core/consumer_multi.c: Add support for color_trc (transfer
   characteristic) to framework.  Frames and consumers can now have a color_trc
-  property. Setting color_trc on the consumer propogates to a
+  property. Setting color_trc on the consumer propagates to a
   consumer_color_trc property on the frame.
 
 2014-07-20  Dan Dennedy <dan@dennedy.org>
@@ -2358,7 +2358,7 @@
   src/modules/opengl/filter_movit_white_balance.cpp,
   src/modules/opengl/transition_movit_luma.cpp,
   src/modules/opengl/transition_movit_mix.cpp: Hide the movit.parms properties
-  from serialization.  These properties were adding unncessary noise in the XML
+  from serialization.  These properties were adding unnecessary noise in the XML
   output.
 
 2014-04-04  Dan Dennedy <dan@dennedy.org>
@@ -3444,7 +3444,7 @@
 2013-03-17  Dan Dennedy <dan@dennedy.org>
 
   * src/modules/frei0r/factory.c, src/modules/frei0r/frei0r_helper.c: Switch to
-  indexed propery names for frei0r params.  Properties supplied by frei0r param
+  indexed property names for frei0r params.  Properties supplied by frei0r param
   name are supported for backwards compatibility.
 
 2013-03-13  Dan Dennedy <dan@dennedy.org>
@@ -3586,7 +3586,7 @@
 
 2013-02-13  Cristian Morales Vega <reddwarf@opensuse.org>
 
-  * src/framework/Makefile, src/mlt++/Makefile: Fix OSX buld which broke when
+  * src/framework/Makefile, src/mlt++/Makefile: Fix OSX build which broke when
   adding Linux symbols versioning
 
 2013-02-10  Dan Dennedy <dan@dennedy.org>
@@ -4351,7 +4351,7 @@
   src/modules/sdl/producer_sdl_image.yml: deprecate sdl_image
 
   * src/mlt++/MltFrame.cpp, src/mlt++/MltFrame.h: make Frame::get_position()
-  retrun type consistent
+  return type consistent
 
 2012-02-12  Simon A. Eugster <simon.eu@gmail.com>
 
@@ -4448,7 +4448,7 @@
   src/modules/videostab/stabilize.c, src/modules/videostab/stabilize.h,
   src/modules/videostab/transform_image.c,
   src/modules/videostab/transform_image.h: use calloc insteadt of malloc/memset
-  use struct for instance data small cleanup use PIX(n) dont use instable
+  use struct for instance data small cleanup use PIX(n) don't use instable
   yuv420 use stabilize on grayimage (converted from yuv422)
 
 2011-11-21  Marco Gittler <g.marco@freenet.de>
@@ -4474,7 +4474,7 @@
   src/modules/videostab/stabilize.c, src/modules/videostab/stabilize.h,
   src/modules/videostab/transform_image.c,
   src/modules/videostab/transform_image.h: use calloc insteadt of malloc/memset
-  use struct for instance data small cleanup use PIX(n) dont use instable
+  use struct for instance data small cleanup use PIX(n) don't use instable
   yuv420 use stabilize on grayimage (converted from yuv422)
 
 2011-11-21  Marco Gittler <g.marco@freenet.de>
@@ -4596,7 +4596,7 @@
   move printf -> mlt_log*
 
   * src/modules/videostab/filter_videostab2.c,
-  src/modules/videostab/stabilize.c: set all paramters
+  src/modules/videostab/stabilize.c: set all parameters
 
   * src/modules/videostab/filter_videostab2.c,
   src/modules/videostab/stabilize.c, src/modules/videostab/stabilize.h,
@@ -5223,7 +5223,7 @@
 
   * src/modules/dv/Makefile, src/modules/dv/consumer_libdv.yml,
   src/modules/dv/factory.c, src/modules/dv/producer_libdv.yml: Add service
-  metdata for dv module (WIP).
+  metadata for dv module (WIP).
 
   * src/modules/core/Makefile, src/modules/core/factory.c,
   src/modules/core/filter_audiowave.yml,
@@ -5837,7 +5837,7 @@
   src/modules/rotoscoping/filter_rotoscoping.c: Rotoscoping: Add support for
   simple keyframes - current limits: - number of points has to be equal for all
   keyframes - points have to be in "correct" order (1. point in 1. kf will be
-  moved to 1. point in 2. kf, ...) - the parameter "polygon" is now formated
+  moved to 1. point in 2. kf, ...) - the parameter "polygon" is now formatted
   using json: - no keyframes: polygon="[[x,y], [x,y], ...]" - keyframes:
   polygon= '{ "framepos1" : [[x,y], [x,y], ...], "framepos2" : [[x,y], [x,y],
   ...], ...}'
@@ -5860,7 +5860,7 @@
   CC for linking C++ (3090682)
 
   * src/modules/sdl/consumer_sdl_audio.c,
-  src/modules/sdl/consumer_sdl_preview.c: Fix undefined bahavior in SDL module
+  src/modules/sdl/consumer_sdl_preview.c: Fix undefined behavior in SDL module
   (3066195).  The standard says the post-increment can have effect at any point
   between the previous and the next sequence point (or something similar), so
   the behavior of "this->refresh_count = this->refresh_count ++" is undefined. 
@@ -5989,7 +5989,7 @@
   kdenlivetitle (kdenlive-1841).  Patch below fixes an issue with the
   kdenlivetitle producer. Basically, the problem was that when loading a
   kdenlivetitle from a file, all the properties were serialized and passed to
-  the xml consumer.  The problem became more obvious with the "embeded" images
+  the xml consumer.  The problem became more obvious with the "embedded" images
   in titles, which then caused images to be embedded inside the kdenlive
   project file, causing problems like reported in this issue: 
   http://kdenlive.org/mantis/view.php?id=1841  With the patch, titles loaded
@@ -6629,7 +6629,7 @@
   also bug in wrong y center
 
   * src/modules/oldfilm/filter_vignette.c,
-  src/modules/oldfilm/filter_vignette.yml: use extra paramters for vignette
+  src/modules/oldfilm/filter_vignette.yml: use extra parameters for vignette
   settings
 
 2009-10-10  Dan Dennedy <dan@dennedy.org>
@@ -7196,7 +7196,7 @@
   src/modules/melt/Makefile, src/modules/{valerie => mvsp}/Makefile,
   src/modules/mvsp/configure, .../consumer_valerie.c => mvsp/consumer_mvsp.c},
   src/modules/{valerie => mvsp}/factory.c, src/modules/xml/Makefile,
-  src/modules/xml/configure: Fix the build afer the reorg.
+  src/modules/xml/configure: Fix the build after the reorg.
 
   * docs/{inigo.txt => melt.txt}, docs/{westley.txt => mlt-xml.txt}, src/{inigo
   => melt}/Makefile, src/{inigo => melt}/configure, src/{inigo => melt}/io.c,
@@ -7816,7 +7816,7 @@
 2008-06-26  ddennedy <ddennedy@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
   * mlt++/src/MltProducer.cpp, mlt++/src/MltProducer.h, mlt++/swig/mltpp.i:
-  MltProducer.{h,cpp}, mltpp.i: remove Producer::get_frame that is unncessary
+  MltProducer.{h,cpp}, mltpp.i: remove Producer::get_frame that is unnecessary
   and introduced a memory leak. 
 
 2008-06-01  ddennedy <ddennedy@d19143bc-622f-0410-bfdd-b5b2a6649095>
@@ -7907,7 +7907,7 @@
 
   * src/modules/sox/Makefile, src/modules/sox/configure: sox/configure,
   Makefile: try to make sox build smarter about library dependencies (pending
-  Darwin compatibilty) 
+  Darwin compatibility) 
 
   * src/framework/metaschema.yaml, src/modules/avformat/producer_avformat.yml:
   metaschema.yaml, producer_avformat.yml: reset schema_version to 0.1 since we
@@ -8045,7 +8045,7 @@
   register their service factory functions mlt_factory.[hc]: change
   mlt_factory_init() to return mlt_repository to app mlt_properties.c: let
   mlt_properties_dir_list() take a NULL filter pattern src/modules/*: - adapt
-  to new module registration system - much simpler! - remove unncessary
+  to new module registration system - much simpler! - remove unnecessary
   configure scripts (now optional!)   
 
 2008-02-04  ddennedy <ddennedy@d19143bc-622f-0410-bfdd-b5b2a6649095>
@@ -8833,7 +8833,7 @@
   Added an output aspect ratio (being the aspect ratio of the background) 
   src/modules/core/filter_rescale.c + Force a rescale of the alpha in parallel
   with image  src/modules/core/filter_resize.c + Rounding errors corrections 
-  src/modules/core/filter_watermark.c + Propogation of output aspect ratio in
+  src/modules/core/filter_watermark.c + Propagation of output aspect ratio in
   reverse case  src/modules/core/producer_colour.c + Reassign aspect ratio
   after get_image  src/modules/core/transition_composite.c + More uneven width
   corrections + Use of output aspect ratio when available 
@@ -8848,7 +8848,7 @@
   Correction for uneven width  filter_avdeinterlace.c + Correction for cases
   were the interlace state of frame is only known after rendering 
   producer_avformat.c + Corrections for uneven width + Corrections for state
-  propogation of top field first and interlaced state  
+  propagation of top field first and interlaced state  
 
 2005-09-15  lilo_booter <lilo_booter@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
@@ -8858,8 +8858,8 @@
   src/modules/core/producer_colour.c, src/modules/core/transition_composite.c,
   src/modules/plus/filter_sepia.c, src/modules/plus/transition_affine.c,
   src/modules/sdl/consumer_sdl.c: src/framework/mlt_frame.c + Removed
-  unecessary even pixel position and width dependency + Rewrote resize methods
-  to accomodate uneven widths  src/framework/mlt_frame.h + Correct RGB2YUV -
+  unnecessary even pixel position and width dependency + Rewrote resize methods
+  to accommodate uneven widths  src/framework/mlt_frame.h + Correct RGB2YUV -
   now 2^10 based and range checks removed (not needed) 
   src/framework/mlt_producer.c + Check for unspecified eof property 
   src/modules/avformat/producer_avformat.c + Provide forced aspect ratio
@@ -10067,7 +10067,7 @@
 2004-09-18  lilo_booter <lilo_booter@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
   * Makefile, src/humperdink/Makefile, src/modules/dv/producer_libdv.c: Build
-  fix and temporary libdv compatability  
+  fix and temporary libdv compatibility  
 
 2004-09-17  lilo_booter <lilo_booter@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
@@ -10535,7 +10535,7 @@
   src/framework/mlt_property.h, src/framework/mlt_repository.h,
   src/framework/mlt_service.c, src/framework/mlt_service.h,
   src/framework/mlt_tokeniser.h, src/framework/mlt_tractor.h,
-  src/framework/mlt_transition.h: C++ compatability  
+  src/framework/mlt_transition.h: C++ compatibility  
 
 2004-04-19  lilo_booter <lilo_booter@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
@@ -10720,7 +10720,7 @@
   * demo/mlt_fade_black, demo/mlt_push, demo/mlt_squeeze, docs/TODO,
   docs/dvcp.txt, docs/framework.txt, docs/inigo.txt, docs/install.txt,
   docs/services.txt, docs/testing.txt, docs/valerie.txt, docs/westley.txt: Doc
-  formating  
+  formatting  
 
 2004-03-26  ddennedy <ddennedy@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
@@ -11151,7 +11151,7 @@
   src/modules/fezzik/producer_fezzik.c: Minor fixes  
 
   * src/modules/core/transition_luma.c, src/modules/sdl/consumer_sdl.c: sdl
-  rework (prepatory read-ahead implementation) and luma work around  
+  rework (preparatory read-ahead implementation) and luma work around  
 
   * src/framework/mlt_pool.c, src/framework/mlt_pool.h,
   src/modules/core/transition_luma.c: Big luma optimisations, minor pooling
@@ -11821,13 +11821,13 @@
 
   * docs/services.txt, mlt/docs/services.txt,
   mlt/src/modules/gtk2/producer_pixbuf.c, src/modules/gtk2/producer_pixbuf.c:
-  doc updates and better control of pixbuf composite property propogation  
+  doc updates and better control of pixbuf composite property propagation  
 
   * mlt/src/inigo/inigo.c, mlt/src/modules/core/transition_composite.c,
   mlt/src/modules/gtk2/producer_pango.c, mlt/src/modules/gtk2/producer_pango.h,
   src/inigo/inigo.c, src/modules/core/transition_composite.c,
   src/modules/gtk2/producer_pango.c, src/modules/gtk2/producer_pango.h: better
-  propogating of producer and transition properties to the frame in pango and
+  propagating of producer and transition properties to the frame in pango and
   composite; add pango support to inigo  
 
 2004-01-11  ddennedy <ddennedy@d19143bc-622f-0410-bfdd-b5b2a6649095>
@@ -12260,7 +12260,7 @@
 2003-12-22  lilo_booter <lilo_booter@d19143bc-622f-0410-bfdd-b5b2a6649095>
 
   * mlt/src/framework/mlt.h, mlt/src/framework/mlt_repository.c,
-  src/framework/mlt.h, src/framework/mlt_repository.c: c++ compatability  
+  src/framework/mlt.h, src/framework/mlt_repository.c: c++ compatibility  
 
   * README, mlt/README, mlt/src/framework/Makefile, mlt/src/framework/mlt.h,
   mlt/src/framework/mlt_factory.c, mlt/src/framework/mlt_factory.h,

--- a/Doxyfile
+++ b/Doxyfile
@@ -269,10 +269,10 @@ TYPEDEF_HIDES_STRUCT = NO
 # For small to medium size projects (<1000 input files) the default value is 
 # probably good enough. For larger projects a too small cache size can cause 
 # doxygen to be busy swapping symbols to and from disk most of the time 
-# causing a significant performance penality. 
+# causing a significant performance penalty. 
 # If the system has enough physical memory increasing the cache will improve the 
 # performance by keeping more symbols in memory. Note that the value works on 
-# a logarithmic scale so increasing the size by one will rougly double the 
+# a logarithmic scale so increasing the size by one will roughly double the 
 # memory usage. The cache size is given by this formula: 
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0, 
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/NEWS
+++ b/NEWS
@@ -172,7 +172,7 @@ Modules
   * Fixed reporting accurage length for image sequences in qimage and pixbuf.
   * Fixed extra audio samples added to end of file in avformat consumer.
   * Fixed rawvideo export in avformat consumer.
-  * Fixed multi-threading wtih FFmpeg 3.2+ in avformat module.
+  * Fixed multi-threading with FFmpeg 3.2+ in avformat module.
   * Fixed JPEG album art in avformat producer.
   * Removed filter_avresample (dropped by FFmpeg).
   * Stop flushing audio buffer in decklink consumer.
@@ -212,7 +212,7 @@ Modules
   * Added qtblend transition and filter to qt module.
   * Added ndi (NewTek NDI) module with producer and consumer.
   * Added opencv module with opencv_tracker filter.
-  * Added line_spacing, strech, wrap_width, and wrap_type properties to
+  * Added line_spacing, stretch, wrap_width, and wrap_type properties to
     pango producer.
   * Added oblique value for style property to pango producer.
   * Added fontmap-reload event to pango producer.
@@ -362,7 +362,7 @@ Modules
 Version 0.9.6 - March 1, 2015
 
 A major regression slipped into the 0.9.4 release plus some other good fixes
-rolled in just afer that release prompting this new release. Please discontinue
+rolled in just after that release prompting this new release. Please discontinue
 using version 0.9.4 and upgrade.
 
 
@@ -425,7 +425,7 @@ Framework
 Modules
   * Renamed "qimage" module to "qt".
   * Added support for Qt 5.
-  * Added qtext producer, which is now prefered by dynamictext filter over pango.
+  * Added qtext producer, which is now preferred by dynamictext filter over pango.
   * Added xml-nogl consumer.
   * Consolidated dgraft, burningtv, and rotoscoping into new plusgpl module.
   * Added vid.stab module with vidstab and deshake filters.
@@ -540,7 +540,7 @@ Version 0.7.8 - February 13, 2012
 This is a bugfix and minor enhancement release.
 
 * Improved support for v53 of libavcodec/libavformat
-* Added "multi" consumer - multiple, simultanous outputs
+* Added "multi" consumer - multiple, simultaneous outputs
 * Added framerate adaption to "consumer" producer and "multi" consumer
 * Can now use YADIF deinterlacer with decklink producer
 * Added "rtaudio" consumer for native audio support on multiple platforms
@@ -611,7 +611,7 @@ Other
  * Added presets for DVD, DV, x264, and WebM encoding.
 
 Since FFmpeg forked and there were a few releases, there is no recommended
-version at this time. With that said, there were changes to accomodate the
+version at this time. With that said, there were changes to accommodate the
 API changes with some moderate testing of the 0.6, 0.7, and 0.8 series
 releases of both FFmpeg and Libav.
 
@@ -641,7 +641,7 @@ The recommended version of FFmpeg for use with this release is 0.6.1.
 
 Version 0.7.0 - March 27, 2011
 
-This is a major new release due to signficant additions to API, framework,
+This is a major new release due to significant additions to API, framework,
 and build.
 
 Build

--- a/demo/README
+++ b/demo/README
@@ -66,7 +66,7 @@ A composite transition
 	
 Fade in and out
 
-	A simple series of transitions betwen 3 clips using dissolves and audio 
+	A simple series of transitions between 3 clips using dissolves and audio 
 	crossfades. This is easy :-).
 
 Clock in and out

--- a/docs/framework.txt
+++ b/docs/framework.txt
@@ -351,7 +351,7 @@ Playlists:
 	and we have a means to play multiple clips.
 
 	[*] This reference functionality was introduced in mlt 0.1.2 - it is 100%
-	compatable with the early mechanism of registering the reference and 
+	compatible with the early mechanism of registering the reference and 
 	destructor with the properties of the playlist object.
 
 

--- a/docs/install.txt
+++ b/docs/install.txt
@@ -8,7 +8,7 @@ Last Revision: 2013-09-07
 
 ---++ Directories
 
-   The directory heirarchy is defined as follows:
+   The directory hierarchy is defined as follows:
 
    * demo                - A selection of samples to show off capabilities.
    * docs                - Location of all documentation

--- a/docs/melt.txt
+++ b/docs/melt.txt
@@ -98,7 +98,7 @@ Terminology:
 	Collectively, these are known as 'services'. 
 	
 	All services have 'properties' associated to them. These are typically
-	defaulted or evaluated and may be overriden on a case by case basis.
+	defaulted or evaluated and may be overridden on a case by case basis.
 	
 	All services except consumers obey in and out properties.
 	
@@ -201,7 +201,7 @@ Attached Filters:
 	localise filters to a specific clip on a track, you have to know information
 	about the lengths of the clip and all clips leading up to it. In practise, 
 	this is horrifically impractical, especially at a command line level (and not
-	even that practical from a programing point of view...).
+	even that practical from a programming point of view...).
 
 	The -attach family of switches simplify things enormously. By default, -attach
 	will attach a filter to the last service created, so:
@@ -236,7 +236,7 @@ Mixes:
 
 	would provide both an audio and video transition between clip1 and clip2.
 
-	This functionality supercedes the enforced use of the -track and -transition
+	This functionality supersedes the enforced use of the -track and -transition
 	switches from earlier versions of melt and makes life a lot easier :-).
 
 	These can be used in combination, so you can for example do a fade from black

--- a/docs/mlt++.txt
+++ b/docs/mlt++.txt
@@ -323,7 +323,7 @@ Mix
 
 	There is a convenience function which simplifies the process of applying 
 	transitions betwee adjacent cuts on a playlist. This is often preferable 
-	to use over the constuction of your own tractor and transition set up.
+	to use over the construction of your own tractor and transition set up.
 
 	To apply a 25 frame luma transition between the first and second cut on 
 	the playlist, you could use:
@@ -377,7 +377,7 @@ That's All Folks...
 
 	And that, believe it or not, is a fairly complete summary of the classes you'll 
 	typically be interfacing with in mlt++. Obviously, there's a little more to it 
-	than this - a couple of intrisinc classes have been glossed over (notably, the 
+	than this - a couple of intrinsic classes have been glossed over (notably, the 
 	Properties and Service base classes). The next section will cover all of the 
 	above, but in much more detail...
 

--- a/docs/mlt-xml.txt
+++ b/docs/mlt-xml.txt
@@ -292,7 +292,7 @@ Tractors:
 	Tracks act like "layers" in an image processing program like the GIMP. The 
 	bottom-most track takes highest priority and higher layers are overlays 
 	and do not appear unless there are gaps in the lower layers or unless
-	a transition is applied that merges the tracks on the specifed region.
+	a transition is applied that merges the tracks on the specified region.
 	Practically speaking, for A/B video editing it does not mean too much, 
 	and it will work as expected; however, as a general rule apply any CGI
 	(graphic overlays with pixbuf or titles with pango) on tracks higher than
@@ -502,7 +502,7 @@ Entities and Parameterisation:
 	
 	There are a couple of rules of usage. The melted LOAD command and melt
 	command line tool require you to preface the URL with "xml:" because
-	the query string destroys the filename extension matching peformed by
+	the query string destroys the filename extension matching performed by
 	the auto-loader. Also, melt looks for '=' to tokenise property settings.
 	Therefore, one uses ':' between name and value instead of '='. Finally,
 	since melt is run from the shell, one must enclose the URL within single
@@ -515,7 +515,7 @@ Entities and Parameterisation:
 	
 	Technically, the entity declaration is not needed in the head of the XML
 	document if you always supply the parameter. However, you run the risk
-	of unpredictable behviour without one. Therefore, it is safest and a best
+	of unpredictable behaviour without one. Therefore, it is safest and a best
 	practice to always supply an entity declaration. It is improves the 
 	readability as one does not need to search for the entity references to 
 	see what parameters are available.

--- a/src/framework/mlt_animation.c
+++ b/src/framework/mlt_animation.c
@@ -66,7 +66,7 @@ mlt_animation mlt_animation_new( )
 	return self;
 }
 
-/** Re-interpolate non-keyframe nodess after a series of insertions or removals.
+/** Re-interpolate non-keyframe nodes after a series of insertions or removals.
  *
  * \public \memberof mlt_animation_s
  * \param self an animation
@@ -311,8 +311,8 @@ void mlt_animation_set_length( mlt_animation self, int length )
  * of the animation for the parsing (e.g. fps, locale).
  * It parses into a mlt_animation_item that you provide.
  * \p item->frame should be specified if the string does not have an equal sign and time field.
- * If an exclamation point (!) or vertical bar (|) character preceeds the equal sign, then
- * the keyframe interpolation is set to discrete. If a tilde (~) preceeds the equal sign,
+ * If an exclamation point (!) or vertical bar (|) character precedes the equal sign, then
+ * the keyframe interpolation is set to discrete. If a tilde (~) precedes the equal sign,
  * then the keyframe interpolation is set to smooth (spline).
  *
  * \public \memberof mlt_animation_s
@@ -343,7 +343,7 @@ int mlt_animation_parse_item( mlt_animation self, mlt_animation_item item, const
 			item->frame = mlt_property_get_int( item->property, self->fps, self->locale );
 			free( s );
 
-			// The character preceeding the equal sign indicates interpolation method.
+			// The character preceding the equal sign indicates interpolation method.
 			p = strchr( value, '=' ) - 1;
 			if ( p[0] == '|' || p[0] == '!' )
 				item->keyframe_type = mlt_keyframe_discrete;
@@ -393,7 +393,7 @@ int mlt_animation_get_item( mlt_animation self, mlt_animation_item item, int pos
 	if (!self || !item) return 1;
 
 	int error = 0;
-	// Need to find the nearest keyframe to the position specifed
+	// Need to find the nearest keyframe to the position specified
 	animation_node node = self->nodes;
 
 	// Iterate through the keyframes until we reach last or have
@@ -577,7 +577,7 @@ int mlt_animation_next_key( mlt_animation self, mlt_animation_item item, int pos
 	return ( node == NULL );
 }
 
-/** Get the keyfame at the position or the next preceeding.
+/** Get the keyfame at the position or the next preceding.
  *
  * \public \memberof mlt_animation_s
  * \param self an animation

--- a/src/framework/mlt_cache.c
+++ b/src/framework/mlt_cache.c
@@ -208,7 +208,7 @@ mlt_cache mlt_cache_init()
 	return result;
 }
 
-/** Set the numer of items to cache.
+/** Set the number of items to cache.
  *
  * This must be called before using the cache. The size can not be more
  * than \p MAX_CACHE_SIZE.
@@ -223,7 +223,7 @@ void mlt_cache_set_size( mlt_cache cache, int size )
 		cache->size = size;
 }
 
-/** Get the numer of possible cache items.
+/** Get the number of possible cache items.
  *
  * \public \memberof mlt_cache_s
  * \param cache the cache to check
@@ -347,7 +347,7 @@ static void** shuffle_get_hit( mlt_cache cache, void *object )
 /** Put a chunk of data in the cache.
  *
  * This function and mlt_cache_get() are not scalable with a large volume
- * of unique \p object paramter values. Therefore, it does not make sense
+ * of unique \p object parameter values. Therefore, it does not make sense
  * to use it for a frame/image cache using the frame position for \p object.
  * Instead, use mlt_cache_put_frame() for that.
  *

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -208,7 +208,7 @@ static void mlt_consumer_property_changed( mlt_properties owner, mlt_consumer se
 {
 	if ( !strcmp( name, "mlt_profile" ) )
 	{
-		// Get the properies
+		// Get the properties
 		mlt_properties properties = MLT_CONSUMER_PROPERTIES( self );
 
 		// Get the current profile
@@ -516,7 +516,7 @@ int mlt_consumer_start( mlt_consumer self )
 	// Stop listening to the property-changed event
 	mlt_event_block( priv->event_listener );
 
-	// Get the properies
+	// Get the properties
 	mlt_properties properties = MLT_CONSUMER_PROPERTIES( self );
 
 	// Determine if there's a test card producer
@@ -617,7 +617,7 @@ int mlt_consumer_put_frame( mlt_consumer self, mlt_frame frame )
 {
 	int error = 1;
 
-	// Get the service assoicated to the consumer
+	// Get the service associated to the consumer
 	mlt_service service = MLT_CONSUMER_SERVICE( self );
 
 	if ( mlt_service_producer( service ) == NULL )
@@ -663,7 +663,7 @@ mlt_frame mlt_consumer_get_frame( mlt_consumer self )
 	// Frame to return
 	mlt_frame frame = NULL;
 
-	// Get the service assoicated to the consumer
+	// Get the service associated to the consumer
 	mlt_service service = MLT_CONSUMER_SERVICE( self );
 
 	// Get the consumer properties
@@ -1153,7 +1153,7 @@ static void consumer_work_start( mlt_consumer self )
 	priv->ahead = 1;
 	priv->threads = thread;
 	
-	// These keep track of the accelleration of frame dropping or recovery.
+	// These keep track of the acceleration of frame dropping or recovery.
 	priv->consecutive_dropped = 0;
 	priv->consecutive_rendered = 0;
 	
@@ -1639,7 +1639,7 @@ void mlt_consumer_stopped( mlt_consumer self )
 
 int mlt_consumer_stop( mlt_consumer self )
 {
-	// Get the properies
+	// Get the properties
 	mlt_properties properties = MLT_CONSUMER_PROPERTIES( self );
 	consumer_private *priv = self->local;
 

--- a/src/framework/mlt_field.c
+++ b/src/framework/mlt_field.c
@@ -173,7 +173,7 @@ int mlt_field_plant_filter( mlt_field self, mlt_filter that, int track )
 	// Connect the filter to the last producer
 	int result = mlt_filter_connect( that, self->producer, track );
 
-	// If sucessful, then we'll use this for connecting in the future
+	// If successful, then we'll use this for connecting in the future
 	if ( result == 0 )
 	{
 		// This is now the new producer
@@ -207,7 +207,7 @@ int mlt_field_plant_transition( mlt_field self, mlt_transition that, int a_track
 	b_track = CLAMP( b_track, 0, track_max );
 	int result = mlt_transition_connect( that, self->producer, a_track, b_track );
 
-	// If sucessful, then we'll use self for connecting in the future
+	// If successful, then we'll use self for connecting in the future
 	if ( result == 0 )
 	{
 		// This is now the new producer

--- a/src/framework/mlt_geometry.c
+++ b/src/framework/mlt_geometry.c
@@ -403,7 +403,7 @@ int mlt_geometry_fetch( mlt_geometry self, mlt_geometry_item item, float positio
 	// Get the local geometry
 	geometry g = self->local;
 
-	// Need to find the nearest key to the position specifed
+	// Need to find the nearest key to the position specified
 	geometry_item key = g->item;
 
 	// Iterate through the keys until we reach last or have 

--- a/src/framework/mlt_playlist.c
+++ b/src/framework/mlt_playlist.c
@@ -261,7 +261,7 @@ static int mlt_playlist_virtual_append( mlt_playlist self, mlt_producer source, 
 	{
 		mlt_position length = out - in + 1;
 
-		// Make sure the blank is long enough to accomodate the length specified
+		// Make sure the blank is long enough to accommodate the length specified
 		if ( length > mlt_producer_get_length( &self->blank ) )
 		{
 			mlt_properties blank_props = MLT_PRODUCER_PROPERTIES( &self->blank );
@@ -992,7 +992,7 @@ int mlt_playlist_resize_clip( mlt_playlist self, int clip, mlt_position in, mlt_
 		{
 			mlt_position length = out - in + 1;
 
-			// Make sure the parent blank is long enough to accomodate the length specified
+			// Make sure the parent blank is long enough to accommodate the length specified
 			if ( length > mlt_producer_get_length( &self->blank ) )
 			{
 				mlt_properties blank_props = MLT_PRODUCER_PROPERTIES( &self->blank );

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -265,8 +265,8 @@ void mlt_slices_close( mlt_slices ctx )
  * \public \memberof mlt_slices_s
  * \deprecated
  * \param ctx context pointer
- * \param jobs number of jobs to proccess
- * \param proc number of jobs to proccess
+ * \param jobs number of jobs to process
+ * \param proc number of jobs to process
  */
 
 void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cookie )

--- a/src/framework/mlt_tractor.c
+++ b/src/framework/mlt_tractor.c
@@ -478,7 +478,7 @@ static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int tra
 		// If we don't have one, we're in trouble...
 		if ( multitrack != NULL )
 		{
-			// The output frame will hold the 'global' data feeds (ie: those which are targetted for the final frame)
+			// The output frame will hold the 'global' data feeds (ie: those which are targeted for the final frame)
 			mlt_deque data_queue = mlt_deque_init( );
 
 			// Used to garbage collect all frames

--- a/src/framework/mlt_transition.c
+++ b/src/framework/mlt_transition.c
@@ -389,7 +389,7 @@ static int get_image_b( mlt_frame b_frame, uint8_t **image, mlt_image_format *fo
 	transition simply treats the frames from c3 as though they're the a track.
 
 	For this to work, we cache all frames coming from all tracks between the a and b
-	tracks.  Before we process, we determine that the b frame contains someting of the
+	tracks.  Before we process, we determine that the b frame contains something of the
 	right type and then we determine which frame to use as the a frame (selecting a
 	matching frame from a_track to b_track - 1). If both frames contain data of the
 	correct type, we process the transition.

--- a/src/melt/melt.c
+++ b/src/melt/melt.c
@@ -818,7 +818,7 @@ query_all:
 				query_services( repo, producer_type );
 				query_services( repo, transition_type );
 				fprintf( stdout, "# You can query the metadata for a specific service using:\n"
-					"# -query <type>=<identifer>\n"
+					"# -query <type>=<identifier>\n"
 					"# where <type> is one of: consumer, filter, producer, or transition.\n" );
 			}
 			goto exit_factory;

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -707,7 +707,7 @@ static int open_audio( mlt_properties properties, AVFormatContext *oc, AVStream 
 		else 
 			audio_input_frame_size = c->frame_size;
 
-		// Some formats want stream headers to be seperate (hmm)
+		// Some formats want stream headers to be separate (hmm)
 		if ( !strcmp( oc->oformat->name, "mp4" ) ||
 			 !strcmp( oc->oformat->name, "mov" ) ||
 			 !strcmp( oc->oformat->name, "3gp" ) )
@@ -862,7 +862,7 @@ static AVStream *add_video_stream( mlt_consumer consumer, AVFormatContext *oc, A
 			c->codec_tag = tag;
 		}
 
-		// Some formats want stream headers to be seperate
+		// Some formats want stream headers to be separate
 		if ( oc->oformat->flags & AVFMT_GLOBALHEADER ) 
 			c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
@@ -1467,7 +1467,7 @@ static void *consumer_thread( void *arg )
 	enc_ctx->audio_codec_id = fmt->audio_codec;
 	enc_ctx->video_codec_id = fmt->video_codec;
 
-	// Check for audio codec overides
+	// Check for audio codec overrides
 	if ( ( acodec && strcmp( acodec, "none" ) == 0 ) || mlt_properties_get_int( properties, "an" ) )
 		enc_ctx->audio_codec_id = AV_CODEC_ID_NONE;
 	else if ( acodec )
@@ -1498,7 +1498,7 @@ static void *consumer_thread( void *arg )
 		audio_codec = avcodec_find_encoder( enc_ctx->audio_codec_id );
 	}
 
-	// Check for video codec overides
+	// Check for video codec overrides
 	if ( ( vcodec && strcmp( vcodec, "none" ) == 0 ) || mlt_properties_get_int( properties, "vn" ) )
 		enc_ctx->video_codec_id = AV_CODEC_ID_NONE;
 	else if ( vcodec )

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -372,7 +372,7 @@ static void init_image_filtergraph( mlt_filter filter, mlt_image_format format, 
 #if defined(__GLIBC__) || defined(__APPLE__) || (__FreeBSD__)
 		// LUT data files use period for the decimal point regardless of LC_NUMERIC.
 		locale_t posix_locale = newlocale( LC_NUMERIC_MASK, "POSIX", NULL );
-		// Get the current locale and swtich to POSIX local.
+		// Get the current locale and switch to POSIX local.
 		locale_t orig_locale  = uselocale( posix_locale );
 		// Initialize the filter.
 		ret = avfilter_init_str(  pdata->avfilter_ctx, NULL );
@@ -380,7 +380,7 @@ static void init_image_filtergraph( mlt_filter filter, mlt_image_format format, 
 		uselocale( orig_locale );
 		freelocale( posix_locale );
 #else
-		// Get the current locale and swtich to POSIX local.
+		// Get the current locale and switch to POSIX local.
 		char *orig_localename = strdup( setlocale( LC_NUMERIC, NULL ) );
 		setlocale( LC_NUMERIC, "C" );
 		// Initialize the filter.

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -661,7 +661,7 @@ static int get_basic_info( producer_avformat self, mlt_profile profile, const ch
 	}
 	if ( self->seekable )
 	{
-		// Do a more rigourous test of seekable on a disposable context
+		// Do a more rigorous test of seekable on a disposable context
 		if ( format->nb_streams > 0 && format->streams[0]->codec && format->streams[0]->codec->codec_id != AV_CODEC_ID_WEBP )
 			self->seekable = av_seek_frame( format, -1, format->start_time, AVSEEK_FLAG_BACKWARD ) >= 0;
 		mlt_properties_set_int( properties, "seekable", self->seekable );
@@ -1248,7 +1248,7 @@ static mlt_audio_format pick_audio_format( int sample_fmt )
 }
 
 /**
- * Handle deprecated pixel format (JPEG range in YUV420P for exemple).
+ * Handle deprecated pixel format (JPEG range in YUV420P for example).
  *
  * Replace pix_fmt with the official pixel format to use.
  * @return 0 if no pix_fmt replacement, 1 otherwise

--- a/src/modules/core/filter_data_feed.c
+++ b/src/modules/core/filter_data_feed.c
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <framework/mlt.h>
 
-/** This filter should be used in conjuction with the data_show filter.
+/** This filter should be used in conjunction with the data_show filter.
 	The concept of the data_feed is that it can be used to pass titles
 	or images to render on the frame, but doesn't actually do it 
 	itself. data_feed imposes few rules on what's passed on and the 

--- a/src/modules/core/filter_data_show.c
+++ b/src/modules/core/filter_data_show.c
@@ -30,7 +30,7 @@ static mlt_filter obtain_filter( mlt_filter filter, char *type )
 	// Result to return
 	mlt_filter result = NULL;
 
-	// Miscelaneous variable
+	// Miscellaneous variable
 	int i = 0;
 	int type_len = strlen( type );
 

--- a/src/modules/core/filter_mono.c
+++ b/src/modules/core/filter_mono.c
@@ -148,7 +148,7 @@ static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	mlt_properties frame_props = MLT_FRAME_PROPERTIES( frame );
 
-	// Propogate the parameters
+	// Propagate the parameters
 	mlt_properties_set_int( frame_props, "mono.channels", mlt_properties_get_int( properties, "channels" ) );
 
 	// Override the get_audio method

--- a/src/modules/core/filter_obscure.c
+++ b/src/modules/core/filter_obscure.c
@@ -92,7 +92,7 @@ static void geometry_parse( struct geometry_s *geometry, struct geometry_s *defa
 		geometry->mask_h = 20;
 	}
 
-	// Parse the geomtry string
+	// Parse the geometry string
 	if ( property != NULL )
 	{
 		char *ptr = property;

--- a/src/modules/core/filter_panner.c
+++ b/src/modules/core/filter_panner.c
@@ -235,7 +235,7 @@ static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
 			// Finally, set the mix property on the frame
 			mlt_properties_set_double( instance_props, "mix", mix );
 	
-			// Initialise filter previous mix value to prevent an inadvertant jump from 0
+			// Initialise filter previous mix value to prevent an inadvertent jump from 0
 			mlt_position last_position = mlt_properties_get_position( properties, "_last_position" );
 			mlt_position current_position = mlt_frame_get_position( frame );
 			mlt_properties_set_position( properties, "_last_position", current_position );

--- a/src/modules/core/filter_rescale.c
+++ b/src/modules/core/filter_rescale.c
@@ -181,7 +181,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 			oheight *= factor;
 		}
 
-		// Default from the scaler if not specifed on the frame
+		// Default from the scaler if not specified on the frame
 		if ( interps == NULL )
 		{
 			interps = mlt_properties_get( MLT_FILTER_PROPERTIES( filter ), "interpolation" );

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -95,7 +95,7 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	if ( *height <= 0 )
 		*height = mlt_service_profile( MLT_PRODUCER_SERVICE(producer) )->height;
 	
-	// Choose default image format if specific request is unsuported
+	// Choose default image format if specific request is unsupported
 	if (*format!=mlt_image_yuv420p  && *format!=mlt_image_yuv422  && *format!=mlt_image_rgb24 && *format!= mlt_image_glsl && *format!= mlt_image_glsl_texture)
 		*format = mlt_image_rgb24a;
 

--- a/src/modules/core/producer_noise.c
+++ b/src/modules/core/producer_noise.c
@@ -50,7 +50,7 @@ static inline unsigned int fast_rand( rand_seed* seed )
 	return ( ( seed->x << 16 ) + ( seed->y & 65535 ) );
 }
 
-// Foward declarations
+// Forward declarations
 static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int index );
 static void producer_close( mlt_producer producer );
 

--- a/src/modules/core/transition_composite.c
+++ b/src/modules/core/transition_composite.c
@@ -305,7 +305,7 @@ static void luma_read_pgm( FILE *f, uint16_t **map, int *width, int *height )
 		if ( *map == NULL )
 			break;
 
-		// proces the raw data into the luma bitmap
+		// process the raw data into the luma bitmap
 		for ( i = 0; i < *width * *height * bpp; i += bpp )
 		{
 			if ( bpp == 1 )
@@ -333,7 +333,7 @@ static void luma_read_yuv422( uint8_t *image, uint16_t **map, int width, int hei
 	if ( *map == NULL )
 		return;
 
-	// proces the image data into the luma bitmap
+	// process the image data into the luma bitmap
 	for ( i = 0; i < width * height * 2; i += 2 )
 		*p++ = ( image[ i ] - 16 ) * 299; // 299 = 65535 / 219
 }
@@ -919,7 +919,7 @@ static int get_b_frame_image( mlt_transition self, mlt_frame b_frame, uint8_t **
 		}
 
 		// Honour the fill request - this will scale the image to fill width or height while maintaining a/r
-		// ????: Shouln't this be the default behaviour?
+		// ????: Shouldn't this be the default behaviour?
 		if ( mlt_properties_get_int( properties, "fill" ) && scaled_width > 0 && scaled_height > 0 )
 		{
 			if ( scaled_height < normalised_height && scaled_width * normalised_height / scaled_height <= normalised_width )

--- a/src/modules/core/transition_luma.c
+++ b/src/modules/core/transition_luma.c
@@ -268,7 +268,7 @@ static void luma_read_pgm( FILE *f, uint16_t **map, int *width, int *height )
 		if ( *map == NULL )
 			break;
 
-		// proces the raw data into the luma bitmap
+		// process the raw data into the luma bitmap
 		for ( i = 0; i < *width * *height * bpp; i += bpp )
 		{
 			if ( bpp == 1 )
@@ -297,7 +297,7 @@ static void luma_read_yuv422( uint8_t *image, uint16_t **map, int width, int hei
 	if ( *map == NULL )
 		return;
 
-	// proces the image data into the luma bitmap
+	// process the image data into the luma bitmap
 	for ( i = 0; i < size; i += 2 )
 		*p++ = ( image[ i ] - 16 ) * 299; // 299 = 65535 / 219
 }

--- a/src/modules/core/transition_mix.c
+++ b/src/modules/core/transition_mix.c
@@ -317,7 +317,7 @@ static mlt_frame transition_process( mlt_transition transition, mlt_frame a_fram
 			// Finally, set the mix property on the frame
 			mlt_properties_set_double( b_props, "audio.mix", mix );
 	
-			// Initialise transition previous mix value to prevent an inadvertant jump from 0
+			// Initialise transition previous mix value to prevent an inadvertent jump from 0
 			mlt_position last_position = mlt_properties_get_position( properties, "_last_position" );
 			mlt_position current_position = mlt_frame_get_position( b_frame );
 			mlt_properties_set_position( properties, "_last_position", current_position );

--- a/src/modules/decklink/producer_decklink.yml
+++ b/src/modules/decklink/producer_decklink.yml
@@ -3,7 +3,7 @@ type: producer
 identifier: decklink
 title: Blackmagic Design DeckLink Capture
 version: 1
-copyright: Copytight (C) 2011 Daniel R. Dennedy
+copyright: Copyright (C) 2011 Daniel R. Dennedy
 license: LGPL
 language: en
 creator: Dan Dennedy

--- a/src/modules/kdenlive/producer_framebuffer.c
+++ b/src/modules/kdenlive/producer_framebuffer.c
@@ -325,7 +325,7 @@ mlt_producer producer_framebuffer_init( mlt_profile profile, mlt_service_type ty
 
 		mlt_properties_set( properties, "resource", arg);
 
-		// Store the producer and fitler
+		// Store the producer and filter
 		mlt_properties_set_data( properties, "producer", real_producer, 0, ( mlt_destructor )mlt_producer_close, NULL );
 
 		// Grab some stuff from the real_producer

--- a/src/modules/kino/avi.cc
+++ b/src/modules/kino/avi.cc
@@ -908,7 +908,7 @@ void AVIFile::UpdateIndx( int stream, int chunk, int duration )
 	int parent;
 	int i;
 
-	/* update the appropiate entry in the super index. It reflects
+	/* update the appropriate entry in the super index. It reflects
 	   the number of frames in the referenced index. */
 
 	i = indx[ stream ] ->nEntriesInUse - 1;

--- a/src/modules/linsys/consumer_SDIstream.c
+++ b/src/modules/linsys/consumer_SDIstream.c
@@ -47,7 +47,7 @@
  *      PCIe LP HD-SDI Master™ O     (model 193)
  *
  *  Note: PCIe LP HD-SDI Master™ O (model 193) is an VidPort model and supports an
- *  seperate video and audio interface. Device file:
+ *  separate video and audio interface. Device file:
  * 		/dev/sdivideotx[]	for active video data
  *  	/dev/sdiaudiotx[]	for pcm audio data
  *
@@ -166,7 +166,7 @@ struct consumer_SDIstream_s {
 	 *		/dev/sdiaudiotx0
 	 **/
 	char *device_file_video; // Path for SDI output
-	char *device_file_audio; // Path for exlusive SDI audio output
+	char *device_file_audio; // Path for exclusive SDI audio output
 
 	/**
 	 *  write own HANC (ancillary data) is available for:
@@ -329,7 +329,7 @@ static void *consumer_thread(void *arg) {
 
 	// Convenience functionality (this is to stop melt/inigo after the end of a playout)
 	int terminate_on_pause = mlt_properties_get_int(MLT_CONSUMER_PROPERTIES( consumer ), "terminate_on_pause");
-	int terminated = 0; // save ony status
+	int terminated = 0; // save only status
 
 	int save_jpegs = mlt_properties_get_int(MLT_CONSUMER_PROPERTIES( consumer ), "save_jpegs");
 	char * jpeg_folder = mlt_properties_get(MLT_CONSUMER_PROPERTIES( consumer ), "jpeg_file");

--- a/src/modules/linsys/sdi_generator.c
+++ b/src/modules/linsys/sdi_generator.c
@@ -47,7 +47,7 @@
  *      PCIe LP HD-SDI Master™ O     (model 193)
  *
  *  Note: PCIe LP HD-SDI Master™ O (model 193) is an VidPort model and supports an
- *  seperate video and audio interface. Device file:
+ *  separate video and audio interface. Device file:
  * 		/dev/sdivideotx[]	for active video data
  *  	/dev/sdiaudiotx[]	for pcm audio data
  *
@@ -411,7 +411,7 @@ static int sdi_init(char *device_video, char *device_audio, uint8_t blanking, ml
 
 				/**
 				 * prepare sample size
-				 * MLT suports: 16bit, 32bit
+				 * MLT supports: 16bit, 32bit
 				 * LINSYS SDI boards supports: 16bit, 24bit, 32bit
 				 * we set 16bit as default
 				 **/
@@ -957,7 +957,7 @@ static int sdi_playout(uint8_t *vBuffer, int16_t aBuffer[MAX_AUDIO_STREAMS][MAX_
 	// if available write audio data
 	if (fh_sdi_audio) {
 
-		// count writen bytes
+		// count written bytes
 		written_bytes = 0;
 
 		// set number of samples and cut by 1600 if NTSC (handle problem of real time encoding of NTSC frequencies)
@@ -968,7 +968,7 @@ static int sdi_playout(uint8_t *vBuffer, int16_t aBuffer[MAX_AUDIO_STREAMS][MAX_
 
 		//printf("samples_total_per_track:%li\n", samples_total_per_track);
 
-		// to write blockwise 2 samples of one track we must claculate the number of bytes we want to write per write-session
+		// to write blockwise 2 samples of one track we must calculate the number of bytes we want to write per write-session
 		// 2samples = 2x16Bit = 32Bit = 4Byte
 		// 2samples = 2x32Bit = 64Bit = 8Byte
 		// set total bytes per session
@@ -1423,8 +1423,8 @@ static int writeANC(uint16_t *p, int videoline_sdiframe, uint16_t DID, int my_DB
 		// 1 DBN	(Data Block Number) inactiv: 1000000000 b9,b8,b7-b0	; SMPTE 272-M chapter15.1
 		//		*p++ = 0x200;
 
-		// 1 DBN (dynamic version0.1-beta ), should start with previus DBN of SDI-Frame
-		//	-need "previus DBN" or "current framenumber"
+		// 1 DBN (dynamic version0.1-beta ), should start with previous DBN of SDI-Frame
+		//	-need "previous DBN" or "current framenumber"
 		//		SDI-LINE:	DBN:
 		//		[1]			[1]		<< start sdi frame
 		//		[2]			[2]
@@ -1539,7 +1539,7 @@ static uint16_t checker(uint16_t *DID_pointer) {
 
 	DID_pointer++;
 
-	// while DID_pointer point to smaller addres like 'ende'
+	// while DID_pointer point to smaller address like 'ende'
 	while (DID_pointer <= ende) {
 		cs += (*DID_pointer++) & 0x1FF; // 9 x LSB
 	}

--- a/src/modules/lumas/configure
+++ b/src/modules/lumas/configure
@@ -6,7 +6,7 @@ then
 Luma options:
 
   --luma-compress         - Produce compressed (png) lumas
-  --luma-8bpp             - Produce 8 bit pgm lumas (defaut is 16 bit)
+  --luma-8bpp             - Produce 8 bit pgm lumas (default is 16 bit)
 
 EOF
 

--- a/src/modules/motion_est/filter_motion_est.c
+++ b/src/modules/motion_est/filter_motion_est.c
@@ -136,12 +136,12 @@ inline static int constrain(	int *x, int *y, int *w,	int *h,
 		h_remains = *h - top + ((*y < y2) ? *y : y2);
 		*y += *h - h_remains;
 	}
-	// Portion of macroblock moves bellow image boundry
+	// Portion of macroblock moves below image boundry
 	else if( *y + *h > bottom || y2 + *h > bottom )
 		h_remains = bottom - ((*y > y2) ?  *y : y2);
 
 	if( w_remains == *w && h_remains == *h ) return penalty;
-	if( w_remains <= 0 || h_remains <= 0) return 0;	// Block is clipped out of existance
+	if( w_remains <= 0 || h_remains <= 0) return 0;	// Block is clipped out of existence
 	penalty = (*w * *h * penalty)
 		/ ( w_remains * h_remains);		// Recipricol of the fraction of the block that remains
 
@@ -205,7 +205,7 @@ inline static int block_compare( uint8_t *block1,
 	int penalty = constrain( &x, &y, &mb_w,	&mb_h, dx, dy, 0, c->width, 0, c->height);
 
 	// Some gotchas
-	if( penalty == 0 )			// Clipped out of existance: Return worst score
+	if( penalty == 0 )			// Clipped out of existence: Return worst score
 		return MAX_MSAD;
 	else if( penalty != 1<<SHIFT )		// Nonstandard macroblock dimensions: Disable SIMD optimizizations.
 		cmp = c->compare_reference;
@@ -338,7 +338,7 @@ static inline void diamond_search(
 		best.dx = result->dx - current.dx;
 		best.dy = result->dy - current.dy;
 
-		// A better canidate was not found
+		// A better candidate was not found
 		if ( best.dx == 0 && best.dy == 0 )
 			return;
 
@@ -395,7 +395,7 @@ int ncompare (const void * a, const void * b)
 }
 
 // motion vector denoising
-// for x and y components seperately,
+// for x and y components separately,
 // change the vector to be the median value of the 9 adjacent vectors
 static void median_denoise( motion_vector *v, struct motion_est_context_s *c )
 {

--- a/src/modules/motion_est/producer_slowmotion.c
+++ b/src/modules/motion_est/producer_slowmotion.c
@@ -55,12 +55,12 @@ inline static int constrain(	int *x, int *y, int *w,	int *h,
 		h_remains = *h - top + ((*y < y2) ? *y : y2);
 		*y += *h - h_remains;
 	}
-	// Portion of macroblock moves bellow image boundry
+	// Portion of macroblock moves below image boundry
 	else if( *y + *h > bottom || y2 + *h > bottom )
 		h_remains = bottom - ((*y > y2) ?  *y : y2);
 
 	if( w_remains == *w && h_remains == *h ) return penalty; 
-	if( w_remains <= 0 || h_remains <= 0) return 0;	// Block is clipped out of existance
+	if( w_remains <= 0 || h_remains <= 0) return 0;	// Block is clipped out of existence
 	penalty = (*w * *h * penalty)
 		/ ( w_remains * h_remains);		// Recipricol of the fraction of the block that remains
 
@@ -379,7 +379,7 @@ mlt_producer producer_slowmotion_init( mlt_profile profile, mlt_service_type typ
 		// The loader normalised it for us already
 		mlt_properties_set_int( properties, "loader_normalised", 1);
 
-		// Store the producer and fitler
+		// Store the producer and filter
 		mlt_properties_set_data( properties, "producer", real_producer, 0, ( mlt_destructor )mlt_producer_close, NULL );
 		mlt_properties_set_data( properties, "motion_est", filter, 0, ( mlt_destructor )mlt_filter_close, NULL );
 		mlt_properties_set_int( MLT_FILTER_PROPERTIES( filter ), "macroblock_width", 16 );

--- a/src/modules/normalize/filter_volume.c
+++ b/src/modules/normalize/filter_volume.c
@@ -227,7 +227,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	if ( max_gain > 0 && gain > max_gain )
 		gain = max_gain;
 
-	// Initialise filter's previous gain value to prevent an inadvertant jump from 0
+	// Initialise filter's previous gain value to prevent an inadvertent jump from 0
 	mlt_position last_position = mlt_properties_get_position( filter_props, "_last_position" );
 	mlt_position current_position = mlt_frame_get_position( frame );
 	if ( mlt_properties_get( filter_props, "_previous_gain" ) == NULL

--- a/src/modules/opengl/filter_movit_opacity.yml
+++ b/src/modules/opengl/filter_movit_opacity.yml
@@ -29,7 +29,7 @@ parameters:
   - identifier: alpha
     title: Alpha
     description: >
-      When this is less than zero, the alpha component of the Movit mutliply
+      When this is less than zero, the alpha component of the Movit multiply
       effect follows opacity. Otherwise, you can set this to another value to
       control the alpha component independently. If you set this to 1, then
       the opacity parameter can be used to fade to and from black.

--- a/src/modules/plus/filter_dynamictext.c
+++ b/src/modules/plus/filter_dynamictext.c
@@ -54,7 +54,7 @@ static int get_next_token(char* str, int* pos, char* token, int* is_keyword)
 	{
 		if( str[*pos] == '\\' && str[(*pos) + 1] == '#' )
 		{
-			// Escape Sequence - "#" preceeded by "\" - copy the # into the token.
+			// Escape Sequence - "#" preceded by "\" - copy the # into the token.
 			token[token_pos] = '#';
 			token_pos++;
 			(*pos)++; // skip "\"

--- a/src/modules/plus/filter_dynamictext.yml
+++ b/src/modules/plus/filter_dynamictext.yml
@@ -11,7 +11,7 @@ tags:
   - Video
 description: Overlay dynamic text onto the video
 notes: >
-  The dynamic text filter will search for keywords in the text to be overlayed
+  The dynamic text filter will search for keywords in the text to be overlaid
   and will replace those keywords on a frame-by-frame basis.
   
 parameters:

--- a/src/modules/plus/filter_timer.yml
+++ b/src/modules/plus/filter_timer.yml
@@ -16,7 +16,7 @@ parameters:
     title: Format
     type: string
     description: >
-      The time format of the overlayed timer text.
+      The time format of the overlaid timer text.
     values:
       - HH:MM:SS
       - HH:MM:SS.S

--- a/src/modules/plus/interp.h
+++ b/src/modules/plus/interp.h
@@ -19,7 +19,7 @@
  */
 
 /*******************************************************************
- * The remapping functions use a map aray, which contains a pair
+ * The remapping functions use a map array, which contains a pair
  * of floating values fo each pixel of the output image. These
  * represent the location in the input image, from where the value
  * of the given output pixel should be interpolated.

--- a/src/modules/plusgpl/cJSON.h
+++ b/src/modules/plusgpl/cJSON.h
@@ -101,7 +101,7 @@ extern void	cJSON_AddItemToObject(cJSON *object,const char *string,cJSON *item);
 extern void cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
 extern void	cJSON_AddItemReferenceToObject(cJSON *object,const char *string,cJSON *item);
 
-// Remove/Detatch items from Arrays/Objects.
+// Remove/Detach items from Arrays/Objects.
 extern cJSON *cJSON_DetachItemFromArray(cJSON *array,int which);
 extern void   cJSON_DeleteItemFromArray(cJSON *array,int which);
 extern cJSON *cJSON_DetachItemFromObject(cJSON *object,const char *string);

--- a/src/modules/plusgpl/consumer_cbrts.c
+++ b/src/modules/plusgpl/consumer_cbrts.c
@@ -1161,7 +1161,7 @@ static void *consumer_thread( void *arg )
 	// Get the consumer and producer
 	mlt_consumer consumer = &self->parent;
 
-	// internal intialization
+	// internal initialization
 	mlt_frame frame = NULL;
 	int last_position = -1;
 

--- a/src/modules/plusgpl/filter_burn.c
+++ b/src/modules/plusgpl/filter_burn.c
@@ -174,7 +174,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 		i = 1;
 		for(y=0; y<video_height; y++) {
 			for(x=1; x<video_width-1; x++) {
-				/* FIXME: endianess? */
+				/* FIXME: endianness? */
 				a = (src[i] & 0xfefeff) + palette[buffer[i]];
 				b = a & 0x1010100;
 				// Add alpha if necessary or use src alpha.

--- a/src/modules/plusgpl/filter_rotoscoping.c
+++ b/src/modules/plusgpl/filter_rotoscoping.c
@@ -131,7 +131,7 @@ static int json2BCurves( cJSON *array, BPointF **points )
     return i;
 }
 
-/** Blurs \param src horizontally. \See funtion blur. */
+/** Blurs \param src horizontally. \See function blur. */
 static void blurHorizontal( uint8_t *src, uint8_t *dst, int width, int height, int radius)
 {
     int x, y, kx, yOff, total, amount, amountInit;
@@ -164,7 +164,7 @@ static void blurHorizontal( uint8_t *src, uint8_t *dst, int width, int height, i
     }
 }
 
-/** Blurs \param src vertically. \See funtion blur. */
+/** Blurs \param src vertically. \See function blur. */
 static void blurVertical( uint8_t *src, uint8_t *dst, int width, int height, int radius)
 {
     int x, y, ky, total, amount, amountInit;
@@ -194,7 +194,7 @@ static void blurVertical( uint8_t *src, uint8_t *dst, int width, int height, int
 
 /**
  * Blurs the \param map using a simple "average" blur.
- * \param map Will be blured; 1bpp
+ * \param map Will be blurred; 1bpp
  * \param width x dimension of channel stored in \param map
  * \param height y dimension of channel stored in \param map
  * \param radius blur radius
@@ -286,7 +286,7 @@ static void deCasteljau( BPointF *p1, BPointF *p2, BPointF *mid )
 /**
  * Calculates points for the cubic Bézier curve defined by \param p1 and \param p2.
  * Points are calculated until the squared distanced between neighbour points is smaller than 2.
- * \param points Pointer to list of points. Will be allocted and filled with calculated points.
+ * \param points Pointer to list of points. Will be allocated and filled with calculated points.
  * \param count Number of calculated points in \param points
  * \param size Allocated size of \param points (in elements not in bytes)
  */

--- a/src/modules/plusgpl/image.c
+++ b/src/modules/plusgpl/image.c
@@ -35,7 +35,7 @@ void image_bgset_y(RGB32 *background, const RGB32 *src, int video_area, int y_th
 	p = src;
 	q = (short *)background;
 	for(i=0; i<video_area; i++) {
-		/* FIXME: endianess */
+		/* FIXME: endianness */
 
 		R = ((*p)&0xff0000)>>(16-1);
 		G = ((*p)&0xff00)>>(8-2);
@@ -59,7 +59,7 @@ void image_bgsubtract_y(unsigned char *diff, const RGB32 *background, const RGB3
 	q = (const short *)background;
 	r = diff;
 	for(i=0; i<video_area; i++) {
-		/* FIXME: endianess */
+		/* FIXME: endianness */
 
 		R = ((*p)&0xff0000)>>(16-1);
 		G = ((*p)&0xff00)>>(8-2);
@@ -99,7 +99,7 @@ void image_bgsubtract_update_y(unsigned char *diff, RGB32 *background, const RGB
 	q = (short *)background;
 	r = diff;
 	for(i=0; i<video_area; i++) {
-		/* FIXME: endianess */
+		/* FIXME: endianness */
 
 		R = ((*p)&0xff0000)>>(16-1);
 		G = ((*p)&0xff00)>>(8-2);

--- a/src/modules/rtaudio/RtAudio.cpp
+++ b/src/modules/rtaudio/RtAudio.cpp
@@ -204,7 +204,7 @@ RtAudio :: RtAudio( RtAudio::Api api )
   // It should not be possible to get here because the preprocessor
   // definition __RTAUDIO_DUMMY__ is automatically defined if no
   // API-specific definitions are passed to the compiler. But just in
-  // case something weird happens, we'll thow an error.
+  // case something weird happens, we'll throw an error.
   std::string errorText = "\nRtAudio: no compiled API support found ... critical error!!\n\n";
   throw( RtAudioError( errorText, RtAudioError::UNSPECIFIED ) );
 }
@@ -2712,13 +2712,13 @@ static long asioMessages( long selector, long value, void* message, double* opt 
 
 RtApiAsio :: RtApiAsio()
 {
-  // ASIO cannot run on a multi-threaded appartment. You can call
-  // CoInitialize beforehand, but it must be for appartment threading
+  // ASIO cannot run on a multi-threaded apartment. You can call
+  // CoInitialize beforehand, but it must be for apartment threading
   // (in which case, CoInitilialize will return S_FALSE here).
   coInitialized_ = false;
   HRESULT hr = CoInitialize( NULL ); 
   if ( FAILED(hr) ) {
-    errorText_ = "RtApiAsio::ASIO requires a single-threaded appartment. Call CoInitializeEx(0,COINIT_APARTMENTTHREADED)";
+    errorText_ = "RtApiAsio::ASIO requires a single-threaded apartment. Call CoInitializeEx(0,COINIT_APARTMENTTHREADED)";
     error( RtAudioError::WARNING );
   }
   coInitialized_ = true;
@@ -6557,7 +6557,7 @@ void RtApiDs :: callbackEvent()
     if ( stream_.mode == DUPLEX ) {
       if ( safeReadPointer < endRead ) {
         if ( duplexPrerollBytes <= 0 ) {
-          // Pre-roll time over. Be more agressive.
+          // Pre-roll time over. Be more aggressive.
           int adjustment = endRead-safeReadPointer;
 
           handle->xrun[1] = true;
@@ -7957,7 +7957,7 @@ void RtApiAlsa :: callbackEvent()
     }
 
     if ( result < (int) stream_.bufferSize ) {
-      // Either an error or overrun occured.
+      // Either an error or overrun occurred.
       if ( result == -EPIPE ) {
         snd_pcm_state_t state = snd_pcm_state( handle[1] );
         if ( state == SND_PCM_STATE_XRUN ) {
@@ -8027,7 +8027,7 @@ void RtApiAlsa :: callbackEvent()
     }
 
     if ( result < (int) stream_.bufferSize ) {
-      // Either an error or underrun occured.
+      // Either an error or underrun occurred.
       if ( result == -EPIPE ) {
         snd_pcm_state_t state = snd_pcm_state( handle[0] );
         if ( state == SND_PCM_STATE_XRUN ) {

--- a/src/modules/rtaudio/RtAudio.h
+++ b/src/modules/rtaudio/RtAudio.h
@@ -205,12 +205,12 @@ class RtAudioError : public std::exception
     UNSPECIFIED,       /*!< The default, unspecified error type. */
     NO_DEVICES_FOUND,  /*!< No devices found on system. */
     INVALID_DEVICE,    /*!< An invalid device ID was specified. */
-    MEMORY_ERROR,      /*!< An error occured during memory allocation. */
+    MEMORY_ERROR,      /*!< An error occurred during memory allocation. */
     INVALID_PARAMETER, /*!< An invalid parameter was specified to a function. */
     INVALID_USE,       /*!< The function was called incorrectly. */
-    DRIVER_ERROR,      /*!< A system driver error occured. */
-    SYSTEM_ERROR,      /*!< A system error occured. */
-    THREAD_ERROR       /*!< A thread error occured. */
+    DRIVER_ERROR,      /*!< A system driver error occurred. */
+    SYSTEM_ERROR,      /*!< A system error occurred. */
+    THREAD_ERROR       /*!< A thread error occurred. */
   };
 
   //! The constructor.
@@ -295,7 +295,7 @@ class RtAudio
        isDefaultOutput(false), isDefaultInput(false), preferredSampleRate(0), nativeFormats(0) {}
   };
 
-  //! The structure for specifying input or ouput stream parameters.
+  //! The structure for specifying input or output stream parameters.
   struct StreamParameters {
     unsigned int deviceId;     /*!< Device index (0 to getDeviceCount() - 1). */
     unsigned int nChannels;    /*!< Number of channels. */
@@ -485,7 +485,7 @@ class RtAudio
            lowest allowable value is used.  The actual value used is
            returned via the structure argument.  The parameter is API dependent.
     \param errorCallback A client-defined function that will be invoked
-           when an error has occured.
+           when an error has occurred.
   */
   void openStream( RtAudio::StreamParameters *outputParameters,
                    RtAudio::StreamParameters *inputParameters,
@@ -867,7 +867,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   bool callbackEvent( AudioDeviceID deviceId,
                       const AudioBufferList *inBufferList,
                       const AudioBufferList *outBufferList );
@@ -903,7 +903,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   bool callbackEvent( unsigned long nframes );
 
   private:
@@ -936,7 +936,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   bool callbackEvent( long bufferIndex );
 
   private:
@@ -974,7 +974,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:
@@ -1047,7 +1047,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:
@@ -1079,7 +1079,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:
@@ -1113,7 +1113,7 @@ public:
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
   // which is not a member of RtAudio.  External use of this function
-  // will most likely produce highly undesireable results!
+  // will most likely produce highly undesirable results!
   void callbackEvent( void );
 
   private:

--- a/src/modules/rtaudio/consumer_rtaudio.cpp
+++ b/src/modules/rtaudio/consumer_rtaudio.cpp
@@ -385,7 +385,7 @@ public:
 		// Video thread
 		pthread_t thread;
 
-		// internal intialization
+		// internal initialization
 		int init_audio = 1;
 		int init_video = 1;
 		mlt_frame frame = NULL;

--- a/src/modules/sdl/consumer_sdl.c
+++ b/src/modules/sdl/consumer_sdl.c
@@ -819,7 +819,7 @@ static void *consumer_thread( void *arg )
 	// Video thread
 	pthread_t thread;
 
-	// internal intialization
+	// internal initialization
 	int init_audio = 1;
 	int init_video = 1;
 	mlt_frame frame = NULL;

--- a/src/modules/sdl/consumer_sdl_audio.c
+++ b/src/modules/sdl/consumer_sdl_audio.c
@@ -544,7 +544,7 @@ static void *consumer_thread( void *arg )
 	// Video thread
 	pthread_t thread;
 
-	// internal intialization
+	// internal initialization
 	int init_audio = 1;
 	int init_video = 1;
 	mlt_frame frame = NULL;

--- a/src/modules/sdl/consumer_sdl_preview.c
+++ b/src/modules/sdl/consumer_sdl_preview.c
@@ -293,7 +293,7 @@ static void *consumer_thread( void *arg )
 	// Get the properties
 	mlt_properties properties = MLT_CONSUMER_PROPERTIES( consumer );
 
-	// internal intialization
+	// internal initialization
 	mlt_frame frame = NULL;
 	int last_position = -1;
 	int eos = 0;

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -814,7 +814,7 @@ static void *consumer_thread( void *arg )
 	// Video thread
 	pthread_t thread;
 
-	// internal intialization
+	// internal initialization
 	int init_audio = 1;
 	int init_video = 1;
 	mlt_frame frame = NULL;

--- a/src/modules/sdl2/consumer_sdl2_audio.c
+++ b/src/modules/sdl2/consumer_sdl2_audio.c
@@ -567,7 +567,7 @@ static void *consumer_thread( void *arg )
 	// Video thread
 	pthread_t thread;
 
-	// internal intialization
+	// internal initialization
 	int init_audio = 1;
 	int init_video = 1;
 	mlt_frame frame = NULL;

--- a/src/modules/videostab/filter_videostab2.c
+++ b/src/modules/videostab/filter_videostab2.c
@@ -76,7 +76,7 @@ static void serialize_vectors( videostab2_data* self, mlt_position length )
 			(mlt_destructor) mlt_geometry_close, (mlt_serialiser) mlt_geometry_serialise );
 	}
 }
-// scale zoom implements the factor that the vetcors must be scaled since the vector is calulated for real with, now we need it for (scaled)width
+// scale zoom implements the factor that the vetcors must be scaled since the vector is calculated for real with, now we need it for (scaled)width
 Transform* deserialize_vectors( char *vectors, mlt_position length ,float scale_zoom )
 {
 	mlt_geometry g = mlt_geometry_init();

--- a/src/modules/videostab/stabilize.c
+++ b/src/modules/videostab/stabilize.c
@@ -182,7 +182,7 @@ double compareImg(unsigned char* I1, unsigned char* I2,
 /**
    compares a small part of two given images
    and returns the average absolute difference.
-   Field center, size and shift have to be choosen,
+   Field center, size and shift have to be chosen,
    so that no clipping is required
 
    \param field Field specifies position(center) and size of subimage
@@ -701,7 +701,7 @@ Transform calcTransFields(StabData* sd, calcFieldTransFunc fieldfunc,
     // cleaned mean
     t = cleanmean_xy_transform(ts, num_trans);
 
-    // substract avg
+    // subtract avg
     for (i = 0; i < num_trans; i++) {
         ts[i] = sub_transforms(&ts[i], &t);
     }

--- a/src/modules/videostab/transform.c
+++ b/src/modules/videostab/transform.c
@@ -140,7 +140,7 @@ int cmp_double(const void *t1, const void* t2)
  *    transforms: array of transforms.
  *           len: length  of array
  * Return value:
- *     A new transform with x and y beeing the median of 
+ *     A new transform with x and y being the median of 
  *     all transforms. alpha and other fields are 0.
  * Preconditions:
  *     len>0
@@ -172,7 +172,7 @@ Transform median_xy_transform(const Transform* transforms, int len)
  *    transforms: array of transforms.
  *           len: length  of array
  * Return value:
- *     A new transform with x and y beeing the cleaned mean 
+ *     A new transform with x and y being the cleaned mean 
  *     (meaning upper and lower pentile are removed) of 
  *     all transforms. alpha and other fields are 0.
  * Preconditions:

--- a/src/modules/videostab/transform_image.c
+++ b/src/modules/videostab/transform_image.c
@@ -221,7 +221,7 @@ void interpolateN(unsigned char *rv, float x, float y,
  * Parameters:
  *         td: private data structure of this filter
  * Return value:
- *         0 for failture, 1 for success
+ *         0 for failure, 1 for success
  * Preconditions:
  *  The frame must be in RGB format
  */
@@ -298,7 +298,7 @@ int transformRGB(TransformData* td)
  * Parameters:
  *         td: private data structure of this filter
  * Return value:
- *         0 for failture, 1 for success
+ *         0 for failure, 1 for success
  * Preconditions:
  *  The frame must be in YUV format
  */
@@ -420,12 +420,12 @@ int transformYUV(TransformData* td)
  *  and cropping of too large transforms.
  *  This is actually the core algorithm for canceling the jiggle in the
  *  movie. We perform a low-pass filter in terms of transformation size.
- *  This enables still camera movement, but in a smooth fasion.
+ *  This enables still camera movement, but in a smooth fashion.
  *
  * Parameters:
- *            td: tranform private data structure
+ *            td: transform private data structure
  * Return value:
- *     1 for success and 0 for failture
+ *     1 for success and 0 for failure
  * Preconditions:
  *     None
  * Side effects:

--- a/src/modules/videostab/transform_image.h
+++ b/src/modules/videostab/transform_image.h
@@ -69,7 +69,7 @@ typedef struct {
     int crop;       // 1: black bg, 0: keep border from last frame(s)
     int invert;     // 1: invert transforms, 0: nothing
     /* constants */
-    /* threshhold below which no rotation is performed */
+    /* threshold below which no rotation is performed */
     double rotation_threshhold;
     double zoom;      // percentage to zoom: 0->no zooming 10:zoom in 10%
     int optzoom;      // 1: determine optimal zoom, 0: nothing

--- a/src/modules/vorbis/producer_vorbis.c
+++ b/src/modules/vorbis/producer_vorbis.c
@@ -225,7 +225,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 	// Get the ogg vorbis file
 	OggVorbis_File *ov = mlt_properties_get_data( properties, "ogg_vorbis_file", NULL );
 
-	// Obtain the expected frame numer
+	// Obtain the expected frame number
 	mlt_position expected = mlt_properties_get_position( properties, "audio_expected" );
 
 	// Get the fps for this producer

--- a/src/modules/xml/consumer_xml.yml
+++ b/src/modules/xml/consumer_xml.yml
@@ -37,7 +37,7 @@ parameters:
     description: >
       The name of a file in which to store the XML.
       If the value does not contain a period (to start an extension), then
-      the value is interpreted as the name of a propery in which to store the
+      the value is interpreted as the name of a property in which to store the
       XML. This makes it easy for an application to use the consumer to
       serialize a service network and retrieve the XML in-memory.
     readonly: no

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -930,7 +930,7 @@ static void on_end_filter( deserialise_context context, const xmlChar *name )
 		mlt_properties_set( properties, "mlt_type", NULL );
 		mlt_properties_set( properties, "mlt_service", NULL );
 
-		// Propogate the properties
+		// Propagate the properties
 		qualify_property( context, properties, "resource" );
 		qualify_property( context, properties, "luma" );
 		qualify_property( context, properties, "luma.resource" );
@@ -1025,7 +1025,7 @@ static void on_end_transition( deserialise_context context, const xmlChar *name 
 		mlt_properties_set( properties, "mlt_type", NULL );
 		mlt_properties_set( properties, "mlt_service", NULL );
 
-		// Propogate the properties
+		// Propagate the properties
 		qualify_property( context, properties, "resource" );
 		qualify_property( context, properties, "luma" );
 		qualify_property( context, properties, "luma.resource" );
@@ -1410,7 +1410,7 @@ static void params_to_entities( deserialise_context context )
 	{	
 		int i;
 		
-		// Add our params as entitiy declarations
+		// Add our params as entity declarations
 		for ( i = 0; i < mlt_properties_count( context->params ); i++ )
 		{
 			xmlChar *name = ( xmlChar* )mlt_properties_get_name( context->params, i );
@@ -1581,7 +1581,7 @@ static void parse_url( mlt_properties properties, char *url )
 		mlt_properties_set( properties, name, value );
 }
 
-// Quick workaround to avoid unecessary libxml2 warnings
+// Quick workaround to avoid unnecessary libxml2 warnings
 static int file_exists( char *name )
 {
 	int exists = 0;
@@ -1594,7 +1594,7 @@ static int file_exists( char *name )
 	return exists;
 }
 
-// This function will add remaing services in the context service stack marked
+// This function will add remaining services in the context service stack marked
 // with a "xml_retain" property to a property named "xml_retain" on the returned
 // service. The property is a mlt_properties data property.
 


### PR DESCRIPTION
Found via `codespell -q 3 -L shotcut,sav,boundry,percentil,readded,uint,ith,sinc,amin,childs`