### PR TITLE
Filter qtext

### DIFF
--- a/src/modules/core/filter_resize.c
+++ b/src/modules/core/filter_resize.c
@@ -62,7 +62,7 @@ static uint8_t *resize_alpha( uint8_t *input, int owidth, int oheight, int iwidt
 	return output;
 }
 
-static void resize_image( uint8_t *output, int owidth, int oheight, uint8_t *input, int iwidth, int iheight, int bpp )
+static void resize_image( uint8_t *output, int owidth, int oheight, uint8_t *input, int iwidth, int iheight, int bpp, mlt_image_format format, uint8_t alpha_value )
 {
 	// Calculate strides
 	int istride = iwidth * bpp;
@@ -85,7 +85,17 @@ static void resize_image( uint8_t *output, int owidth, int oheight, uint8_t *inp
 		return;
 	}
 
-	if ( bpp == 2 )
+	if ( format == mlt_image_rgb24a )
+	{
+		while ( size -- )
+		{
+			*p ++ = 0;
+			*p ++ = 0;
+			*p ++ = 0;
+			*p ++ = alpha_value;
+		}
+	}
+	else if ( bpp == 2 )
 	{
 		while( size -- )
 		{
@@ -122,7 +132,7 @@ static void resize_image( uint8_t *output, int owidth, int oheight, uint8_t *inp
 	resizes.
 */
 
-static uint8_t *frame_resize_image( mlt_frame frame, int owidth, int oheight, int bpp )
+static uint8_t *frame_resize_image( mlt_frame frame, int owidth, int oheight, mlt_image_format format )
 {
 	// Get properties
 	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
@@ -132,6 +142,8 @@ static uint8_t *frame_resize_image( mlt_frame frame, int owidth, int oheight, in
 	uint8_t *alpha = mlt_frame_get_alpha( frame );
 	int alpha_size = 0;
 	mlt_properties_get_data( properties, "alpha", &alpha_size );
+	int bpp = 0;
+	mlt_image_format_size( format, owidth, oheight, &bpp );
 
 	int iwidth = mlt_properties_get_int( properties, "width" );
 	int iheight = mlt_properties_get_int( properties, "height" );
@@ -140,18 +152,17 @@ static uint8_t *frame_resize_image( mlt_frame frame, int owidth, int oheight, in
 	if ( iwidth < owidth || iheight < oheight )
 	{
 		uint8_t alpha_value = mlt_properties_get_int( properties, "resize_alpha" );
-
 		// Create the output image
 		uint8_t *output = mlt_pool_alloc( owidth * ( oheight + 1 ) * bpp );
 
 		// Call the generic resize
-		resize_image( output, owidth, oheight, input, iwidth, iheight, bpp );
+		resize_image( output, owidth, oheight, input, iwidth, iheight, bpp, format, alpha_value );
 
 		// Now update the frame
 		mlt_frame_set_image( frame, output, owidth * ( oheight + 1 ) * bpp, mlt_pool_release );
 
 		// We should resize the alpha too
-		if ( alpha && alpha_size >= iwidth * iheight )
+		if ( format != mlt_image_rgb24a && alpha && alpha_size >= iwidth * iheight )
 		{
 			alpha = resize_alpha( alpha, owidth, oheight, iwidth, iheight, alpha_value );
 			if ( alpha )
@@ -271,9 +282,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 
 	if ( error == 0 && *image && *format != mlt_image_yuv420p )
 	{
-		int bpp;
-		mlt_image_format_size( *format, owidth, oheight, &bpp );
-		*image = frame_resize_image( frame, *width, *height, bpp );
+		*image = frame_resize_image( frame, *width, *height, *format );
 	}
 
 	return error;

--- a/src/modules/plus/filter_timer.c
+++ b/src/modules/plus/filter_timer.c
@@ -142,7 +142,10 @@ static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
 mlt_filter filter_timer_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
 {
 	mlt_filter filter = mlt_filter_new();
-	mlt_filter text_filter = mlt_factory_filter( profile, "text", NULL );
+	mlt_filter text_filter = mlt_factory_filter( profile, "qtext", NULL );
+
+	if( !text_filter )
+		text_filter = mlt_factory_filter( profile, "text", NULL );
 
 	if( !text_filter )
 		mlt_log_warning( MLT_FILTER_SERVICE(filter), "Unable to create text filter.\n" );

--- a/src/modules/plus/filter_timer.c
+++ b/src/modules/plus/filter_timer.c
@@ -23,6 +23,25 @@
 
 #define MAX_TEXT_LEN 512
 
+static void property_changed( mlt_service owner, mlt_filter filter, char *name )
+{
+	if( !strcmp( "geometry", name ) ||
+		!strcmp( "family", name ) ||
+		!strcmp( "size", name ) ||
+		!strcmp( "weight", name ) ||
+		!strcmp( "style", name ) ||
+		!strcmp( "fgcolour", name ) ||
+		!strcmp( "bgcolour", name ) ||
+		!strcmp( "olcolour", name ) ||
+		!strcmp( "pad", name ) ||
+		!strcmp( "halign", name ) ||
+		!strcmp( "valign", name ) ||
+		!strcmp( "outline", name ) )
+	{
+		mlt_properties_set_int( MLT_FILTER_PROPERTIES(filter), "_reset", 1 );
+	}
+}
+
 double time_to_seconds( char* time )
 {
 	int hours = 0;
@@ -102,43 +121,20 @@ static void get_timer_str( mlt_filter filter, mlt_frame frame, char* text )
 	}
 }
 
-static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
+static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
 {
-	int error = 0;
-	mlt_filter filter = mlt_frame_pop_service( frame );
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	mlt_filter text_filter = mlt_properties_get_data( properties, "_text_filter", NULL );
 	mlt_properties text_filter_properties = MLT_FILTER_PROPERTIES( text_filter );
-
-	// Configure this filter
-	mlt_service_lock( MLT_FILTER_SERVICE( filter ) );
-
 	char result[MAX_TEXT_LEN] = "";
 	get_timer_str( filter, frame, result );
 	mlt_properties_set( text_filter_properties, "argument", (char*)result );
-
-	mlt_properties_pass_list( text_filter_properties, properties,
-		"geometry family size weight style fgcolour bgcolour olcolour pad halign valign outline" );
-	mlt_filter_process( text_filter, frame );
-
-	// Get the image
-	*format = mlt_image_rgb24a;
-	error = mlt_frame_get_image( frame, image, format, width, height, writable );
-
-	mlt_service_unlock( MLT_FILTER_SERVICE( filter ) );
-
-	return error;
-}
-
-static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
-{
-	// Push the filter on to the stack
-	mlt_frame_push_service( frame, filter );
-
-	// Push the get_image on to the stack
-	mlt_frame_push_get_image( frame, filter_get_image );
-
-	return frame;
+	if( mlt_properties_get_int( properties, "_reset" ) )
+	{
+		mlt_properties_pass_list( text_filter_properties, properties,
+			"geometry family size weight style fgcolour bgcolour olcolour pad halign valign outline" );
+	}
+	return mlt_filter_process( text_filter, frame );
 }
 
 /** Constructor for the filter.
@@ -158,6 +154,9 @@ mlt_filter filter_timer_init( mlt_profile profile, mlt_service_type type, const 
 		// Register the text filter for reuse/destruction
 		mlt_properties_set_data( my_properties, "_text_filter", text_filter, 0, ( mlt_destructor )mlt_filter_close, NULL );
 
+		// Listen for property changes.
+		mlt_events_listen( MLT_FILTER_PROPERTIES(filter), filter, "property-changed", (mlt_listener)property_changed );
+
 		// Assign default values
 		mlt_properties_set( my_properties, "format", "SS.SS" );
 		mlt_properties_set( my_properties, "start", "00:00:00.000" );
@@ -175,7 +174,7 @@ mlt_filter filter_timer_init( mlt_profile profile, mlt_service_type type, const 
 		mlt_properties_set( my_properties, "halign", "left" );
 		mlt_properties_set( my_properties, "valign", "top" );
 		mlt_properties_set( my_properties, "outline", "0" );
-
+		mlt_properties_set_int( my_properties, "_reset", 1 );
 		mlt_properties_set_int( my_properties, "_filter_private", 1 );
 
 		filter->process = filter_process;

--- a/src/modules/qt/Makefile
+++ b/src/modules/qt/Makefile
@@ -11,6 +11,7 @@ OBJS = factory.o producer_qimage.o producer_kdenlivetitle.o
 CPPOBJS = common.o \
 	graph.o \
 	filter_audiowaveform.o \
+	filter_qtext.o \
 	qimage_wrapper.o \
 	kdenlivetitle_wrapper.o \
 	producer_qtext.o \

--- a/src/modules/qt/factory.c
+++ b/src/modules/qt/factory.c
@@ -26,6 +26,7 @@
 extern mlt_consumer consumer_qglsl_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 #endif
 extern mlt_filter filter_audiowaveform_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
+extern mlt_filter filter_qtext_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_qimage_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_qtext_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_kdenlivetitle_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
@@ -51,6 +52,7 @@ MLT_REPOSITORY
 	MLT_REGISTER( consumer_type, "qglsl", consumer_qglsl_init );
 #endif
 	MLT_REGISTER( filter_type, "audiowaveform", filter_audiowaveform_init );
+	MLT_REGISTER( filter_type, "qtext", filter_qtext_init );
 	MLT_REGISTER( producer_type, "qimage", producer_qimage_init );
 	MLT_REGISTER( producer_type, "qtext", producer_qtext_init );
 	MLT_REGISTER( producer_type, "kdenlivetitle", producer_kdenlivetitle_init );
@@ -63,6 +65,7 @@ MLT_REPOSITORY
 	MLT_REGISTER( filter_type, "lightshow", filter_lightshow_init );
 #endif
 	MLT_REGISTER_METADATA( filter_type, "audiowaveform", metadata, "filter_audiowaveform.yml" );
+	MLT_REGISTER_METADATA( filter_type, "qtext", metadata, "filter_qtext.yml" );
 #ifdef USE_FFTW
 	MLT_REGISTER_METADATA( filter_type, "lightshow", metadata, "filter_lightshow.yml" );
 	MLT_REGISTER_METADATA( filter_type, "audiospectrum", metadata, "filter_audiospectrum.yml" );

--- a/src/modules/qt/filter_qtext.cpp
+++ b/src/modules/qt/filter_qtext.cpp
@@ -1,0 +1,344 @@
+/*
+ * filter_qtext.cpp -- text overlay filter
+ * Copyright (c) 2018 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "common.h"
+#include <framework/mlt.h>
+#include <framework/mlt_log.h>
+#include <QPainter>
+#include <QTextCodec>
+
+static QRectF get_text_path( QPainterPath* qpath, mlt_properties filter_properties, const char* text )
+{
+	int outline = mlt_properties_get_int( filter_properties, "outline" );
+	char* halign = mlt_properties_get( filter_properties, "halign" );
+	char* style = mlt_properties_get( filter_properties, "style" );
+	char* encoding = mlt_properties_get( filter_properties, "encoding" );
+	int pad = mlt_properties_get_int( filter_properties, "pad" );
+	int offset = pad + ( outline / 2 );
+	int width = 0;
+	int height = 0;
+
+	qpath->setFillRule( Qt::WindingFill );
+
+	// Get the strings to display
+	QTextCodec *codec = QTextCodec::codecForName( encoding );
+	QTextDecoder *decoder = codec->makeDecoder();
+	QString s = decoder->toUnicode( text );
+	delete decoder;
+	QStringList lines = s.split( "\n" );
+
+	// Configure the font
+	QFont font;
+	font.setPixelSize( mlt_properties_get_int( filter_properties, "size" ) );
+	font.setFamily( mlt_properties_get( filter_properties, "family" ) );
+	font.setWeight( ( mlt_properties_get_int( filter_properties, "weight" ) / 10 ) -1 );
+	switch( style[0] )
+	{
+	case 'i':
+	case 'I':
+		font.setStyle( QFont::StyleItalic );
+		break;
+	}
+	QFontMetrics fm( font );
+
+	// Determine the text rectangle size
+	height = fm.lineSpacing() * lines.size();
+	for( int i = 0; i < lines.size(); ++i )
+	{
+		const QString line = lines[i];
+		int line_width = fm.width(line);
+		int bearing = (line.size() > 0) ? fm.leftBearing(line.at(0)) : 0;
+		if (bearing < 0)
+			line_width -= bearing;
+		bearing = (line.size() > 0) ? fm.rightBearing(line.at(line.size() - 1)) : 0;
+		if (bearing < 0)
+			line_width -= bearing;
+		if (line_width > width)
+			width = line_width;
+	}
+
+	// Lay out the text in the path
+	int x = 0;
+	int y = fm.ascent() + offset;
+	for( int i = 0; i < lines.size(); ++i )
+	{
+		QString line = lines.at(i);
+		x = offset;
+		int line_width = fm.width(line);
+		int bearing = (line.size() > 0)? fm.leftBearing(line.at(0)) : 0;
+
+		if (bearing < 0) {
+			line_width -= bearing;
+			x -= bearing;
+		}
+		bearing = (line.size() > 0)? fm.rightBearing(line.at(line.size() - 1)) : 0;
+		if (bearing < 0)
+			line_width -= bearing;
+
+		switch( halign[0] )
+		{
+			default:
+			case 'l':
+			case 'L':
+				break;
+			case 'c':
+			case 'C':
+				x += ( width - line_width ) / 2;
+				break;
+			case 'r':
+			case 'R':
+				x += width - line_width;
+				break;
+		}
+		qpath->addText( x, y, font, line );
+		y += fm.lineSpacing();
+	}
+
+	// Account for outline and pad
+	width += offset * 2;
+	height += offset * 2;
+	// Sanity check
+	if( width == 0 ) width = 1;
+	height += 2; // I found some fonts whose descenders get cut off.
+
+	return QRectF( 0, 0, width, height );
+}
+
+static QColor get_qcolor( mlt_properties filter_properties, const char* name )
+{
+	mlt_color color = mlt_properties_get_color( filter_properties, name );
+	return QColor( color.r, color.g, color.b, color.a );
+}
+
+static QPen get_qpen( mlt_properties filter_properties )
+{
+	QColor color;
+	int outline = mlt_properties_get_int( filter_properties, "outline" );
+	QPen pen;
+
+	pen.setWidth( outline );
+	if( outline )
+	{
+		color = get_qcolor( filter_properties, "olcolour" );
+	}
+	else
+	{
+		color = get_qcolor( filter_properties, "bgcolour" );
+	}
+	pen.setColor( color );
+
+	return pen;
+}
+
+static QBrush get_qbrush( mlt_properties filter_properties )
+{
+	QColor color = get_qcolor( filter_properties, "fgcolour" );
+	return QBrush ( color );
+}
+
+static void transform_painter( QPainter* painter, mlt_rect frame_rect, QRectF path_rect, mlt_properties filter_properties, mlt_profile profile )
+{
+	qreal sx = 1.0;
+	qreal sy = mlt_profile_sar( profile );
+	qreal path_width = path_rect.width() * sx;
+	if( path_width > frame_rect.w )
+	{
+		sx *= frame_rect.w / path_width;
+		sy *= frame_rect.w / path_width;
+	}
+	qreal path_height = path_rect.height() * sy;
+	if( path_height > frame_rect.h )
+	{
+		sx *= frame_rect.h / path_height;
+		sy *= frame_rect.h / path_height;
+	}
+
+	qreal dx = frame_rect.x;
+	qreal dy = frame_rect.y;
+	char* halign = mlt_properties_get( filter_properties, "halign" );
+	switch( halign[0] )
+	{
+		default:
+		case 'l':
+		case 'L':
+			break;
+		case 'c':
+		case 'C':
+			dx += ( frame_rect.w - ( sx * path_rect.width() ) ) / 2;
+			break;
+		case 'r':
+		case 'R':
+			dx += frame_rect.w - ( sx * path_rect.width() );
+			break;
+	}
+	char* valign = mlt_properties_get( filter_properties, "valign" );
+	switch( valign[0] )
+	{
+		default:
+		case 't':
+		case 'T':
+			break;
+		case 'm':
+		case 'M':
+			dy += ( frame_rect.h - ( sy * path_rect.height() ) ) / 2;
+			break;
+		case 'b':
+		case 'B':
+			dy += frame_rect.h - ( sy * path_rect.height() );
+			break;
+	}
+
+	QTransform transform;
+	transform.translate( dx, dy );
+	transform.scale( sx, sy );
+	painter->setTransform( transform );
+}
+
+static void paint_background( QPainter* painter, QRectF path_rect, mlt_properties filter_properties )
+{
+	QColor bg_color = get_qcolor( filter_properties, "bgcolour" );
+	painter->fillRect( path_rect, bg_color );
+}
+
+static void paint_text( QPainter* painter, QPainterPath* qpath, mlt_properties filter_properties )
+{
+	QPen pen = get_qpen( filter_properties );
+	painter->setPen( pen );
+	QBrush brush = get_qbrush( filter_properties );
+	painter->setBrush( brush );
+	painter->drawPath( *qpath );
+}
+
+static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format *image_format, int *width, int *height, int writable )
+{
+	int error = 0;
+	mlt_filter filter = (mlt_filter)mlt_frame_pop_service( frame );
+	char* argument = (char*)mlt_frame_pop_service( frame );
+	mlt_properties filter_properties = MLT_FILTER_PROPERTIES( filter );
+	mlt_profile profile = mlt_service_profile(MLT_FILTER_SERVICE(filter));
+	mlt_position position = mlt_filter_get_position( filter, frame );
+	mlt_position length = mlt_filter_get_length2( filter, frame );
+	char* geom_str = mlt_properties_get( filter_properties, "geometry" );
+	if( !geom_str )
+	{
+		mlt_log_warning( MLT_FILTER_SERVICE(filter), "geometry property not set\n" );
+		mlt_frame_get_image( frame, image, image_format, width, height, writable );
+		free( argument );
+		return 1;
+	}
+	mlt_rect rect = mlt_properties_anim_get_rect( filter_properties, "geometry", position, length );
+
+	// Get the current image
+	*image_format = mlt_image_rgb24a;
+	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "resize_alpha", 255 );
+	error = mlt_frame_get_image( frame, image, image_format, width, height, writable );
+
+	if( !error )
+	{
+		if ( strchr( geom_str, '%' ) )
+		{
+			rect.x *= *width;
+			rect.w *= *width;
+			rect.y *= *height;
+			rect.h *= *height;
+		}
+
+		QImage qimg( *width, *height, QImage::Format_ARGB32 );
+		convert_mlt_to_qimage_rgba( *image, &qimg, *width, *height );
+
+		QPainterPath text_path;
+		QRectF path_rect = get_text_path( &text_path, filter_properties, argument );
+		QPainter painter( &qimg );
+		painter.setRenderHints( QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::HighQualityAntialiasing );
+		transform_painter( &painter, rect, path_rect, filter_properties, profile );
+		paint_background( &painter, path_rect, filter_properties );
+		paint_text( &painter, &text_path, filter_properties );
+		painter.end();
+
+		convert_qimage_to_mlt_rgba( &qimg, *image, *width, *height );
+	}
+	free( argument );
+
+	return error;
+}
+
+/** Filter processing.
+*/
+
+static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
+{
+	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
+	char* argument = mlt_properties_get( properties, "argument" );
+	if ( !argument || !strcmp( "", argument ) )
+		return frame;
+
+	// Save the text to be used by get_image() to support parallel processing
+	// when this filter is encapsulated by other filters.
+	mlt_frame_push_service( frame, strdup( argument ) );
+
+	// Push the filter on to the stack
+	mlt_frame_push_service( frame, filter );
+
+	// Push the get_image on to the stack
+	mlt_frame_push_get_image( frame, filter_get_image );
+
+	return frame;
+}
+
+/** Constructor for the filter.
+*/
+
+extern "C" {
+
+mlt_filter filter_qtext_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	mlt_filter filter = mlt_filter_new();
+
+	if( !filter ) return NULL;
+
+	if ( !createQApplicationIfNeeded( MLT_FILTER_SERVICE(filter) ) )  {
+		mlt_filter_close( filter );
+		return NULL;
+	}
+
+	filter->process = filter_process;
+
+	mlt_properties filter_properties = MLT_FILTER_PROPERTIES( filter );
+	// Assign default values
+	mlt_properties_set( filter_properties, "argument", arg ? arg: "text" );
+	mlt_properties_set( filter_properties, "geometry", "0%/0%:100%x100%:100%" );
+	mlt_properties_set( filter_properties, "family", "Sans" );
+	mlt_properties_set( filter_properties, "size", "48" );
+	mlt_properties_set( filter_properties, "weight", "400" );
+	mlt_properties_set( filter_properties, "style", "normal" );
+	mlt_properties_set( filter_properties, "fgcolour", "0x000000ff" );
+	mlt_properties_set( filter_properties, "bgcolour", "0x00000020" );
+	mlt_properties_set( filter_properties, "olcolour", "0x00000000" );
+	mlt_properties_set( filter_properties, "pad", "0" );
+	mlt_properties_set( filter_properties, "halign", "left" );
+	mlt_properties_set( filter_properties, "valign", "top" );
+	mlt_properties_set( filter_properties, "outline", "0" );
+	mlt_properties_set( filter_properties, "encoding", "UTF-8" );
+
+	mlt_properties_set_int( filter_properties, "_filter_private", 1 );
+
+	return filter;
+}
+
+}

--- a/src/modules/qt/filter_qtext.yml
+++ b/src/modules/qt/filter_qtext.yml
@@ -1,0 +1,156 @@
+schema_version: 0.1
+type: filter
+identifier: qtext
+title: QText
+version: 1
+copyright: Meltytech, LLC
+creator: Brian Matherly
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+description: Overlay text onto the video
+
+parameters:
+  - identifier: argument
+    title: Text
+    type: string
+    description: |
+      The text to overlay.
+    required: yes
+    readonly: no
+    default: text
+    widget: text
+
+  - identifier: geometry
+    title: Geometry
+    type: geometry
+    description: A set of X/Y coordinates by which to adjust the text.
+    default: 0%/0%:100%x100%:100
+
+  - identifier: family
+    title: Font family
+    type: string
+    description: >
+      The typeface of the font.
+    default: Sans
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: size
+    title: Font size
+    type: integer
+    description: >
+      The size in pixels of the font. 
+    default: 48
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: style
+    title: Font style
+    type: string
+    description: >
+      The style of the font.
+    values:
+      - normal
+      - italic
+    default: normal
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: weight
+    title: Font weight
+    type: integer
+    description: The weight of the font.
+    minimum: 100
+    maximum: 1000
+    default: 400
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: fgcolour
+    title: Foreground color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x000000ff
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: bgcolour
+    title: Background color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x00000020
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: olcolour
+    title: Outline color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: outline
+    title: Outline Width
+    type: string
+    description: >
+      The width of the outline in pixels.
+    readonly: no
+    default: 0
+    minimum: 0
+    maximum: 3
+    mutable: yes
+    widget: spinner
+
+  - identifier: pad
+    title: Padding
+    type: integer
+    description: >
+      The number of pixels to pad the background rectangle beyond edges of text.
+    readonly: no
+    default: 0
+    mutable: yes
+    widget: spinner
+
+  - identifier: halign
+    title: Horizontal alignment
+    description: >
+      Set the horizontal alignment within the geometry rectangle.
+    type: string
+    default: left
+    values:
+      - left
+      - centre
+      - right
+    mutable: yes
+    widget: combo
+
+  - identifier: valign
+    title: Vertical alignment
+    description: >
+      Set the vertical alignment within the geometry rectangle.
+    type: string
+    default: top
+    values:
+      - top
+      - middle
+      - bottom
+    mutable: yes
+    widget: combo


### PR DESCRIPTION
When I apply the dynamic text filter in Shotcut on my system it causes slight lag in the preview. I set out to see if I could find an optimization. This change adds a new qtext filter which draws directly on to the video frame.

Here are some examples that show the performance change:

Generate 10000 color frames:
```
time ./shotcut/Shotcut/Shotcut.app/melt colour:red length=10000 out=10000 -consumer null terminate_on_pause=1 real_time=4
real	0m4.415s
user	0m6.723s
sys	0m0.557s
```

Generate 10000 color frames and apply the original dynamictext filter:
```
time ./shotcut/Shotcut/Shotcut.app/melt colour:red length=10000 out=10000 -filter dynamictext:hello size=500 geometry="0 0 720 480" -consumer null terminate_on_pause=1 real_time=4
real	0m20.823s
user	0m49.622s
sys	0m1.853s
```

Generate 10000 color frames and appy the new dynamictext filter using qtext:
```
time ./shotcut/Shotcut/Shotcut.app/melt colour:red length=10000 out=10000 -filter dynamictext:hello size=500 geometry="0 0 720 480" -consumer null terminate_on_pause=1 real_time=4
eal	0m7.605s
user	0m20.214s
sys	0m0.705s
```

This is obviously a large change that requires vetting before release. Also, there is no urgency. Please let me know there are any changes I should make or any tests you would like me to run.