### PR TITLE
qtblend filter: don't process alpha if no transparency, add background_color property

### DIFF
--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -102,7 +102,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 		hasAlpha = true;
 	}
 
-	if (!hasAlpha) {
+	if ( !hasAlpha ) {
 		uint8_t *src_image = NULL;
 		error = mlt_frame_get_image( frame, &src_image, format, &b_width, &b_height, 0 );
 		if ( *format == mlt_image_rgb24a || mlt_frame_get_alpha( frame ) ) {
@@ -159,7 +159,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 
 	QImage destImage;
 	convert_mlt_to_qimage_rgba( dest_image, &destImage, *width, *height );
-	destImage.fill( mlt_properties_get_int( properties, "background_color" ));
+	destImage.fill( mlt_properties_get_int( properties, "background_color" ) );
 
 	QPainter painter( &destImage );
 	painter.setCompositionMode( ( QPainter::CompositionMode ) mlt_properties_get_int( properties, "compositing" ) );

--- a/src/modules/qt/filter_qtblend.yml
+++ b/src/modules/qt/filter_qtblend.yml
@@ -23,7 +23,8 @@ parameters:
   - identifier: compositing
     title: Composition mode
     description: >
-      Defines which composition operation will be performed (see QPainter CompositionMode for doc).
+      Defines which composition operation will be performed
+      (see QPainter CompositionMode for doc).
     type: integer
     default: 0
     minimum: 0
@@ -45,8 +46,20 @@ parameters:
   - identifier: rotate_center
     title: Rotate from center
     type: integer
-    description: Process the rotation from center if set, otherwise from top left corner
+    description: >
+      Process the rotation from center if set, otherwise from top left corner
     minimum: 0
     maximum: 1
     mutable: yes
     widget: checkbox
+
+  - identifier: background_color
+    title: Background color
+    type: integer
+    description: >
+      An integer formed like 0xaabbggrr that will be used
+      as background color for the compositing operation.
+      Defaults to 0 (fully transparent)
+    default: 0
+    mutable: yes
+    widget: color


### PR DESCRIPTION
This will allow to use the qtblend filter on the lower video track instead of compositing with an extra black track