### PR TITLE
Add reorder function to mlt playlist.

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -532,4 +532,5 @@ MLT_6.12.0 {
 MLT_6.14.0 {
   global:
     mlt_frame_get_unique_properties;
+    mlt_playlist_reorder;
 } MLT_6.12.0;

--- a/src/framework/mlt_playlist.c
+++ b/src/framework/mlt_playlist.c
@@ -946,6 +946,48 @@ int mlt_playlist_move( mlt_playlist self, int src, int dest )
 	return 0;
 }
 
+/** Reorder the entries in the playlist.
+ *
+ * \public \memberof mlt_playlist_s
+ * \param self a playlist
+ * \param indices a list of current indices mapped to the new desired index
+ * \return true if there was an error
+ */
+
+int mlt_playlist_reorder( mlt_playlist self, const int *indices )
+{
+	// Check that the playlist is sortable.
+	if ( self->count < 2 ) return 1;
+
+	// Sanity check the indices. The values must be in range and unique.
+	int i, j;
+	for ( i = 0; i < self->count - 1; i++ )
+		for ( j = i + 1; j < self->count; j++ )
+			if ( indices[i] < 0 || indices[i] >= self->count ||
+				 indices[j] < 0 || indices[j] >= self->count ||
+				 indices[i] == indices[j] )
+				return 1;
+
+	// Create a new list to copy entries in a new order.
+	playlist_entry **new_list = calloc( self->size, sizeof( playlist_entry * ) );
+	if ( new_list == NULL ) return 1;
+
+	// Copy entries according to the new indices
+	int new_index;
+	for ( new_index = 0; new_index < self->count; new_index++ )
+	{
+		int old_index = indices[new_index];
+		new_list[new_index] = self->list[old_index];
+	}
+
+	// Delete the old list and save the new list
+	free( self->list );
+	self->list = new_list;
+	mlt_playlist_virtual_refresh( self );
+
+	return 0;
+}
+
 /** Repeat the specified clip n times.
  *
  * \public \memberof mlt_playlist_s

--- a/src/framework/mlt_playlist.h
+++ b/src/framework/mlt_playlist.h
@@ -101,6 +101,7 @@ extern int mlt_playlist_get_clip_info( mlt_playlist self, mlt_playlist_clip_info
 extern int mlt_playlist_insert( mlt_playlist self, mlt_producer producer, int where, mlt_position in, mlt_position out );
 extern int mlt_playlist_remove( mlt_playlist self, int where );
 extern int mlt_playlist_move( mlt_playlist self, int from, int to );
+extern int mlt_playlist_reorder( mlt_playlist self, const int *indices );
 extern int mlt_playlist_resize_clip( mlt_playlist self, int clip, mlt_position in, mlt_position out );
 extern int mlt_playlist_repeat_clip( mlt_playlist self, int clip, int repeat );
 extern int mlt_playlist_split( mlt_playlist self, int clip, mlt_position position );

--- a/src/mlt++/MltPlaylist.cpp
+++ b/src/mlt++/MltPlaylist.cpp
@@ -201,6 +201,11 @@ int Playlist::move( int from, int to )
 	return mlt_playlist_move( get_playlist( ), from, to );
 }
 
+int Playlist::reorder( const int *indices )
+{
+	return mlt_playlist_reorder( get_playlist( ), indices );
+}
+
 int Playlist::resize_clip( int clip, int in, int out )
 {
 	return mlt_playlist_resize_clip( get_playlist( ), clip, in, out );

--- a/src/mlt++/MltPlaylist.h
+++ b/src/mlt++/MltPlaylist.h
@@ -81,6 +81,7 @@ namespace Mlt
 			int insert( Producer &producer, int where, int in = -1, int out = -1 );
 			int remove( int where );
 			int move( int from, int to );
+			int reorder( const int *indices );
 			int resize_clip( int clip, int in, int out );
 			int split( int clip, int position );
 			int split_at( int position, bool left = true );

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -556,5 +556,6 @@ MLTPP_6.14.0 {
       "Mlt::Filter::Filter(mlt_profile_s*, char const*, char const*)";
       "Mlt::Tractor::Tractor(mlt_profile_s*, char const*, char const*)";
       "Mlt::Service::set_profile(mlt_profile_s*)";
+      "Mlt::Playlist::reorder(int const*)";
   };
 } MLTPP_6.10.0;

--- a/src/tests/test_playlist/test_playlist.cpp
+++ b/src/tests/test_playlist/test_playlist.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2019 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with consumer library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <QtTest>
+
+#include <mlt++/Mlt.h>
+using namespace Mlt;
+
+class TestPlaylist : public QObject
+{
+    Q_OBJECT
+    Profile profile;
+
+public:
+    TestPlaylist()
+        : profile("dv_pal")
+    {
+        Factory::init();
+    }
+
+private Q_SLOTS:
+
+    void Append()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+        Producer p(profile, "noise");
+        QVERIFY(p.is_valid());
+        QCOMPARE(pl.count(), 0);
+        int result = pl.append(p);
+        QCOMPARE(result, 0); // Success
+        QCOMPARE(pl.count(), 1);
+    }
+
+    void Remove()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+        Producer p(profile, "noise");
+        QVERIFY(p.is_valid());
+        QCOMPARE(pl.count(), 0);
+        pl.append(p);
+        QCOMPARE(pl.count(), 1);
+        int result = pl.remove(0);
+        QCOMPARE(result, 0); // Success
+        QCOMPARE(pl.count(), 0);
+    }
+
+    void RemoveErrorOnInvalidIndex()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+        Producer p(profile, "noise");
+        QVERIFY(p.is_valid());
+        QCOMPARE(pl.count(), 0);
+        pl.append(p);
+        QCOMPARE(pl.count(), 1);
+        int result = pl.remove(10); // Invalid index
+        QCOMPARE(result, 1); // Fail
+        QCOMPARE(pl.count(), 1);
+    }
+
+    void Move()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+
+        // Initial order: 1, 2, 3
+        Producer p1(profile, "noise");
+        p1.set("id", 1);
+        QVERIFY(p1.is_valid());
+        pl.append(p1);
+        Producer p2(profile, "noise");
+        p2.set("id", 2);
+        QVERIFY(p2.is_valid());
+        pl.append(p2);
+        Producer p3(profile, "noise");
+        p3.set("id", 3);
+        QVERIFY(p3.is_valid());
+        pl.append(p3);
+        QCOMPARE(pl.count(), 3);
+
+        // Move first to last
+        int result = pl.move(0, 2);
+        QCOMPARE(result, 0); // Success
+        QCOMPARE(pl.count(), 3);
+
+        // New order: 2, 3, 1
+        Producer* pp1 = pl.get_clip(0);
+        Producer* pp2 = pl.get_clip(1);
+        Producer* pp3 = pl.get_clip(2);
+        QCOMPARE(pp1->parent().get_int("id"), 2);
+        QCOMPARE(pp2->parent().get_int("id"), 3);
+        QCOMPARE(pp3->parent().get_int("id"), 1);
+        delete pp1;
+        delete pp2;
+        delete pp3;
+    }
+
+    void MoveCorrectInvalidIndex()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+
+        // Initial order: 1, 2, 3
+        Producer p1(profile, "noise");
+        p1.set("id", 1);
+        QVERIFY(p1.is_valid());
+        pl.append(p1);
+        Producer p2(profile, "noise");
+        p2.set("id", 2);
+        QVERIFY(p2.is_valid());
+        pl.append(p2);
+        Producer p3(profile, "noise");
+        p3.set("id", 3);
+        QVERIFY(p3.is_valid());
+        pl.append(p3);
+        QCOMPARE(pl.count(), 3);
+
+        // Move first to an invalid index
+        int result = pl.move(0, 10); // 10 is invalid
+        // This is still successful because move() corrects the index to be the last entry.
+        QCOMPARE(result, 0); // Success
+        QCOMPARE(pl.count(), 3);
+
+        // The first will be moved to the last after move() corrects the index.
+        Producer* pp1 = pl.get_clip(0);
+        Producer* pp2 = pl.get_clip(1);
+        Producer* pp3 = pl.get_clip(2);
+        QCOMPARE(pp1->parent().get_int("id"), 2);
+        QCOMPARE(pp2->parent().get_int("id"), 3);
+        QCOMPARE(pp3->parent().get_int("id"), 1);
+        delete pp1;
+        delete pp2;
+        delete pp3;
+    }
+
+    void Reorder()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+
+        // Initial order: 1, 2, 3
+        Producer p1(profile, "noise");
+        p1.set("id", 1);
+        QVERIFY(p1.is_valid());
+        pl.append(p1);
+        Producer p2(profile, "noise");
+        p2.set("id", 2);
+        QVERIFY(p2.is_valid());
+        pl.append(p2);
+        Producer p3(profile, "noise");
+        p3.set("id", 3);
+        QVERIFY(p3.is_valid());
+        pl.append(p3);
+        QCOMPARE(pl.count(), 3);
+
+        // Reverse the order of the clips.
+        int new_order[] = {2, 1, 0};
+        int result = pl.reorder(new_order);
+        QCOMPARE(result, 0); // Success
+        QCOMPARE(pl.count(), 3);
+
+        // The order will be reversed.
+        Producer* pp1 = pl.get_clip(0);
+        Producer* pp2 = pl.get_clip(1);
+        Producer* pp3 = pl.get_clip(2);
+        QCOMPARE(pp1->parent().get_int("id"), 3);
+        QCOMPARE(pp2->parent().get_int("id"), 2);
+        QCOMPARE(pp3->parent().get_int("id"), 1);
+        delete pp1;
+        delete pp2;
+        delete pp3;
+    }
+
+    void ReorderErrorOnDuplicate()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+
+        // Initial order: 1, 2, 3
+        Producer p1(profile, "noise");
+        p1.set("id", 1);
+        QVERIFY(p1.is_valid());
+        pl.append(p1);
+        Producer p2(profile, "noise");
+        p2.set("id", 2);
+        QVERIFY(p2.is_valid());
+        pl.append(p2);
+        Producer p3(profile, "noise");
+        p3.set("id", 3);
+        QVERIFY(p3.is_valid());
+        pl.append(p3);
+        QCOMPARE(pl.count(), 3);
+
+        // Provide an order with duplicate indices.
+        int new_order[] = {2, 2, 2};
+        int result = pl.reorder(new_order);
+        QCOMPARE(result, 1); // Fail
+        QCOMPARE(pl.count(), 3);
+
+        // The order will unchanged.
+        Producer* pp1 = pl.get_clip(0);
+        Producer* pp2 = pl.get_clip(1);
+        Producer* pp3 = pl.get_clip(2);
+        QCOMPARE(pp1->parent().get_int("id"), 1);
+        QCOMPARE(pp2->parent().get_int("id"), 2);
+        QCOMPARE(pp3->parent().get_int("id"), 3);
+        delete pp1;
+        delete pp2;
+        delete pp3;
+    }
+
+    void ReorderErrorOnInvalidIndex()
+    {
+        Playlist pl(profile);
+        QVERIFY(pl.is_valid());
+
+        // Initial order: 1, 2, 3
+        Producer p1(profile, "noise");
+        p1.set("id", 1);
+        QVERIFY(p1.is_valid());
+        pl.append(p1);
+        Producer p2(profile, "noise");
+        p2.set("id", 2);
+        QVERIFY(p2.is_valid());
+        pl.append(p2);
+        Producer p3(profile, "noise");
+        p3.set("id", 3);
+        QVERIFY(p3.is_valid());
+        pl.append(p3);
+        QCOMPARE(pl.count(), 3);
+
+        // Provide an order with an invalid index.
+        int new_order[] = {0, 1, 10};
+        int result = pl.reorder(new_order);
+        QCOMPARE(result, 1); // Fail
+        QCOMPARE(pl.count(), 3);
+
+        // The order will unchanged.
+        Producer* pp1 = pl.get_clip(0);
+        Producer* pp2 = pl.get_clip(1);
+        Producer* pp3 = pl.get_clip(2);
+        QCOMPARE(pp1->parent().get_int("id"), 1);
+        QCOMPARE(pp2->parent().get_int("id"), 2);
+        QCOMPARE(pp3->parent().get_int("id"), 3);
+        delete pp1;
+        delete pp2;
+        delete pp3;
+    }
+};
+
+QTEST_APPLESS_MAIN(TestPlaylist)
+
+#include "test_playlist.moc"

--- a/src/tests/test_playlist/test_playlist.pro
+++ b/src/tests/test_playlist/test_playlist.pro
@@ -1,0 +1,3 @@
+include(../common.pri)
+TARGET = test_playlist
+SOURCES += test_playlist.cpp

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -1,6 +1,7 @@
 TEMPLATE = subdirs
 SUBDIRS = test_filter \
     test_frame \
+    test_playlist \
     test_properties \
     test_repository \
     test_animation \


### PR DESCRIPTION
This change adds a function to allow a playlist to be arbitrarily reordered I would be open to discussion of other ways to accomplish this.