### PR TITLE
Fix chroma bleeding due to colorspace conversion.

### DIFF
--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -22,7 +22,7 @@
 #include <libavutil/channel_layout.h>
 #include <libavutil/samplefmt.h>
 
-int mlt_default_sws_flags = SWS_BICUBIC | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT | SWS_ACCURATE_RND;
+int mlt_default_sws_flags = SWS_BICUBIC | SWS_ACCURATE_RND;
 
 int mlt_to_av_sample_format( mlt_audio_format format )
 {


### PR DESCRIPTION
This is a proposal to help reduce the chroma bleeding when performing colorspace conversions.

**Colorbars Before:**
![before](https://user-images.githubusercontent.com/821968/71545197-ee923000-294d-11ea-9e5b-a292a74c89c6.png)

**Colorbars After:**
![after](https://user-images.githubusercontent.com/821968/71545201-f651d480-294d-11ea-8f25-5608719347f6.png)

The vectorscope uses data that was converted from RGB->YUV420. The Zoom and Waveform scopes uses data that was converted in a round trip: RGB->YUV420->RGB.

I do not know the significance of the two removed flags.

Based on this comment, they might not be completely implemented?
https://ffmpeg.org/doxygen/trunk/swscale_8h_source.html#l00077

Also, this is a relevant change: https://github.com/mltframework/mlt/commit/adc5a2284b3a1073cb364c5f07d1d7c97e94c937
It seems that prior to that change, the flags were applied selectively based on the format.

For example, this was removed:
```
	// Set swscale flags to get good quality	
	switch ( *format )
	{
		case mlt_image_yuv422:
			interp |= SWS_FULL_CHR_H_INP;	
			break;	
		case mlt_image_rgb24:
			interp |= SWS_FULL_CHR_H_INT;	
			break;	
		case mlt_image_rgb24a:
		case mlt_image_opengl:
			interp |= SWS_FULL_CHR_H_INT;	
			break;
		default:
			// XXX: we only know how to rescale packed formats
			return 1;
	}
```

Maybe you have more history about the application of those flags.