### PR TITLE
Add get/set datetime to producer.

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -533,4 +533,6 @@ MLT_6.14.0 {
   global:
     mlt_frame_get_unique_properties;
     mlt_playlist_reorder;
+    mlt_producer_set_creation_time;
+    mlt_producer_get_creation_time;
 } MLT_6.12.0;

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -125,5 +125,7 @@ extern int mlt_producer_is_blank( mlt_producer self );
 extern mlt_producer mlt_producer_cut_parent( mlt_producer self );
 extern int mlt_producer_optimise( mlt_producer self );
 extern void mlt_producer_close( mlt_producer self );
+int64_t mlt_producer_get_creation_time( mlt_producer self );
+void mlt_producer_set_creation_time( mlt_producer self, int64_t creation_time );
 
 #endif

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -235,3 +235,13 @@ int Producer::clear( )
 {
 	return mlt_producer_clear( get_producer( ) );
 }
+
+int64_t Producer::get_creation_time( )
+{
+	return mlt_producer_get_creation_time( get_producer( ) );
+}
+
+void Producer::set_creation_time( int64_t creation_time )
+{
+	mlt_producer_set_creation_time( get_producer( ), creation_time );
+}

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -74,6 +74,8 @@ namespace Mlt
 			bool runs_into( Producer &that );
 			void optimise( );
 			int clear( );
+			int64_t get_creation_time( );
+			void set_creation_time( int64_t creation_time );
 	};
 }
 

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -558,5 +558,8 @@ MLTPP_6.14.0 {
       "Mlt::Service::set_profile(mlt_profile_s*)";
       "Mlt::Playlist::reorder(int const*)";
       "Mlt::Transition::connect(Mlt::Service&, int, int)";
+      "Mlt::Producer::set_creation_time(long)";
+      "Mlt::Producer::set_creation_time(long long)";
+      "Mlt::Producer::get_creation_time()";
   };
 } MLTPP_6.10.0;

--- a/src/modules/plus/filter_dynamictext.c
+++ b/src/modules/plus/filter_dynamictext.c
@@ -167,35 +167,12 @@ static void get_resource_str( mlt_filter filter, mlt_frame frame, char* text )
 
 static void get_createdate_str( const char* keyword, mlt_filter filter, mlt_frame frame, char* text )
 {
-	char* datestr = mlt_properties_get( MLT_FRAME_PROPERTIES( frame ), "meta.attr.creation_time.markup");
+	time_t creation_date = (time_t)(mlt_producer_get_creation_time( mlt_frame_get_original_producer( frame ) ) / 1000);
 	const char *format = "%Y/%m/%d";
 	int n = strlen( "createdate" ) + 1;
 	if ( strlen( keyword ) > n )
 		format = &keyword[n];
-	struct tm time_info;
-	char *date = calloc( 1, MAX_TEXT_LEN );
-
-	if ( datestr && strptime( datestr, "%Y-%m-%dT%H:%M:%S", &time_info ) )
-	{
-		// Prefer creation_time property if available.
-		strftime( date, MAX_TEXT_LEN, format, &time_info );
-	}
-	else
-	{
-		// Fall back to file modification time.
-		mlt_producer producer = mlt_producer_cut_parent( mlt_frame_get_original_producer( frame ) );
-		mlt_properties producer_properties = MLT_PRODUCER_PROPERTIES( producer );
-		char* filename = mlt_properties_get( producer_properties, "resource");
-		struct stat file_info;
-		if ( !stat( filename, &file_info ) )
-		{
-			strftime( date, MAX_TEXT_LEN, format, gmtime( &(file_info.st_mtime) ) );
-
-		}
-	}
-
-	strncat( text, date, MAX_TEXT_LEN - strlen( text ) - 1 );
-	free( date );
+	strftime( text, MAX_TEXT_LEN - strlen( text ) - 1, format, localtime( &creation_date ) );
 }
 
 /** Perform substitution for keywords that are enclosed in "# #".


### PR DESCRIPTION
"datetime" is a reserved producer property that can hold the origin
(creation) time of the producer. The datetime property is always in
UTC.

Here is an alternative method to associate time with a producer. The advantage of this method is that it can be applied to non-file producers. The disadvantage is that it requires new producer functions and a new reserved producer property (datetime).