### PR TITLE
Limit pitch compensation to > 0.1x speed.

### DIFF
--- a/src/modules/core/producer_timewarp.c
+++ b/src/modules/core/producer_timewarp.c
@@ -245,7 +245,8 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 			mlt_frame_push_audio( *frame, producer );
 			mlt_frame_push_audio( *frame, producer_get_audio );
 
-			if ( mlt_properties_get_int( producer_properties, "warp_pitch" ) )
+			// Pitch compensation does not work well for speed *reduction* of 1/10th or less.
+			if ( mlt_properties_get_int( producer_properties, "warp_pitch" ) && fabs(pdata->speed) >= 0.1 )
 			{
 				if ( !pdata->pitch_filter )
 				{

--- a/src/modules/rubberband/filter_rbpitch.cpp
+++ b/src/modules/rubberband/filter_rbpitch.cpp
@@ -200,7 +200,7 @@ static int rbpitch_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *
 
 	mlt_service_unlock( MLT_FILTER_SERVICE(filter) );
 
-	mlt_log_debug( MLT_FILTER_SERVICE(filter), "Requested: %d\tReceived: %d\tSent: %d\tLatency: %f\n", requested_samples, in_samples, out_samples, latency );
+	mlt_log_debug( MLT_FILTER_SERVICE(filter), "Requested: %d\tReceived: %d\tSent: %d\tLatency: %d(%fms)\n", requested_samples, in_samples, out_samples, (pdata->in_samples - pdata->out_samples), latency );
 	return error;
 }
 


### PR DESCRIPTION
Compensating for slower speed change results in too much audio delay.

Speeds slower than 0.1x result in an audio lag of 120ms. After much testing, that seems to be the magic lag where we don't always get expected results. This change will not apply compensation for speed slower than 0.1x