### PR TITLE
Mark frei0r IIRblur not thread safe

### DIFF
--- a/src/modules/frei0r/not_thread_safe.txt
+++ b/src/modules/frei0r/not_thread_safe.txt
@@ -31,6 +31,7 @@ grain_extract=0.2
 gain_merge=0.2
 hardlight=0.2
 hqdn3d
+IIRblur
 hue=0.2
 keyspillm0pup=0.3
 lighten=0.2


### PR DESCRIPTION
From my tests, frei0r IIRblur is not thread safe and produces corrupted result when using threads