### PR TITLE
Fix build with Qt 5.15.0

### DIFF
--- a/src/modules/qt/filter_qtext.cpp
+++ b/src/modules/qt/filter_qtext.cpp
@@ -21,6 +21,7 @@
 #include <framework/mlt.h>
 #include <framework/mlt_log.h>
 #include <QPainter>
+#include <QPainterPath>
 #include <QString>
 
 static QRectF get_text_path( QPainterPath* qpath, mlt_properties filter_properties, const char* text, double scale )

--- a/src/modules/qt/graph.cpp
+++ b/src/modules/qt/graph.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "graph.h"
+#include <QPainterPath>
 #include <QVector>
 #include <math.h>
 

--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -26,6 +26,7 @@
 #include <QImage>
 #include <QColor>
 #include <QPainter>
+#include <QPainterPath>
 #include <QFont>
 #include <QString>
 #include <QTextCodec>


### PR DESCRIPTION
QPainterPath is no longer included via qtransform.h (since
5.15.0-beta2, 50d2acdc93b4de2ba56eb67787e2bdcb21dd4bea in qtbase.git).