### PR TITLE
[Heap overflow] Ignore non-avfilter params when processing avfilter properties

### DIFF
--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -53,16 +53,18 @@ typedef struct
 
 static void property_changed( mlt_service owner, mlt_filter filter, char *name )
 {
-	private_data* pdata = (private_data*)filter->child;
-	if( pdata->avfilter )
-	{
-		const AVOption *opt = NULL;
-		while( ( opt = av_opt_next( &pdata->avfilter->priv_class, opt ) ) )
+	if( strncmp( PARAM_PREFIX, name, PARAM_PREFIX_LEN ) == 0 ) {
+		private_data* pdata = (private_data*)filter->child;
+		if( pdata->avfilter )
 		{
-			if( !strcmp( opt->name, name + PARAM_PREFIX_LEN ) )
+			const AVOption *opt = NULL;
+			while( ( opt = av_opt_next( &pdata->avfilter->priv_class, opt ) ) )
 			{
-				pdata->reset = 1;
-				break;
+				if( !strcmp( opt->name, name + PARAM_PREFIX_LEN ) )
+				{
+					pdata->reset = 1;
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The root of the issue is that the strcmp on line 62 is unsafe: if `name` is shorter than PARAM_PREFIX_LEN, the pointer arithmetic will get out of bounds, creating heap overflows.
Based on the logic, I assumed that filtering non-avfilter params was the correct fix.