### PR TITLE
Adds a guard on null input before invalidate_pixel_data.

### DIFF
--- a/src/modules/opengl/filter_movit_convert.cpp
+++ b/src/modules/opengl/filter_movit_convert.cpp
@@ -424,7 +424,8 @@ static void dispose_pixel_pointers( GlslChain *chain, mlt_service service, mlt_f
 	if ( service == (mlt_service) -1 ) {
 		mlt_producer producer = mlt_producer_cut_parent( mlt_frame_get_original_producer( frame ) );
 		MltInput* input = chain->inputs[ producer ];
-		input->invalidate_pixel_data();
+		if (input)
+			input->invalidate_pixel_data();
 		mlt_pool_release( GlslManager::get_input_pixel_pointer( producer, frame ) );
 		return;
 	}


### PR DESCRIPTION
Matches an equivalent guard on set_pixel_data line 350.

This resolves a repeatable null pointer dereference on export from kdenlive when movit effects are used. Did not investigate why the input associated with a provider would be null. Any background on that would be appreciated :)