### PR TITLE
Improve colorspace conversion.

### DIFF
--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -20,9 +20,65 @@
 #include "common.h"
 
 #include <libavutil/channel_layout.h>
+#include <libavutil/pixdesc.h>
 #include <libavutil/samplefmt.h>
 
-int mlt_default_sws_flags = SWS_BICUBIC | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT | SWS_ACCURATE_RND;
+int get_sws_flags(int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat)
+{
+	// Use default flags unless there is a reason to use something different.
+	int flags = SWS_BICUBIC | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT | SWS_ACCURATE_RND;
+
+	if( srcwidth != dstwidth || srcheight != dstheight )
+	{
+		// Any resolution change should use default flags
+		return flags;
+	}
+
+	const AVPixFmtDescriptor* srcDesc = av_pix_fmt_desc_get(srcformat);
+	const AVPixFmtDescriptor* dstDesc = av_pix_fmt_desc_get(dstformat);
+
+	if( !srcDesc || !dstDesc )
+	{
+		return flags;
+	}
+
+	if( (srcDesc->flags & AV_PIX_FMT_FLAG_RGB) != 0 &&
+		(dstDesc->flags & AV_PIX_FMT_FLAG_RGB) == 0)
+	{
+		// RGB -> YUV
+		flags = SWS_BICUBIC;
+		flags |=  SWS_ACCURATE_RND;   // Can improve precision by one bit
+		flags |=  SWS_FULL_CHR_H_INT; // Avoids luma reduction. Causes chroma bleeding when used with SWS_BICUBIC
+	}
+	else if( (srcDesc->flags & AV_PIX_FMT_FLAG_RGB) == 0 &&
+			(dstDesc->flags & AV_PIX_FMT_FLAG_RGB) != 0)
+	{
+		// YUV -> RGB
+		// Going from lower sampling to full sampling - so pick the closest sample without interpolation
+		flags = SWS_POINT;
+		flags |=  SWS_ACCURATE_RND;   // Can improve precision by one bit
+		flags |=  SWS_FULL_CHR_H_INT; // Avoids luma reduction. Does not cause chroma bleeding when used with SWS_POINT
+	}
+	else if( (srcDesc->flags & AV_PIX_FMT_FLAG_RGB) == 0 &&
+			(dstDesc->flags & AV_PIX_FMT_FLAG_RGB) == 0)
+	{
+		// YUV -> YUV
+		if( srcDesc->log2_chroma_w == dstDesc->log2_chroma_w &&
+			srcDesc->log2_chroma_h == dstDesc->log2_chroma_h )
+		{
+			// No chroma subsampling conversion. No interpolation required
+			flags = SWS_POINT;
+			flags |=  SWS_ACCURATE_RND; // Can improve precision by one bit
+		}
+		else
+		{
+			// Chroma will be interpolated. Bilinear is suitable.
+			flags = SWS_FAST_BILINEAR | SWS_ACCURATE_RND;
+		}
+	}
+
+	return flags;
+}
 
 int mlt_to_av_sample_format( mlt_audio_format format )
 {

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -23,7 +23,7 @@
 #include <libavutil/pixdesc.h>
 #include <libavutil/samplefmt.h>
 
-int get_sws_flags(int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat)
+int mlt_get_sws_flags(int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat)
 {
 	// Use default flags unless there is a reason to use something different.
 	int flags = SWS_BICUBIC | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT | SWS_ACCURATE_RND;

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -29,6 +29,6 @@ mlt_channel_layout av_channel_layout_to_mlt( int64_t layout );
 mlt_channel_layout mlt_get_channel_layout_or_default( const char* name, int channels );
 int mlt_set_luma_transfer( struct SwsContext *context, int src_colorspace,
 	int dst_colorspace, int src_full_range, int dst_full_range );
-extern int mlt_default_sws_flags;
+int get_sws_flags(int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat);
 
 #endif // COMMON_H

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -29,6 +29,6 @@ mlt_channel_layout av_channel_layout_to_mlt( int64_t layout );
 mlt_channel_layout mlt_get_channel_layout_or_default( const char* name, int channels );
 int mlt_set_luma_transfer( struct SwsContext *context, int src_colorspace,
 	int dst_colorspace, int src_full_range, int dst_full_range );
-int get_sws_flags(int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat);
+int mlt_get_sws_flags(int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat);
 
 #endif // COMMON_H

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1925,8 +1925,9 @@ static void *consumer_thread( void *arg )
 						mlt_image_format_planes( img_fmt, width, height, image, video_avframe.data, video_avframe.linesize );
 
 						// Do the colour space conversion
-						int flags = mlt_default_sws_flags;
-						struct SwsContext *context = sws_getContext( width, height, pick_pix_fmt( img_fmt ),
+						int srcfmt = pick_pix_fmt( img_fmt );
+						int flags = get_sws_flags( width, height, srcfmt, width, height, pix_fmt);
+						struct SwsContext *context = sws_getContext( width, height, srcfmt,
 							width, height, pix_fmt, flags, NULL, NULL, NULL);
 						int src_colorspace = mlt_properties_get_int( frame_properties, "colorspace" );
 						int src_full_range = mlt_properties_get_int( frame_properties, "full_luma" );

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1926,7 +1926,7 @@ static void *consumer_thread( void *arg )
 
 						// Do the colour space conversion
 						int srcfmt = pick_pix_fmt( img_fmt );
-						int flags = get_sws_flags( width, height, srcfmt, width, height, pix_fmt);
+						int flags = mlt_get_sws_flags( width, height, srcfmt, width, height, pix_fmt);
 						struct SwsContext *context = sws_getContext( width, height, srcfmt,
 							width, height, pix_fmt, flags, NULL, NULL, NULL);
 						int src_colorspace = mlt_properties_get_int( frame_properties, "colorspace" );

--- a/src/modules/avformat/filter_avcolour_space.c
+++ b/src/modules/avformat/filter_avcolour_space.c
@@ -84,7 +84,7 @@ static int av_convert_image( uint8_t *out, uint8_t *in, int out_fmt, int in_fmt,
 	int in_stride[4];
 	uint8_t *out_data[4];
 	int out_stride[4];
-	int flags = get_sws_flags( width, height, in_fmt, width, height, out_fmt);
+	int flags = mlt_get_sws_flags( width, height, in_fmt, width, height, out_fmt);
 	int error = -1;
 
 	if ( in_fmt == AV_PIX_FMT_YUV422P16LE )

--- a/src/modules/avformat/filter_avcolour_space.c
+++ b/src/modules/avformat/filter_avcolour_space.c
@@ -84,7 +84,7 @@ static int av_convert_image( uint8_t *out, uint8_t *in, int out_fmt, int in_fmt,
 	int in_stride[4];
 	uint8_t *out_data[4];
 	int out_stride[4];
-	int flags = mlt_default_sws_flags;
+	int flags = get_sws_flags( width, height, in_fmt, width, height, out_fmt);
 	int error = -1;
 
 	if ( in_fmt == AV_PIX_FMT_YUV422P16LE )

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -1367,12 +1367,12 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 		// Thankfully, there is not much other use of yuv420p except consumer
 		// avformat with no filters and explicitly requested.
 #if defined(FFUDIV)
-		int flags = get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_YUV420P);
+		int flags = mlt_get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_YUV420P);
 		struct SwsContext *context = sws_getContext(width, height, src_pix_fmt,
 			width, height, AV_PIX_FMT_YUV420P, flags, NULL, NULL, NULL);
 #else
 		int dst_pix_fmt = self->full_luma ? AV_PIX_FMT_YUVJ420P : AV_PIX_FMT_YUV420P;
-		int flags = get_sws_flags(width, height, pix_fmt, width, height, dxt_pix_fmt);
+		int flags = mlt_get_sws_flags(width, height, pix_fmt, width, height, dxt_pix_fmt);
 		struct SwsContext *context = sws_getContext( width, height, pix_fmt,
 					width, height, dxt_pix_fmt,
 					flags, NULL, NULL, NULL);
@@ -1394,7 +1394,7 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 	}
 	else if ( *format == mlt_image_rgb24 )
 	{
-		int flags = get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_RGB24);
+		int flags = mlt_get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_RGB24);
 		struct SwsContext *context = sws_getContext( width, height, src_pix_fmt,
 			width, height, AV_PIX_FMT_RGB24, flags, NULL, NULL, NULL);
 		uint8_t *out_data[4];
@@ -1408,7 +1408,7 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 	}
 	else if ( *format == mlt_image_rgb24a || *format == mlt_image_opengl )
 	{
-		int flags = get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_RGBA);
+		int flags = mlt_get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_RGBA);
 		struct SwsContext *context = sws_getContext( width, height, src_pix_fmt,
 			width, height, AV_PIX_FMT_RGBA, flags, NULL, NULL, NULL);
 		uint8_t *out_data[4];
@@ -1438,7 +1438,7 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 		ctx.src_format = (self->full_luma && src_pix_fmt == AV_PIX_FMT_YUV422P) ? AV_PIX_FMT_YUVJ422P : src_pix_fmt;
 		ctx.src_desc = av_pix_fmt_desc_get( ctx.src_format );
 		ctx.dst_desc = av_pix_fmt_desc_get( ctx.dst_format );
-		ctx.flags = get_sws_flags(width, height, ctx.src_format, width, height, ctx.dst_format);
+		ctx.flags = mlt_get_sws_flags(width, height, ctx.src_format, width, height, ctx.dst_format);
 
 		av_image_fill_arrays(ctx.out_data, ctx.out_stride, buffer, ctx.dst_format, width, height, IMAGE_ALIGN);
 
@@ -1469,11 +1469,11 @@ static int convert_image( producer_avformat self, AVFrame *frame, uint8_t *buffe
 #else
 	{
 #if defined(FFUDIV)
-		int flags = get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_YUYV422);
+		int flags = mlt_get_sws_flags(width, height, src_pix_fmt, width, height, AV_PIX_FMT_YUYV422);
 		struct SwsContext *context = sws_getContext( width, height, src_pix_fmt,
 			width, height, AV_PIX_FMT_YUYV422, flags, NULL, NULL, NULL);
 #else
-		int flags = get_sws_flags(width, height, pix_fmt, width, height, AV_PIX_FMT_YUYV422);
+		int flags = mlt_get_sws_flags(width, height, pix_fmt, width, height, AV_PIX_FMT_YUYV422);
 		struct SwsContext *context = sws_getContext( width, height, pix_fmt,
 			width, height, AV_PIX_FMT_YUYV422, flags, NULL, NULL, NULL);
 #endif


### PR DESCRIPTION
Here is another suggestion for colorspace conversion. I was able to reproduce the luma reduction reported by users and test for that. This proposal does not completely eliminate chroma bleeding. But it greatly reduces it and the scopes look very clean when color bars are played.

**Before:**
![before](https://user-images.githubusercontent.com/821968/71609729-8b242000-2b50-11ea-818b-aeb0e20cfb0d.png)
**After**
![after2](https://user-images.githubusercontent.com/821968/71609743-92e3c480-2b50-11ea-9e4d-bbfc4de1e6fc.png)

One thing I like about this approach is that it provides a framework to further refine the flag decision down the road if further optimization is desired.

I understand that the timing is not good for this. Maybe it would be good to sit on this for a while and after a stable release it could be released to beta testers for further quality testing.