### PR TITLE
Fix melt not allowing profile change from embeded consumer

### DIFF
--- a/src/melt/melt.c
+++ b/src/melt/melt.c
@@ -921,6 +921,20 @@ query_all:
 				mlt_properties_inc_ref( MLT_CONSUMER_PROPERTIES(consumer) ); // because we explicitly close it
 				mlt_properties_set_data( MLT_CONSUMER_PROPERTIES(consumer),
 					"transport_callback", transport_action, 0, NULL, NULL );
+				mlt_profile consumer_profile = mlt_service_profile(MLT_CONSUMER_SERVICE(consumer));
+
+				// Reload producer if consumer changed profile
+				if ( consumer_profile && (
+					profile->width != consumer_profile->width ||
+					profile->height != consumer_profile->height ||
+					profile->sample_aspect_num != consumer_profile->sample_aspect_num ||
+					profile->sample_aspect_den != consumer_profile->sample_aspect_den ||
+					profile->frame_rate_den != consumer_profile->frame_rate_den ||
+					profile->frame_rate_num != consumer_profile->frame_rate_num ||
+					profile->colorspace != consumer_profile->colorspace ) ) {
+						mlt_producer_close( melt );
+						melt = mlt_factory_producer( consumer_profile, "melt", &argv[ 1 ] );
+				}
 			}
 		}
 

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -1149,6 +1149,8 @@ static void on_end_consumer( deserialise_context context, const xmlChar *name )
 				char *id = trim( mlt_properties_get( properties, "mlt_service" ) );
 				mlt_profile consumer_profile = mlt_profile_clone( context->profile );
 				context->consumer = mlt_factory_consumer( consumer_profile, id, resource );
+				mlt_properties_set_data(MLT_CONSUMER_PROPERTIES(context->consumer), "producer_xml.consumer_profile",
+					consumer_profile, 0, (mlt_destructor) mlt_profile_close, NULL);
 				if ( context->consumer )
 				{
 					// Track this consumer

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -1147,7 +1147,8 @@ static void on_end_consumer( deserialise_context context, const xmlChar *name )
 			{
 				// Instantiate the consumer
 				char *id = trim( mlt_properties_get( properties, "mlt_service" ) );
-				context->consumer = mlt_factory_consumer( context->profile, id, resource );
+				mlt_profile consumer_profile = mlt_profile_clone( context->profile );
+				context->consumer = mlt_factory_consumer( consumer_profile, id, resource );
 				if ( context->consumer )
 				{
 					// Track this consumer


### PR DESCRIPTION
When using melt to render a .mlt playlist file that contains a <code>consumer</code> tag, it does not support profile changes. For example if the consumer contains rescale info (like s=320x200), the rescaling is not correctly passed to the producer. Kdenlive bug: https://bugs.kde.org/show_bug.cgi?id=407678

To reproduce, save the following playlist text in a file playlist.mlt file.
This playlist uses a PAL profile and has a red rectangle scaled to 200x200 with an affine filter. The consumer tag applies a rescale using s=320x200.

To reproduce issue, process the playlist with :

melt playlist.mlt

It will create a render in /tmp/test.mp4

You can see that the affine filter does not correctly apply scaling (it scales to 200x200 but ignores the fact that the consumer rescales to 320x200 using the "s=320x200" option), so it almost fills the frame.

This patch fixes the problem, and in the render, the rectangle is now less than a quarter of the frame size.

`<mlt LC_NUMERIC="C" version="6.17.0" title="color:red">
  <profile description="DV/DVD PAL" width="720" height="576" progressive="0" sample_aspect_num="16" sample_aspect_den="15" display_aspect_num="4" display_aspect_den="3" frame_rate_num="25" frame_rate_den="1" colorspace="601"/>
  <consumer f="mp4" g="15" crf="23" progressive="1" target="/tmp/test.mp4" threads="1" real_time="-8" mlt_service="avformat" vcodec="libx264" ab="192k" movflags="+faststart" s="320x200" bf="2" acodec="aac" in="0" out="74"/>
  <producer id="producer0" in="0" out="100">
    <property name="length">15000</property>
    <property name="eof">pause</property>
    <property name="resource">red</property>
    <property name="aspect_ratio">1.06667</property>
    <property name="mlt_service">color</property>
    <filter id="filter0">
      <property name="background">colour:0</property>
      <property name="mlt_service">affine</property>
      <property name="transition.geometry">0 0 200 200</property>
    </filter>
  </producer>
  <playlist id="playlist0">
    <entry producer="producer0" in="0" out="100"/>
  </playlist>
  <tractor id="tractor0" title="color:red" global_feed="1" in="0" out="100">
    <track producer="playlist0"/>
  </tractor>
</mlt>`
