### PR TITLE
add convenience constructor for Mlt::Producer

### DIFF
--- a/src/mlt++/Makefile
+++ b/src/mlt++/Makefile
@@ -10,7 +10,7 @@ LIBFLAGS += -install_name $(libdir)/$(SONAME) -current_version $(version) -compa
 else ifeq ($(targetos), MinGW)
 NAME = libmlt++$(LIBSUF)
 TARGET = libmlt++-$(soversion)$(LIBSUF)
-CXXFLAGS += -DMLTPP_EXPORTS
+CXXFLAGS += -DMLTPP_EXPORTS --std=c++11
 LIBFLAGS += -Wl,--output-def,libmlt++.def
 else
 NAME = libmlt++$(LIBSUF)

--- a/src/mlt++/MltConsumer.cpp
+++ b/src/mlt++/MltConsumer.cpp
@@ -38,6 +38,11 @@ Consumer::Consumer( Profile& profile ) :
 }
 
 Consumer::Consumer( Profile& profile, const char *id, const char *arg ) :
+	Consumer ( profile.get_profile(), id, arg )
+{
+}
+
+Consumer::Consumer( mlt_profile profile, const char *id, const char *arg ) :
 	instance( NULL )
 {
 	if ( id == NULL || arg != NULL )

--- a/src/mlt++/MltConsumer.h
+++ b/src/mlt++/MltConsumer.h
@@ -40,6 +40,7 @@ namespace Mlt
 			Consumer( );
 			Consumer( Profile& profile );
 			Consumer( Profile& profile, const char *id , const char *service = NULL );
+			Consumer( mlt_profile profile, const char *id , const char *service = NULL );
 			Consumer( Service &consumer );
 			Consumer( Consumer &consumer );
 			Consumer( mlt_consumer consumer );

--- a/src/mlt++/MltFilter.cpp
+++ b/src/mlt++/MltFilter.cpp
@@ -25,6 +25,11 @@
 using namespace Mlt;
 
 Filter::Filter( Profile& profile, const char *id, const char *arg ) :
+	Filter( profile.get_profile(), id, arg )
+{
+}
+
+Filter::Filter( mlt_profile profile, const char *id, const char *arg ) :
 	instance( NULL )
 {
 	if ( arg != NULL )

--- a/src/mlt++/MltFilter.h
+++ b/src/mlt++/MltFilter.h
@@ -39,6 +39,7 @@ namespace Mlt
 			mlt_filter instance;
 		public:
 			Filter( Profile& profile, const char *id, const char *service = NULL );
+			Filter( mlt_profile profile, const char *id, const char *service = NULL );
 			Filter( Service &filter );
 			Filter( Filter &filter );
 			Filter( mlt_filter filter );

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -32,13 +32,18 @@ Producer::Producer( ) :
 }
 
 Producer::Producer( Profile& profile, const char *id, const char *service ) :
+	Producer( profile.get_profile() , id, service )
+{
+}
+
+Producer::Producer( mlt_profile profile, const char *id, const char *service ) :
 	instance( NULL ),
 	parent_( NULL )
 {
 	if ( id != NULL && service != NULL )
-		instance = mlt_factory_producer( profile.get_profile(), id, service );
+		instance = mlt_factory_producer( profile, id, service );
 	else
-		instance = mlt_factory_producer( profile.get_profile(), NULL, id != NULL ? id : service );
+		instance = mlt_factory_producer( profile, NULL, id != NULL ? id : service );
 }
 
 Producer::Producer( Service &producer ) :

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -42,6 +42,7 @@ namespace Mlt
 		public:
 			Producer( );
 			Producer( Profile& profile, const char *id, const char *service = NULL );
+			Producer( mlt_profile profile, const char *id, const char *service = NULL );
 			Producer( Service &producer );
 			Producer( mlt_producer producer );
 			Producer( Producer &producer );

--- a/src/mlt++/MltService.cpp
+++ b/src/mlt++/MltService.cpp
@@ -149,7 +149,12 @@ Filter *Service::filter( int index )
 	return result == NULL ? NULL : new Filter( result );
 }
 
+void Service::set_profile( mlt_profile profile )
+{
+    mlt_service_set_profile( get_service( ), profile );
+}
+
 void Service::set_profile( Profile &profile )
 {
-	mlt_service_set_profile( get_service( ), profile.get_profile( ) );
+	set_profile( profile.get_profile( ) );
 }

--- a/src/mlt++/MltService.h
+++ b/src/mlt++/MltService.h
@@ -63,6 +63,7 @@ namespace Mlt
 			int filter_count( );
 			int move_filter( int from, int to );
 			Filter *filter( int index );
+			void set_profile( mlt_profile profile );
 			void set_profile( Profile &profile );
 	};
 }

--- a/src/mlt++/MltTractor.cpp
+++ b/src/mlt++/MltTractor.cpp
@@ -61,6 +61,11 @@ Tractor::Tractor( Tractor &tractor ) :
 }
 
 Tractor::Tractor( Profile& profile, char *id, char *resource ) :
+	Tractor( profile.get_profile(), id, resource )
+{
+}
+
+Tractor::Tractor( mlt_profile profile, char *id, char *resource ) :
 	instance( NULL )
 {
 	Producer producer( profile, id, resource );

--- a/src/mlt++/MltTractor.h
+++ b/src/mlt++/MltTractor.h
@@ -47,6 +47,7 @@ namespace Mlt
 			Tractor( mlt_tractor tractor );
 			Tractor( Tractor &tractor );
 			Tractor( Profile& profile, char *id, char *arg = NULL );
+			Tractor( mlt_profile profile, char *id, char *arg = NULL );
 			virtual ~Tractor( );
 			virtual mlt_tractor get_tractor( );
 			mlt_producer get_producer( );

--- a/src/mlt++/MltTransition.cpp
+++ b/src/mlt++/MltTransition.cpp
@@ -26,6 +26,11 @@
 using namespace Mlt;
 
 Transition::Transition( Profile& profile, const char *id, const char *arg ) :
+	Transition( profile.get_profile(), id, arg )
+{
+}
+
+Transition::Transition( mlt_profile profile, const char *id, const char *arg ) :
 	instance( NULL )
 {
 	if ( arg != NULL )

--- a/src/mlt++/MltTransition.h
+++ b/src/mlt++/MltTransition.h
@@ -38,6 +38,7 @@ namespace Mlt
 			mlt_transition instance;
 		public:
 			Transition( Profile& profile, const char *id, const char *arg = NULL );
+			Transition( mlt_profile profile, const char *id, const char *arg = NULL );
 			Transition( Service &transition );
 			Transition( Transition &transition );
 			Transition( mlt_transition transition );

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -546,3 +546,10 @@ MLTPP_6.10.0 {
       "Mlt::Animation::serialize_cut(mlt_time_format, int, int)";
   };
 } MLTPP_6.8.0;
+
+MLTPP_6.14.0 {
+  global:
+    extern "C++" {
+      "Mlt::Producer::Producer(mlt_profile_s*, char const*, char const*)";
+  };
+} MLTPP_6.10.0;

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -552,5 +552,6 @@ MLTPP_6.14.0 {
     extern "C++" {
       "Mlt::Producer::Producer(mlt_profile_s*, char const*, char const*)";
       "Mlt::Consumer::Consumer(mlt_profile_s*, char const*, char const*)";
+      "Mlt::Transition::Transition(mlt_profile_s*, char const*, char const*)";
   };
 } MLTPP_6.10.0;

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -554,5 +554,7 @@ MLTPP_6.14.0 {
       "Mlt::Consumer::Consumer(mlt_profile_s*, char const*, char const*)";
       "Mlt::Transition::Transition(mlt_profile_s*, char const*, char const*)";
       "Mlt::Filter::Filter(mlt_profile_s*, char const*, char const*)";
+      "Mlt::Tractor::Tractor(mlt_profile_s*, char const*, char const*)";
+      "Mlt::Service::set_profile(mlt_profile_s*)";
   };
 } MLTPP_6.10.0;

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -551,5 +551,6 @@ MLTPP_6.14.0 {
   global:
     extern "C++" {
       "Mlt::Producer::Producer(mlt_profile_s*, char const*, char const*)";
+      "Mlt::Consumer::Consumer(mlt_profile_s*, char const*, char const*)";
   };
 } MLTPP_6.10.0;

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -553,5 +553,6 @@ MLTPP_6.14.0 {
       "Mlt::Producer::Producer(mlt_profile_s*, char const*, char const*)";
       "Mlt::Consumer::Consumer(mlt_profile_s*, char const*, char const*)";
       "Mlt::Transition::Transition(mlt_profile_s*, char const*, char const*)";
+      "Mlt::Filter::Filter(mlt_profile_s*, char const*, char const*)";
   };
 } MLTPP_6.10.0;


### PR DESCRIPTION
The motivation behind is the following. Let's assume you want to create a producer, and use the same profile as another producer that you have a pointer to. The natural way of doing so would look like this:
```
Producer *original; // obtained externally
Producer copy(*original->profile(), "color", "red");
```
However, this will create a memory leak, since the Producer::profile() function creates a Profile instance that will never be freed.

Another approach could be similar to:
```
Producer *original; // obtained externally
Profile originalProfile(original->get_profile());
Producer copy(originalProfile, "color", "red");
```
However, this solution is not possible: if the producer outlives the `originalProfile`, then, since profiles are not ref-counted, the destructor of Profile will close the profile and the producer will be in a very unstable state (accessing any profile property, directly or indirectly, will cause a segfault).

One "good" solution would be to add a reference counter to the profile objects, in a similar spirit to the properties. However, this is a substantial design change, and as a hacky solution I propose to add a constructor to profile that allows to avoid the creation of a cpp Profile. The leak-free, correct version of the snippet above would then become
```
Producer *original; // obtained externally
Producer copy(original->get_profile(), "color", "red");
```

I'm happy to discuss alternative design fixes.
