### PR TITLE
New option to change Windows installation layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ src/melt/melt
 src/modules/lumas/luma
 src/modules/lumas/NTSC/*.pgm
 src/modules/lumas/PAL/*.pgm
+src/modules/lumas/16_9/*.pgm
+src/modules/lumas/9_16/*.pgm
+src/modules/lumas/square/*.pgm
 src/modules/lumas/.executed
 src/swig/csharp/src_swig/*
 src/swig/perl/blib/*

--- a/configure
+++ b/configure
@@ -31,6 +31,7 @@ General build options:
   --cpu='cpu'                - Compile for a specific CPU (default: none)
   --target-os='os'           - Cross-compile to a specific OS (default: $(uname -s))
   --target-arch='arch'       - Cross-compile to a specific CPU architecture
+  --disable-windeploy        - Keep bin/ lib/ layout on Windows
 
 Module disable options:
 
@@ -60,6 +61,7 @@ build_config()
 		echo "extra_versioning=$extra_versioning"
 		echo "melt_noversion=$melt_noversion"
 		echo "targetos=$targetos"
+		echo "windeploy=$windeploy"
 
 		[ "$mmx" = "true" ] && 
 		echo "MMX_FLAGS=-DUSE_MMX"
@@ -123,6 +125,8 @@ build_config()
 		echo "LDFLAGS+=-Wl,--no-undefined -Wl,--as-needed"
 		;;
 		MinGW)
+		[ "$windeploy" = false ] &&
+			echo "CFLAGS+=-DNODEPLOY"
 		[ "$optimisations" = "true" ] &&
 			echo "OPTIMISATIONS+=-ffast-math"
 		echo "SHFLAGS=-shared"
@@ -194,7 +198,7 @@ build_pkgconfig()
 }
 
 # Debug mode
-set +x
+# set -x
 
 # Define build directory for scripts called
 export build_dir=`dirname $0`
@@ -217,6 +221,7 @@ export targetarch=
 export amd64=false
 export extra_versioning=false
 export melt_noversion=false
+export windeploy=true
 
 # Define the compiler used in tests (gcc is not installed everywhere)
 : ${CC:=gcc}
@@ -243,6 +248,7 @@ do
 		--cpu=* )			cpu="${i#--cpu=}" ;;
 		--target-os=* )			targetos="${i#--target-os=}" ;;
 		--target-arch=* )		targetarch="${i#--target-arch=}" ;;
+		--disable-windeploy )		windeploy=false ;;
 	esac
 done
 

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -113,9 +113,14 @@ clean:
 install:
 	install -d $(DESTDIR)$(libdir)
 	if [ "$(targetos)" = "MinGW" ]; then \
-		install -m 755 $(TARGET) $(DESTDIR)$(prefix) ; \
-		install -m 755 $(TARGET) $(DESTDIR)$(libdir)/libmlt.dll ; \
-		install -m 644 libmlt.def $(DESTDIR)$(libdir) ; \
+		if [ "$(windeploy)" = true ]; then \
+			install -m 755 $(TARGET) "$(DESTDIR)$(prefix)" ; \
+			install -m 755 $(TARGET) "$(DESTDIR)$(libdir)/libmlt.dll" ; \
+		else \
+			install -m 755 $(TARGET) "$(DESTDIR)$(bindir)" ; \
+			install -m 755 $(TARGET) "$(DESTDIR)$(bindir)/libmlt.dll" ; \
+		fi; \
+		install -m 644 libmlt.def "$(DESTDIR)$(libdir)" ; \
 	else \
 		install -m 755 $(TARGET) $(DESTDIR)$(libdir) ; \
 		ln -sf $(TARGET) $(DESTDIR)$(libdir)/$(SONAME) ; \
@@ -131,6 +136,15 @@ uninstall:
 	if [ "$(targetos)" != "MinGW" ]; then \
 		rm -f "$(DESTDIR)$(libdir)/$(SONAME)" ; \
 		rm -f "$(DESTDIR)$(libdir)/$(NAME)" ; \
+	else \
+		if [ "$(windeploy)" = true ]; then \
+			rm -f "$(DESTDIR)$(prefix)/$(TARGET)" ; \
+			rm -f "$(DESTDIR)$(libdir)/libmlt.dll" ; \
+		else \
+			rm -f "$(DESTDIR)$(bindir)/$(TARGET)" ; \
+			rm -f "$(DESTDIR)$(bindir)/libmlt.dll" ; \
+		fi ;
+		rm -f "$(DESTDIR)$(libdir)/libmlt.def" ; \
 	fi
 	rm -rf "$(DESTDIR)$(prefix)/include/mlt/framework"
 	rm -f "$(DESTDIR)$(mltdatadir)/metaschema.yaml"

--- a/src/framework/mlt_factory.c
+++ b/src/framework/mlt_factory.c
@@ -148,7 +148,11 @@ mlt_repository mlt_factory_init( const char *directory )
 		char path[1024];
 		DWORD size = sizeof( path );
 		GetModuleFileName( NULL, path, size );
+		#ifndef NODEPLOY
 		char *appdir = mlt_dirname( strdup( path ) );
+		#else
+		char *appdir = mlt_dirname( mlt_dirname( strdup( path ) ) );
+		#endif
 		mlt_properties_set( global_properties, "MLT_APPDIR", appdir );
 		free( appdir );
 #elif defined(__APPLE__)  && defined(RELOCATABLE)

--- a/src/melt/Makefile
+++ b/src/melt/Makefile
@@ -25,7 +25,9 @@ endif
 
 ifeq ($(targetos), MinGW)
 LDFLAGS += -mconsole
+ifeq ($(windeploy), true)
 bindir = $(prefix)
+endif
 endif
 
 all: $(meltname)

--- a/src/mlt++/Makefile
+++ b/src/mlt++/Makefile
@@ -73,9 +73,14 @@ distclean:	clean
 install:
 	$(INSTALL) -d "$(DESTDIR)$(libdir)"
 	if [ "$(targetos)" = "MinGW" ]; then \
-		$(INSTALL) -m 755 $(TARGET) $(DESTDIR)$(prefix) ; \
-		$(INSTALL) -m 755 $(TARGET) $(DESTDIR)$(libdir)/libmlt++.dll ; \
-		$(INSTALL) -m 644 libmlt++.def $(DESTDIR)$(libdir) ; \
+		if [ "$(windeploy)" = true ]; then \
+			$(INSTALL) -m 755 $(TARGET) "$(DESTDIR)$(prefix)" ; \
+			$(INSTALL) -m 755 $(TARGET) "$(DESTDIR)$(libdir)/libmlt++.dll" ; \
+		else \
+			$(INSTALL) -m 755 $(TARGET) "$(DESTDIR)$(bindir)" ; \
+			$(INSTALL) -m 755 $(TARGET) "$(DESTDIR)$(bindir)/libmlt++.dll" ; \
+		fi; \
+		$(INSTALL) -m 644 libmlt++.def "$(DESTDIR)$(libdir)" ; \
 	else \
 		$(INSTALL) -m 755 $(TARGET) $(DESTDIR)$(libdir) ; \
 		ln -sf $(TARGET) $(DESTDIR)$(libdir)/$(SONAME) ; \
@@ -89,6 +94,15 @@ uninstall:
 	if [ "$(targetos)" != "MinGW" ]; then \
 		rm -f "$(DESTDIR)$(libdir)/$(NAME)" ; \
 		rm -f "$(DESTDIR)$(libdir)/$(SONAME)" ; \
+	else \
+		if [ "$(windeploy)" = true ]; then \
+			rm -f "$(DESTDIR)$(prefix)/$(TARGET)" ; \
+			rm -f "$(DESTDIR)$(libdir)/libmlt++.dll" ; \
+		else \
+			rm -f "$(DESTDIR)$(bindir)/$(TARGET)" ; \
+			rm -f "$(DESTDIR)$(bindir)/libmlt++.dll" ; \
+		fi ; \
+		rm -f "$(DESTDIR)$(libdir)/libmlt++.def" ; \
 	fi
 	rm -rf "$(DESTDIR)$(prefix)/include/mlt++"
 

--- a/src/modules/lumas/Makefile
+++ b/src/modules/lumas/Makefile
@@ -25,13 +25,13 @@ clean:
 	rm -f luma 
 
 install:	all
-	install -d $(DESTDIR)$(mltdatadir)/lumas/9_16
-	install -d $(DESTDIR)$(mltdatadir)/lumas/16_9
-	install -d $(DESTDIR)$(mltdatadir)/lumas/NTSC
-	install -d $(DESTDIR)$(mltdatadir)/lumas/PAL
-	install -d $(DESTDIR)$(mltdatadir)/lumas/square
-	install -m 644 9_16/* $(DESTDIR)$(mltdatadir)/lumas/9_16
-	install -m 644 16_9/* $(DESTDIR)$(mltdatadir)/lumas/16_9
-	install -m 644 NTSC/* $(DESTDIR)$(mltdatadir)/lumas/NTSC
-	install -m 644 PAL/* $(DESTDIR)$(mltdatadir)/lumas/PAL
-	install -m 644 square/* $(DESTDIR)$(mltdatadir)/lumas/square
+	install -d "$(DESTDIR)$(mltdatadir)/lumas/9_16"
+	install -d "$(DESTDIR)$(mltdatadir)/lumas/16_9"
+	install -d "$(DESTDIR)$(mltdatadir)/lumas/NTSC"
+	install -d "$(DESTDIR)$(mltdatadir)/lumas/PAL"
+	install -d "$(DESTDIR)$(mltdatadir)/lumas/square"
+	install -m 644 9_16/* "$(DESTDIR)$(mltdatadir)/lumas/9_16"
+	install -m 644 16_9/* "$(DESTDIR)$(mltdatadir)/lumas/16_9"
+	install -m 644 NTSC/* "$(DESTDIR)$(mltdatadir)/lumas/NTSC"
+	install -m 644 PAL/*  "$(DESTDIR)$(mltdatadir)/lumas/PAL"
+	install -m 644 square/* "$(DESTDIR)$(mltdatadir)/lumas/square"

--- a/src/modules/oldfilm/Makefile
+++ b/src/modules/oldfilm/Makefile
@@ -32,7 +32,7 @@ clean:
 
 install: all
 	install -m 755 $(TARGET) "$(DESTDIR)$(moduledir)"
-	install -d $(DESTDIR)$(mltdatadir)/oldfilm
+	install -d "$(DESTDIR)$(mltdatadir)/oldfilm"
 	install -m 644 *.svg "$(DESTDIR)$(mltdatadir)/oldfilm"
 	install -m 644 *.yml "$(DESTDIR)$(mltdatadir)/oldfilm"
 


### PR DESCRIPTION
Hello,

After struggles to build & debug Kdenlive on Windows, I've understood that the misunderstanding was MLT assuming the EXE and framework DLL's were located in prefix root, and not in bin/ as CMake and autotools do for other libs.

I've been using this patch for a while in Craft (KDE package system) and it makes native debugging easier as there is no more need to copy files around before being able to execute the app.

I've added it as an option, off by default, to avoid breaking running systems.

While at writing a PR, I've added 2 minor fixes, to ignore new luma formats just like old ones, and for prefix containing space.

I would love to have it for our future 19.04 release, but of course you judge what's pertinent :)

Cheers!