### PR TITLE
from __future__ import print_function is not always required

### DIFF
--- a/src/swig/python/build
+++ b/src/swig/python/build
@@ -13,7 +13,7 @@ path=`which python 2> /dev/null`
 if [ $? = 0 ]
 then
 	# Change this as needed
-	export PYTHON_INCLUDE=`python -c "from __future__ import print_function;import sys;print(\"%s/include/python%d.%d\"%(sys.prefix,sys.version_info[0],sys.version_info[1]))"`
+	export PYTHON_INCLUDE=`python -c "import sys;print(\"{}/include/python{}.{}\".format(sys.prefix,*sys.version_info))"`
 
 	[ ! -d "$PYTHON_INCLUDE" ] && echo python development missing && exit 1
 


### PR DESCRIPTION
The __from \_\_future\_\_ import print_function__ line is only required when:
1. The legacy __print__ statement contains a comma (,)
2. The new __print()__ function will require a named parameter (__end=__, __file=__, ...)
3. We want legacy __print__ statements to also be a syntax error in Python 2 to prevent the addition of new __print__ statements that break Python 3 compatibility.

Since none of these conditions are met in this instance, we can drop the import for readability.