### PR TITLE
Fix returning image data for Python 3 bindigs

### DIFF
--- a/src/swig/mlt.i
+++ b/src/swig/mlt.i
@@ -247,7 +247,7 @@ binary_data frame_get_image( Mlt::Frame &frame, mlt_image_format format, int w, 
 %#if PY_MAJOR_VERSION < 3
         PyString_FromStringAndSize(
 %#else
-        PyUnicode_FromStringAndSize(
+        PyByteArray_FromStringAndSize(
 %#endif
 	$1.data, $1.size );
 }


### PR DESCRIPTION
Both frame.get_image() and mlt.frame_get_waveform() return image data as char[].

In Python 2 strings are byte arrays and we were able to use PyString_FromStringAndSize to create the returned PyObject.

In Python 3 using PyUnicode_FromStringAndSize will try to create UTF-8 string from image data and obviously fail.

We need to use PyByteArray_FromStringAndSize instead.

Tested and works on my system.