### PR TITLE
Pass the consumer's in/out properties when using movit or multi consumer

### DIFF
--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -1130,6 +1130,9 @@ static void on_end_consumer( deserialise_context context, const xmlChar *name )
 					mlt_properties_set_data( consumer_properties, key, properties, 0,
 						(mlt_destructor) mlt_properties_close, NULL );
 
+					// Pass in / out if provided
+					mlt_properties_pass_list( consumer_properties, properties, "in, out" );
+
 					// Pass along quality and performance properties to the multi consumer and its render thread(s).
 					if ( !context->qglsl )
 					{


### PR DESCRIPTION
When rendering an mlt playlist with an embedded consumer tag that contains in and out to render only part of the playlist, these values were not passed to the multi consumer, which always rendered the full playlist. This patch simply passes the in/out values to the multi consumer. In case of fps change, it's up to the app to adjust in/out