### PR TITLE
Travis CI: Add a parallel run of Python 3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,3 @@ matrix:
       script:
         # stop the build if there are Python syntax errors or undefined names
         - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
-language: c
-services:
-  - docker
-before_install:
-  - docker pull ubuntu:16.04
-script:
-  - docker run -v $PWD:/root -w /root ubuntu:16.04 /bin/sh -c "sed -i -e 's/# deb-src/deb-src/' /etc/apt/sources.list && apt-get -qq update && apt-get -y build-dep melt && ./configure --enable-gpl --enable-gpl3 && make -j"
-
 matrix:
   include:
+    - language: c
+      services:
+        - docker
+      before_install:
+        - docker pull ubuntu:16.04
+      script:
+        - docker run -v $PWD:/root -w /root ubuntu:16.04 /bin/sh -c "sed -i -e 's/# deb-src/deb-src/' /etc/apt/sources.list && apt-get -qq update && apt-get -y build-dep melt && ./configure --enable-gpl --enable-gpl3 && make -j"
     - language: python
       python: 3.7
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: c
-sudo: required
 services:
   - docker
 before_install:
   - docker pull ubuntu:16.04
 script:
   - docker run -v $PWD:/root -w /root ubuntu:16.04 /bin/sh -c "sed -i -e 's/# deb-src/deb-src/' /etc/apt/sources.list && apt-get -qq update && apt-get -y build-dep melt && ./configure --enable-gpl --enable-gpl3 && make -j"
- 
+
+matrix:
+  include:
+    - language: python
+      python: 3.7
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      services: true  # override docker
+      before_install: pip install flake8
+      script:
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     - language: python
       python: 3.7
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-      services: true  # override docker
       before_install: pip install flake8
       script:
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Blocked by #407

[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
