### PR TITLE
Fix multi consumer doesn't correctly handle in point

### DIFF
--- a/src/modules/core/consumer_multi.c
+++ b/src/modules/core/consumer_multi.c
@@ -304,7 +304,7 @@ static void foreach_consumer_start( mlt_consumer consumer )
 		if ( nested )
 		{
 			mlt_properties nested_props = MLT_CONSUMER_PROPERTIES(nested);
-			mlt_properties_set_position( nested_props, "_multi_position", 0 );
+			mlt_properties_set_position( nested_props, "_multi_position", mlt_properties_get_position( properties, "in" ) );
 			mlt_properties_set_data( nested_props, "_multi_audio", NULL, 0, NULL, NULL );
 			mlt_properties_set_int( nested_props, "_multi_samples", 0 );
 			mlt_consumer_start( nested );


### PR DESCRIPTION
Currently, when trying to render a playlist file with embedded consumer tag, rendering does not correctly handle the "in" point. This only happens when trying to use the xml producer and enforce multi consumer.
Example:

melt xml:playlist.mlt?multi=1

If the playlist.mlt file contains a "consumer" tag with in=500 and out=600, the result will be a 600 frames length rendering where the first 500 frames are a copy of the 500th frame. My patch fixes the problem and rendering with the patch produces a 100 frames result.