### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/src/swig/python/codecs.py
+++ b/src/swig/python/codecs.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Import required modules
+from __future__ import print_function
 import mlt
 
 # Start the mlt system
@@ -21,4 +22,4 @@ codecs = mlt.Properties( c.get_data( 'vcodec' ) )
 
 # Print the list of codecs
 for i in range( 0, codecs.count()):
-	print codecs.get( i )
+	print(codecs.get( i ))

--- a/src/swig/python/play.py
+++ b/src/swig/python/play.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Import required modules
+from __future__ import print_function
 import mlt
 import time
 import sys
@@ -33,5 +34,5 @@ if p:
 		time.sleep( 1 )
 else:
 	# Diagnostics
-	print "Unable to open ", sys.argv[ 1 ]
+	print("Unable to open ", sys.argv[ 1 ])
 

--- a/src/swig/python/test_animation.py
+++ b/src/swig/python/test_animation.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import mlt
 
 p = mlt.Properties()
 p.anim_set("foo", "bar", 10)
 a = p.get_anim("bar")
-print "bar is valid:", a.is_valid()
+print("bar is valid:", a.is_valid())
 a = p.get_anim("foo")
-print "foo is valid:", a.is_valid()
-print "serialize:", a.serialize_cut()
+print("foo is valid:", a.is_valid())
+print("serialize:", a.serialize_cut())


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.