### PR TITLE
(hopefully) make GPU effects (aka. movit) less crashy.

### DIFF
--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -823,7 +823,7 @@ static void on_property_changed( void*, mlt_properties properties, const char *n
 			{
 				char *name_cstr = getCString( name );
 				const char *format = "device.%d";
-				char *key = (char*) calloc( 1, strlen( format ) + 1 );
+				char *key = (char*) calloc( 1, strlen( format ) + 17 );
 
 				sprintf( key, format, i );
 				mlt_properties_set( properties, key, name_cstr );

--- a/src/modules/opengl/consumer_xgl.c
+++ b/src/modules/opengl/consumer_xgl.c
@@ -268,7 +268,7 @@ void* video_thread( void *arg )
 				int width = 0, height = 0;
 				GLuint *image = 0;
 				int error = mlt_frame_get_image( next, (uint8_t**) &image, &vfmt, &width, &height, 0 );
-				if ( !error && image && width && height && !new_frame.new ) {
+				if ( !error && image && width > 0 && height > 0 && !new_frame.new ) {
 					new_frame.width = width;
 					new_frame.height = height;
 					new_frame.texture = *image;

--- a/src/modules/opengl/filter_glsl_manager.cpp
+++ b/src/modules/opengl/filter_glsl_manager.cpp
@@ -391,7 +391,7 @@ void GlslManager::set_effect_third_input( mlt_service service, mlt_frame frame, 
 int GlslManager::render_frame_texture(EffectChain *chain, mlt_frame frame, int width, int height, uint8_t **image)
 {
 	if (width < 1 || height < 1) {
-		return NULL;
+		return 1;
 	}
 
 	glsl_texture texture = get_texture( width, height, GL_RGBA8 );
@@ -454,7 +454,7 @@ int GlslManager::render_frame_texture(EffectChain *chain, mlt_frame frame, int w
 int GlslManager::render_frame_rgba(EffectChain *chain, mlt_frame frame, int width, int height, uint8_t **image)
 {
 	if (width < 1 || height < 1) {
-		return NULL;
+		return 1;
 	}
 
 	glsl_texture texture = get_texture( width, height, GL_RGBA8 );

--- a/src/modules/opengl/filter_glsl_manager.cpp
+++ b/src/modules/opengl/filter_glsl_manager.cpp
@@ -111,6 +111,10 @@ GlslManager* GlslManager::get_instance()
 
 glsl_texture GlslManager::get_texture(int width, int height, GLint internal_format)
 {
+	if (width < 1 || height < 1) {
+		return NULL;
+	}
+
 #if USE_TEXTURE_POOL
 	lock();
 	for (int i = 0; i < texture_list.count(); ++i) {
@@ -386,6 +390,10 @@ void GlslManager::set_effect_third_input( mlt_service service, mlt_frame frame, 
 
 int GlslManager::render_frame_texture(EffectChain *chain, mlt_frame frame, int width, int height, uint8_t **image)
 {
+	if (width < 1 || height < 1) {
+		return NULL;
+	}
+
 	glsl_texture texture = get_texture( width, height, GL_RGBA8 );
 	if (!texture) {
 		return 1;
@@ -445,6 +453,10 @@ int GlslManager::render_frame_texture(EffectChain *chain, mlt_frame frame, int w
 
 int GlslManager::render_frame_rgba(EffectChain *chain, mlt_frame frame, int width, int height, uint8_t **image)
 {
+	if (width < 1 || height < 1) {
+		return NULL;
+	}
+
 	glsl_texture texture = get_texture( width, height, GL_RGBA8 );
 	if (!texture) {
 		return 1;

--- a/src/modules/opengl/filter_movit_blur.cpp
+++ b/src/modules/opengl/filter_movit_blur.cpp
@@ -28,6 +28,10 @@ using namespace movit;
 
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
+	if (!width || !height || *width < 1 || *height < 1) {
+		return 1;
+	}
+
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );

--- a/src/modules/opengl/filter_movit_blur.cpp
+++ b/src/modules/opengl/filter_movit_blur.cpp
@@ -28,10 +28,6 @@ using namespace movit;
 
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
-	if (!width || !height || *width < 1 || *height < 1) {
-		return 1;
-	}
-
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
@@ -42,6 +38,11 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		return error;
+	}
+
 	radius *= mlt_profile_scale_width(profile, *width);
 	mlt_properties_set_double( properties, "_movit.parms.float.radius",
 		radius );

--- a/src/modules/opengl/filter_movit_convert.cpp
+++ b/src/modules/opengl/filter_movit_convert.cpp
@@ -472,7 +472,7 @@ static MltInput* create_input( mlt_properties properties, mlt_image_format forma
 {
 	if (width < 1 || height < 1) {
 		mlt_log_error( NULL, "Invalid frame size for create_input: %dx%d.\n", width, height );
-		return NULL;
+		return nullptr;
 	}
 
 	MltInput* input = new MltInput( format );

--- a/src/modules/opengl/filter_movit_crop.cpp
+++ b/src/modules/opengl/filter_movit_crop.cpp
@@ -51,7 +51,7 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 
 	if (*width < 1 || *height < 1) {
 		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
+		return error;
 	}
 
 	mlt_properties_set_int( properties, "rescale_width", *width );

--- a/src/modules/opengl/filter_movit_crop.cpp
+++ b/src/modules/opengl/filter_movit_crop.cpp
@@ -38,16 +38,22 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	// Correct width/height if necessary
 	*width = mlt_properties_get_int( properties, "crop.original_width" );
 	*height = mlt_properties_get_int( properties, "crop.original_height" );
-	if ( *width == 0 || *height == 0 )
+	if ( *width < 1 || *height < 1 )
 	{
 		*width = mlt_properties_get_int( properties, "meta.media.width" );
 		*height = mlt_properties_get_int( properties, "meta.media.height" );
 	}
-	if ( *width == 0 || *height == 0 )
+	if ( *width < 1 || *height < 1 )
 	{
 		*width = profile->width;
 		*height = profile->height;
 	}
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties_set_int( properties, "rescale_width", *width );
 	mlt_properties_set_int( properties, "rescale_height", *height );
 
@@ -77,8 +83,8 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		double bottom  = mlt_properties_get_double( properties, "crop.bottom" );
 		int owidth  = *width - left - right;
 		int oheight = *height - top - bottom;
-		owidth = owidth < 0 ? 0 : owidth;
-		oheight = oheight < 0 ? 0 : oheight;
+		owidth = owidth < 1 ? 1 : owidth;
+		oheight = oheight < 1 ? 1 : oheight;
 
 		mlt_log_debug( MLT_FILTER_SERVICE(filter), "%dx%d -> %dx%d\n", *width, *height, owidth, oheight);
 

--- a/src/modules/opengl/filter_movit_deconvolution_sharpen.cpp
+++ b/src/modules/opengl/filter_movit_deconvolution_sharpen.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -62,6 +57,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new DeconvolutionSharpenEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_deconvolution_sharpen.cpp
+++ b/src/modules/opengl/filter_movit_deconvolution_sharpen.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_diffusion.cpp
+++ b/src/modules/opengl/filter_movit_diffusion.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -46,6 +41,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new DiffusionEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_diffusion.cpp
+++ b/src/modules/opengl/filter_movit_diffusion.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_flip.cpp
+++ b/src/modules/opengl/filter_movit_flip.cpp
@@ -30,6 +30,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );

--- a/src/modules/opengl/filter_movit_flip.cpp
+++ b/src/modules/opengl/filter_movit_flip.cpp
@@ -31,13 +31,14 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new Mlt::VerticalFlip );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_glow.cpp
+++ b/src/modules/opengl/filter_movit_glow.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	mlt_position position = mlt_filter_get_position( filter, frame );
 	mlt_position length = mlt_filter_get_length2( filter, frame );
@@ -49,6 +44,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new GlowEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_glow.cpp
+++ b/src/modules/opengl/filter_movit_glow.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	mlt_position position = mlt_filter_get_position( filter, frame );
 	mlt_position length = mlt_filter_get_length2( filter, frame );

--- a/src/modules/opengl/filter_movit_lift_gamma_gain.cpp
+++ b/src/modules/opengl/filter_movit_lift_gamma_gain.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_lift_gamma_gain.cpp
+++ b/src/modules/opengl/filter_movit_lift_gamma_gain.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -60,6 +55,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new LiftGammaGainEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_mirror.cpp
+++ b/src/modules/opengl/filter_movit_mirror.cpp
@@ -30,13 +30,14 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new MirrorEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_mirror.cpp
+++ b/src/modules/opengl/filter_movit_mirror.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );

--- a/src/modules/opengl/filter_movit_opacity.cpp
+++ b/src/modules/opengl/filter_movit_opacity.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -48,6 +43,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new MultiplyEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_opacity.cpp
+++ b/src/modules/opengl/filter_movit_opacity.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_resample.cpp
+++ b/src/modules/opengl/filter_movit_resample.cpp
@@ -35,10 +35,15 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	mlt_profile profile = mlt_service_profile( MLT_FILTER_SERVICE( filter ) );
 
 	// Correct width/height if necessary
-	if ( *width == 0 || *height == 0 )
+	if ( *width < 0 || *height < 1 )
 	{
 		*width = profile->width;
 		*height = profile->height;
+	}
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
 	}
 
 	int iwidth = *width;
@@ -53,6 +58,11 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	{
 		iwidth = mlt_properties_get_int( properties, "meta.media.width" );
 		iheight = mlt_properties_get_int( properties, "meta.media.height" );
+	}
+
+	if (iwidth < 1 || iheight < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid input size for get_image: %dx%d", *width, *height);
+		return 1;
 	}
 
 	mlt_properties_set_int( properties, "rescale_width", *width );

--- a/src/modules/opengl/filter_movit_resample.cpp
+++ b/src/modules/opengl/filter_movit_resample.cpp
@@ -41,11 +41,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		*height = profile->height;
 	}
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	int iwidth = *width;
 	int iheight = *height;
 	double factor = mlt_properties_get_double( filter_properties, "factor" );
@@ -58,11 +53,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	{
 		iwidth = mlt_properties_get_int( properties, "meta.media.width" );
 		iheight = mlt_properties_get_int( properties, "meta.media.height" );
-	}
-
-	if (iwidth < 1 || iheight < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid input size for get_image: %dx%d", *width, *height);
-		return 1;
 	}
 
 	mlt_properties_set_int( properties, "rescale_width", *width );
@@ -88,6 +78,13 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	if ( *format != mlt_image_none )
 		*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, &iwidth, &iheight, writable );
+
+	if (*width < 1 || *height < 1 || iwidth < 1 || iheight < 1 || owidth < 1 || oheight < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d, in: %dx%d, out: %dx%d",
+			       *width, *height, iwidth, iheight, owidth, oheight);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	Effect *effect = GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new OptionalEffect<ResampleEffect> );
 	// This needs to be something else than 0x0 at chain finalization time.

--- a/src/modules/opengl/filter_movit_resize.cpp
+++ b/src/modules/opengl/filter_movit_resize.cpp
@@ -70,6 +70,7 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	// Use a mlt_rect to compute position and size
 	mlt_rect rect;
 	rect.x = rect.y = 0.0;
+	rect.w = rect.h = 1.0;
 	if ( mlt_properties_get( properties, "resize.rect" ) ) {
 		mlt_position position = mlt_filter_get_position( filter, frame );
 		mlt_position length = mlt_filter_get_length2( filter, frame );
@@ -169,7 +170,7 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 
 	if (*width < 1 || *height < 1) {
 		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
+		return error;
 	}
 
 	if ( !error ) {

--- a/src/modules/opengl/filter_movit_resize.cpp
+++ b/src/modules/opengl/filter_movit_resize.cpp
@@ -57,7 +57,7 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	double consumer_aspect = mlt_profile_sar( profile );
 
 	// Correct Width/height if necessary
-	if ( *width == 0 || *height == 0 )
+	if ( *width < 1 || *height < 1 )
 	{
 		*width = profile->width;
 		*height = profile->height;
@@ -165,6 +165,11 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		float h = float( *height - oheight );
 		rect.x = w * 0.5f;
 		rect.y = h * 0.5f;
+	}
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
 	}
 
 	if ( !error ) {

--- a/src/modules/opengl/filter_movit_saturation.cpp
+++ b/src/modules/opengl/filter_movit_saturation.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_saturation.cpp
+++ b/src/modules/opengl/filter_movit_saturation.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -44,6 +39,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new SaturationEffect() );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_vignette.cpp
+++ b/src/modules/opengl/filter_movit_vignette.cpp
@@ -30,11 +30,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -46,6 +41,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new VignetteEffect() );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/filter_movit_vignette.cpp
+++ b/src/modules/opengl/filter_movit_vignette.cpp
@@ -29,6 +29,12 @@ using namespace movit;
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_white_balance.cpp
+++ b/src/modules/opengl/filter_movit_white_balance.cpp
@@ -40,6 +40,12 @@ static double srgb8_to_linear(int c)
 static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );

--- a/src/modules/opengl/filter_movit_white_balance.cpp
+++ b/src/modules/opengl/filter_movit_white_balance.cpp
@@ -41,11 +41,6 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 {
 	mlt_filter filter = (mlt_filter) mlt_frame_pop_service( frame );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 	GlslManager::get_instance()->lock_service( frame );
 	mlt_position position = mlt_filter_get_position( filter, frame );
@@ -66,6 +61,12 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	GlslManager::get_instance()->unlock_service( frame );
 	*format = mlt_image_glsl;
 	int error = mlt_frame_get_image( frame, image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
+
 	GlslManager::set_effect_input( MLT_FILTER_SERVICE( filter ), frame, (mlt_service) *image );
 	GlslManager::set_effect( MLT_FILTER_SERVICE( filter ), frame, new WhiteBalanceEffect );
 	*image = (uint8_t *) MLT_FILTER_SERVICE( filter );

--- a/src/modules/opengl/mlt_movit_input.cpp
+++ b/src/modules/opengl/mlt_movit_input.cpp
@@ -27,6 +27,8 @@ using namespace movit;
 
 MltInput::MltInput( mlt_image_format format )
 	: m_format(format)
+	, m_width(0)
+	, m_height(0)
 	, input(0)
 	, isRGB(true)
 {
@@ -73,10 +75,16 @@ void MltInput::useYCbCrInput(const ImageFormat& image_format, const YCbCrFormat&
 
 void MltInput::set_pixel_data(const unsigned char* data)
 {
-    if (!input) {
+	if (!input) {
 		mlt_log_error( NULL, "No input for set_pixel_data");
-        return;
-    }
+		return;
+	}
+
+	// In case someone didn't think properly and passed -1 to an unsigned
+	if (int(m_width) < 1 || int(m_height) < 1) {
+		mlt_log_error( NULL, "Invalid size %dx%d\n", m_width, m_height);
+		return;
+	}
 
 	if (isRGB) {
 		FlatInput* flat = (FlatInput*) input;

--- a/src/modules/opengl/mlt_movit_input.cpp
+++ b/src/modules/opengl/mlt_movit_input.cpp
@@ -19,6 +19,10 @@
 
 #include "mlt_movit_input.h"
 
+extern "C" {
+#include <framework/mlt_log.h>
+}
+
 using namespace movit;
 
 MltInput::MltInput( mlt_image_format format )
@@ -34,6 +38,12 @@ MltInput::~MltInput()
 
 void MltInput::useFlatInput(MovitPixelFormat pix_fmt, unsigned width, unsigned height)
 {
+	// In case someone didn't think properly and passed -1 to an unsigned
+	if (int(width) < 1 || int(height) < 1) {
+		mlt_log_error( NULL, "Invalid size %dx%d\n", width, height);
+		return;
+	}
+
 	if (!input) {
 		m_width = width;
 		m_height = height;
@@ -46,6 +56,12 @@ void MltInput::useFlatInput(MovitPixelFormat pix_fmt, unsigned width, unsigned h
 
 void MltInput::useYCbCrInput(const ImageFormat& image_format, const YCbCrFormat& ycbcr_format, unsigned width, unsigned height)
 {
+	// In case someone didn't think properly and passed -1 to an unsigned
+	if (int(width) < 1 || int(height) < 1) {
+		mlt_log_error( NULL, "Invalid size %dx%d\n", width, height);
+		return;
+	}
+
 	if (!input) {
 		m_width = width;
 		m_height = height;
@@ -57,7 +73,11 @@ void MltInput::useYCbCrInput(const ImageFormat& image_format, const YCbCrFormat&
 
 void MltInput::set_pixel_data(const unsigned char* data)
 {
-	assert(input);
+    if (!input) {
+		mlt_log_error( NULL, "No input for set_pixel_data");
+        return;
+    }
+
 	if (isRGB) {
 		FlatInput* flat = (FlatInput*) input;
 		flat->set_pixel_data(data);
@@ -71,7 +91,11 @@ void MltInput::set_pixel_data(const unsigned char* data)
 
 void MltInput::invalidate_pixel_data()
 {
-	assert(input);
+	if (!input) {
+		mlt_log_error( NULL, "Invalidate called without input\n");
+		return;
+	}
+
 	if (isRGB) {
 		FlatInput* flat = (FlatInput*) input;
 		flat->invalidate_pixel_data();

--- a/src/modules/opengl/mlt_movit_input.h
+++ b/src/modules/opengl/mlt_movit_input.h
@@ -44,10 +44,10 @@ public:
 
 private:
 	mlt_image_format m_format;
-	unsigned m_width, m_height;
+	unsigned m_width = 1, m_height = 1;
 	// Note: Owned by the EffectChain, so should not be deleted by us.
-	movit::Input *input;
-	bool isRGB;
+	movit::Input *input = nullptr;
+	bool isRGB = false;
 	movit::YCbCrFormat m_ycbcr_format;
 };
 

--- a/src/modules/opengl/mlt_movit_input.h
+++ b/src/modules/opengl/mlt_movit_input.h
@@ -44,10 +44,10 @@ public:
 
 private:
 	mlt_image_format m_format;
-	unsigned m_width = 1, m_height = 1;
+	unsigned m_width, m_height;
 	// Note: Owned by the EffectChain, so should not be deleted by us.
-	movit::Input *input = nullptr;
-	bool isRGB = false;
+	movit::Input *input;
+	bool isRGB;
 	movit::YCbCrFormat m_ycbcr_format;
 };
 

--- a/src/modules/opengl/transition_movit_luma.cpp
+++ b/src/modules/opengl/transition_movit_luma.cpp
@@ -39,12 +39,6 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	// Get the transition object
 	mlt_transition transition = (mlt_transition) mlt_frame_pop_service( a_frame );
 	mlt_service service = MLT_TRANSITION_SERVICE( transition );
-
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	// Get the b frame from the stack
 	mlt_frame b_frame = (mlt_frame) mlt_frame_pop_frame( a_frame );
 	mlt_frame c_frame = (mlt_frame) mlt_frame_pop_frame( a_frame );
@@ -73,13 +67,18 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 			!mlt_properties_get_int( properties, "invert" ) );
 
 		uint8_t *a_image, *b_image, *c_image;
-	
+
 		// Get the images.
 		*format = mlt_image_glsl;
 		error = mlt_frame_get_image( a_frame, &a_image, format, width, height, writable );
 		error = mlt_frame_get_image( b_frame, &b_image, format, width, height, writable );
 		error = mlt_frame_get_image( c_frame, &c_image, format, width, height, writable );
-	
+
+		if (*width < 1 || *height < 1) {
+			mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+			return error;
+		}
+
 		GlslManager::set_effect_input( service, a_frame, (mlt_service) a_image );
 		GlslManager::set_effect_secondary_input( service, a_frame, (mlt_service) b_image, b_frame );
 		GlslManager::set_effect_third_input( service, a_frame, (mlt_service) c_image, c_frame );
@@ -100,6 +99,11 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 		*format = mlt_image_glsl;
 		error = mlt_frame_get_image( a_frame, &a_image, format, width, height, writable );
 		error = mlt_frame_get_image( b_frame, &b_image, format, width, height, writable );
+
+		if (*width < 1 || *height < 1) {
+			mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+			return error;
+		}
 	
 		GlslManager::set_effect_input( service, a_frame, (mlt_service) a_image );
 		GlslManager::set_effect_secondary_input( service, a_frame, (mlt_service) b_image, b_frame );

--- a/src/modules/opengl/transition_movit_luma.cpp
+++ b/src/modules/opengl/transition_movit_luma.cpp
@@ -40,6 +40,11 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	mlt_transition transition = (mlt_transition) mlt_frame_pop_service( a_frame );
 	mlt_service service = MLT_TRANSITION_SERVICE( transition );
 
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	// Get the b frame from the stack
 	mlt_frame b_frame = (mlt_frame) mlt_frame_pop_frame( a_frame );
 	mlt_frame c_frame = (mlt_frame) mlt_frame_pop_frame( a_frame );

--- a/src/modules/opengl/transition_movit_mix.cpp
+++ b/src/modules/opengl/transition_movit_mix.cpp
@@ -44,6 +44,11 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	mlt_service service = MLT_TRANSITION_SERVICE( transition );
 	mlt_service_lock( service );
 
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	// Get the properties of the transition
 	mlt_properties properties = MLT_TRANSITION_PROPERTIES( transition );
 

--- a/src/modules/opengl/transition_movit_mix.cpp
+++ b/src/modules/opengl/transition_movit_mix.cpp
@@ -44,11 +44,6 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	mlt_service service = MLT_TRANSITION_SERVICE( transition );
 	mlt_service_lock( service );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	// Get the properties of the transition
 	mlt_properties properties = MLT_TRANSITION_PROPERTIES( transition );
 
@@ -72,6 +67,11 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	*format = mlt_image_glsl;
 	error = mlt_frame_get_image( a_frame, &a_image, format, width, height, writable );
 	error = mlt_frame_get_image( b_frame, &b_image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
 
 	GlslManager::set_effect_input( service, a_frame, (mlt_service) a_image );
 	GlslManager::set_effect_secondary_input( service, a_frame, (mlt_service) b_image, b_frame );

--- a/src/modules/opengl/transition_movit_overlay.cpp
+++ b/src/modules/opengl/transition_movit_overlay.cpp
@@ -42,6 +42,11 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	mlt_service service = MLT_TRANSITION_SERVICE( transition );
 	mlt_service_lock( service );
 
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+		return 1;
+	}
+
 	uint8_t *a_image, *b_image;
 
 	// Get the two images.

--- a/src/modules/opengl/transition_movit_overlay.cpp
+++ b/src/modules/opengl/transition_movit_overlay.cpp
@@ -42,17 +42,17 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	mlt_service service = MLT_TRANSITION_SERVICE( transition );
 	mlt_service_lock( service );
 
-	if (*width < 1 || *height < 1) {
-		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
-		return 1;
-	}
-
 	uint8_t *a_image, *b_image;
 
 	// Get the two images.
 	*format = mlt_image_glsl;
 	error = mlt_frame_get_image( a_frame, &a_image, format, width, height, writable );
 	error = mlt_frame_get_image( b_frame, &b_image, format, width, height, writable );
+
+	if (*width < 1 || *height < 1) {
+		mlt_log_error( service, "Invalid size for get_image: %dx%d", *width, *height);
+		return error;
+	}
 
 	GlslManager::set_effect_input( service, a_frame, (mlt_service) a_image );
 	GlslManager::set_effect_secondary_input( service, a_frame, (mlt_service) b_image, b_frame );


### PR DESCRIPTION
movit assert()s on all errors, so make really sure we don't pass in invalid values.

Looking at a couple of bug reports, I think some of the problems are because of invalid values passed around and handed directly to movit, and movit just asserts instead of handling invalid values gracefully.