### PR TITLE
Add window parameter to waveform filter.

### DIFF
--- a/src/modules/qt/filter_audiowaveform.yml
+++ b/src/modules/qt/filter_audiowaveform.yml
@@ -74,6 +74,7 @@ parameters:
       The audio channel to draw.
       
       "0" indicates that all channels should be drawn.
+      "-1" indicates that all channels will be added together in a single waveform.
     readonly: no
     default: 0
     minimum: 0
@@ -126,3 +127,17 @@ parameters:
     readonly: no
     mutable: yes
     widget: combo
+
+  - identifier: window
+    title: Window
+    type: integer
+    description: >
+      The duration of the audio (in ms) to be drawn in the waveform.
+      If the window is less than the duration of a frame, the duration of a
+      frame will be used. If the window is more than the duration of a
+      frame, samples will be buffered from previous frames to fill the window.
+      The buffering is performed as a sliding window so that the most recent
+      samples are always transformed.
+    mutable: no
+    readonly: no
+    default: 0


### PR DESCRIPTION
Historical audio samples are stored in a sliding window buffer and
copied on to each frame to be draw in get_image().