### PR TITLE
Windows: fix melt.exe with nodeploy

### DIFF
--- a/src/framework/mlt_repository.c
+++ b/src/framework/mlt_repository.c
@@ -81,13 +81,19 @@ mlt_repository mlt_repository_init( const char *directory )
 #ifdef _WIN32
 	char *syspath = getenv("PATH");
 	char *exedir = mlt_environment( "MLT_APPDIR" );
-	char *newpath = "PATH=";
-	newpath = calloc( 1, strlen( newpath )+ strlen( exedir ) + 1 + strlen( syspath ) + 1 );
-	strcat( newpath, "PATH=" );
+	#ifdef NODEPLOY
+	char *sep = "\\bin;";
+	#else
+	char *sep = ";";
+	#endif
+	char *newpath;
+	newpath = calloc( 1, 5 + strlen( exedir ) + strlen( sep ) + strlen( syspath ) + 1 );
+	strcat( newpath, "PATH=" ); // len=5
 	strcat( newpath, exedir );
-	strcat( newpath, ";" );
+	strcat( newpath, sep );
 	strcat( newpath, syspath );
-	putenv(newpath);
+	putenv( newpath );
+	free(newpath);
 #endif
 
 	// Iterate over files

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -29,6 +29,10 @@
 bool createQApplicationIfNeeded(mlt_service service)
 {
 	if (!qApp) {
+#if defined(Q_OS_WIN) && defined(NODEPLOY)
+		QCoreApplication::addLibraryPath(QString(mlt_environment("MLT_APPDIR"))+QStringLiteral("/bin"));
+		QCoreApplication::addLibraryPath(QString(mlt_environment("MLT_APPDIR"))+QStringLiteral("/plugins"));
+#endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
 		if (getenv("DISPLAY") == 0) {
 			mlt_log_error(service,


### PR DESCRIPTION
Hello,
I'm further debugging Kdenlive packages generated by Craft system.
Kdenlive was working, but melt.exe did not load properly qt module (Qt plugins not found).
Qt plugins location changes between Craft build time (environment to test & debug) and package time, so looking in different locations increases the chance to have it working.
Thanks & Regards