### PR TITLE
Allow using FFTW built with CMake (different pkg-config file name)

### DIFF
--- a/src/modules/plus/configure
+++ b/src/modules/plus/configure
@@ -5,13 +5,17 @@ then
 
 	echo > config.mak
 
-	pkg-config fftw3
-	if [ $? -eq 0 ]
+	if pkg-config fftw3
+	then FFTWPC=fftw3
+	elif pkg-config fftw
+	then FFTWPC=fftw
+	fi
+	if [ "$FFTWPC" != "" ]
 	then
 		echo "USE_FFTW=1" >> config.mak
 		echo "CFLAGS += -DUSE_FFTW" >> config.mak
-		echo "CFLAGS += $(pkg-config --cflags fftw3)" >> config.mak
-		echo "LDFLAGS += $(pkg-config --libs fftw3)" >> config.mak
+		echo "CFLAGS += $(pkg-config --cflags $FFTWPC)" >> config.mak
+		echo "LDFLAGS += $(pkg-config --libs $FFTWPC)" >> config.mak
 	else
 		echo "- fftw not found: disable fft and dance filters"
 	fi

--- a/src/modules/qt/configure
+++ b/src/modules/qt/configure
@@ -196,14 +196,18 @@ else
 		fi
 	fi
 	
-	pkg-config fftw3
-	if [ $? -eq 0 ]
+	if pkg-config fftw3
+	then FFTWPC=fftw3
+	elif pkg-config fftw
+	then FFTWPC=fftw
+	fi
+	if [ "$FFTWPC" != "" ]
 	then
 		echo "- fftw found, enabling lightshow"
 		echo "USE_FFTW=1" >> config.mak
-		echo FFTWCXXFLAGS=$(pkg-config --cflags fftw3 ) >> config.mak
+		echo FFTWCXXFLAGS=$(pkg-config --cflags $FFTWPC ) >> config.mak
 		echo FFTWCXXFLAGS += -DUSE_FFTW >> config.mak
-		echo FFTWLIBS=$(pkg-config --libs fftw3) >> config.mak
+		echo FFTWLIBS=$(pkg-config --libs $FFTWPC ) >> config.mak
 		
 	else
 		echo "- fftw not found: disabling lightshow filter"


### PR DESCRIPTION
Hello,

FFTW offers CMake in addition to autotools build system, and this is what is picked in KDE Craft package manager.
However, FFTW's CMake generates the pkg-config file as fftw.pc instead of fftw3.pc
This change allows to detect both (fftw3 1st, as before).

Other options:

- move fftw.pc to fftw3.pc in Craft... but other distributions may miss the issue
- fix FFTW CMake upstream... will propose it, but this may take some time to reach end users
- in the meantime, detect both in MLT (low cost)

Do you agree?

Best regards,

Vincent