### PR TITLE
fix python include detection

### DIFF
--- a/src/swig/python/build
+++ b/src/swig/python/build
@@ -13,7 +13,7 @@ path=`which python 2> /dev/null`
 if [ $? = 0 ]
 then
 	# Change this as needed
-	export PYTHON_INCLUDE=`python -c "import sys;print(\"{}/include/python{}.{}\".format(sys.prefix,*sys.version_info))"`
+	export PYTHON_INCLUDE=`python -c "from sysconfig import get_paths; info = get_paths(); print(info['include'])"`
 
 	[ ! -d "$PYTHON_INCLUDE" ] && echo python development missing && exit 1
 


### PR DESCRIPTION
Fix python detection. Based on OpenMandriva patch
https://github.com/OpenMandrivaAssociation/mlt/blob/master/mlt-6.14.0-fix-python3-detect.patch