### PR TITLE
Fix broken -profile on melt command line

### DIFF
--- a/src/melt/melt.c
+++ b/src/melt/melt.c
@@ -766,6 +766,10 @@ int main( int argc, char **argv )
 		// Look for the profile option
 		else if ( !strcmp( argv[ i ], "-profile" ) )
 		{
+			// Construct the factory
+			if ( !repo )
+				repo = mlt_factory_init( repo_path );
+
 			const char *pname = argv[ ++ i ];
 			if ( pname && pname[0] != '-' )
 				profile = mlt_profile_init( pname );


### PR DESCRIPTION
The -profile command line param from melt was broken with this commit:
https://github.com/mltframework/mlt/commit/33493c70c7b076b03181296f2a549437a457fbb3

To reproduce:
melt -profile atsc_1080p_25 color:red

produces a pal sized result, profiles were not found since mlt_factory was not initialized
This patch fixes the problem