### PR TITLE
Linsys: do not free null pointer

### DIFF
--- a/src/modules/linsys/consumer_SDIstream.c
+++ b/src/modules/linsys/consumer_SDIstream.c
@@ -378,7 +378,6 @@ static void *consumer_thread(void *arg) {
 		}
 	} else if (this->device_file_video &&
 			strstr(this->device_file_video, "sdivideotx")) {
-		free(this->device_file_audio);
 		this->device_file_audio = strdup("/dev/sdiaudiotx0");
 	}
 


### PR DESCRIPTION
This seems to be a dangerous copy-pasted line.
Refer issue https://github.com/mltframework/mlt/issues/392 part 1