### PR TITLE
Chain/Link Proof of Concept with Time Remapping example

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -51,7 +51,9 @@ OBJS = mlt_audio.o \
 	   mlt_cache.o \
 	   mlt_animation.o \
 	   mlt_slices.o \
-	   mlt_luma_map.o
+	   mlt_luma_map.o \
+	   mlt_link.o \
+	   mlt_chain.o
 
 INCS = mlt_audio.h \
 	   mlt_consumer.h \
@@ -82,7 +84,9 @@ INCS = mlt_audio.h \
 	   mlt_cache.h \
 	   mlt_animation.h \
 	   mlt_slices.h \
-	   mlt_luma_map.h
+	   mlt_luma_map.h \
+	   mlt_link.h \
+	   mlt_chain.h
 
 SRCS := $(OBJS:.o=.c)
 

--- a/src/framework/mlt.h
+++ b/src/framework/mlt.h
@@ -59,6 +59,8 @@ extern "C"
 #include "mlt_cache.h"
 #include "mlt_version.h"
 #include "mlt_slices.h"
+#include "mlt_link.h"
+#include "mlt_chain.h"
 
 #ifdef __cplusplus
 }

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -576,3 +576,21 @@ MLT_6.22.0 {
     mlt_audio_channel_layout_channels;
     mlt_audio_channel_layout_default;
 } MLT_6.20.0;
+
+MLT_6.24.0 {
+  global:
+    mlt_factory_link;
+    mlt_chain_init;
+    mlt_chain_set_source;
+    mlt_chain_get_source;
+    mlt_chain_attach;
+    mlt_chain_detach;
+    mlt_chain_link_count;
+    mlt_chain_move_link;
+    mlt_chain_link;
+    mlt_chain_close;
+    mlt_link_init;
+    mlt_link_connect_next;
+    mlt_link_close;
+    mlt_repository_links;
+} MLT_6.22.0;

--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -1,0 +1,460 @@
+/**
+ * \file mlt_chain.c
+ * \brief link service class
+ * \see mlt_chain_s
+ *
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "mlt_chain.h"
+#include "mlt_factory.h"
+#include "mlt_frame.h"
+#include "mlt_log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** \brief private service definition */
+
+typedef struct
+{
+	int link_count;
+	int link_size;
+	mlt_link* links;
+	mlt_producer source;
+	mlt_profile source_profile;
+	mlt_properties source_parameters;
+	mlt_producer begin;
+}
+mlt_chain_base;
+
+/* Forward references to static methods.
+*/
+
+static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int index );
+static void relink_chain( mlt_chain self );
+static void chain_property_changed( mlt_service owner, mlt_chain self, char *name );
+static void source_property_changed( mlt_service owner, mlt_chain self, char *name );
+
+/** Construct a chain.
+ *
+ * \public \memberof mlt_chain_s
+ * \return the new chain
+ */
+
+mlt_chain mlt_chain_init( mlt_profile profile )
+{
+	mlt_chain self = calloc( 1, sizeof( struct mlt_chain_s ) );
+	if ( self != NULL )
+	{
+		mlt_producer producer = &self->parent;
+		if ( mlt_producer_init( producer, self ) == 0 )
+		{
+			mlt_properties properties = MLT_PRODUCER_PROPERTIES( producer );
+
+			mlt_properties_set( properties, "mlt_type", "chain" );
+			mlt_properties_clear( properties, "resource");
+			mlt_properties_clear( properties, "mlt_service");
+			mlt_properties_clear( properties, "in");
+			mlt_properties_clear( properties, "out");
+			mlt_properties_clear( properties, "length");
+
+			producer->get_frame = producer_get_frame;
+			producer->close = ( mlt_destructor )mlt_chain_close;
+			producer->close_object = self;
+
+			mlt_service_set_profile( MLT_CHAIN_SERVICE( self ), profile );
+
+			// Generate local space
+			self->local = calloc( 1, sizeof( mlt_chain_base ) );
+			mlt_chain_base* base = self->local;
+			base->source_profile = mlt_profile_init(NULL);
+
+			// Listen to property changes to pass along to the source
+			mlt_events_listen( MLT_CHAIN_PROPERTIES(self), self, "property-changed", ( mlt_listener )chain_property_changed );
+		}
+		else
+		{
+			free( self );
+			self = NULL;
+		}
+	}
+	return self;
+}
+
+/** Set the source producer.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \param source the new source producer
+ */
+
+void mlt_chain_set_source( mlt_chain self, mlt_producer source )
+{
+	int error = self == NULL || source == NULL;
+	if ( error == 0 )
+	{
+		mlt_chain_base* base = self->local;
+		mlt_properties source_properties = MLT_PRODUCER_PROPERTIES( source );
+		int n = 0;
+		int i = 0;
+
+		// Clean up from previous source
+		mlt_producer_close( base->source );
+		mlt_properties_close( base->source_parameters );
+
+		// Save the source producer
+		base->source = source;
+		mlt_properties_inc_ref( source_properties );
+
+		// Create a list of all parameters used by the source producer so that
+		// they can be passed between the source producer and this chain.
+		base->source_parameters = mlt_properties_new();
+		mlt_repository repository = mlt_factory_repository();
+		mlt_properties source_metadata = mlt_repository_metadata( repository, producer_type, mlt_properties_get( source_properties, "mlt_service" ) );
+		if ( source_metadata )
+		{
+			mlt_properties params = (mlt_properties) mlt_properties_get_data( source_metadata, "parameters", NULL );
+			if ( params )
+			{
+				n = mlt_properties_count( params );
+				for ( i = 0; i < n; i++ )
+				{
+					mlt_properties param = (mlt_properties) mlt_properties_get_data( params, mlt_properties_get_name( params, i ), NULL );
+					char* identifier = mlt_properties_get( param, "identifier" );
+					if ( identifier )
+					{
+						// Set the value to 1 to indicate the parameter exists.
+						mlt_properties_set_int( base->source_parameters, identifier, 1 );
+					}
+				}
+			}
+		}
+
+		// Pass parameters and properties from the source producer to this chain.
+		// Some properties may have been set during source initialization.
+		n = mlt_properties_count( source_properties );
+		mlt_events_block( MLT_CHAIN_PROPERTIES(self), self );
+		for ( i = 0; i < n; i++ )
+		{
+			char* name = mlt_properties_get_name( source_properties, i );
+			if ( mlt_properties_get_int( base->source_parameters, name ) ||
+				 !strcmp( name, "mlt_service" ) ||
+				 !strcmp( name, "_mlt_service_hidden" ) ||
+				 !strncmp( name, "meta.", 5 ) )
+			{
+				mlt_properties_pass_property( MLT_CHAIN_PROPERTIES(self), source_properties, name );
+			}
+		}
+		// If a length has not been specified for this chain, copy in/out/length from the source producer
+		if ( !mlt_producer_get_length( MLT_CHAIN_PRODUCER(self) ) ) {
+			mlt_properties_set_int( MLT_CHAIN_PROPERTIES(self), "length", mlt_producer_get_length( base->source ) );
+			mlt_producer_set_in_and_out( MLT_CHAIN_PRODUCER(self), mlt_producer_get_in( base->source ), mlt_producer_get_out( base->source ) );
+		}
+		mlt_events_unblock( MLT_CHAIN_PROPERTIES(self), self );
+
+		// Monitor property changes from the source to pass to the chain.
+		mlt_events_listen( source_properties, self, "property-changed", ( mlt_listener )source_property_changed );
+
+		// Save the native source producer profile
+		mlt_profile_from_producer( base->source_profile, base->source );
+
+		// This chain will control the speed
+		mlt_producer_set_speed( base->source, 0.0 );
+
+		// Reconfigure the chain
+		relink_chain( self );
+		mlt_events_fire( MLT_CHAIN_PROPERTIES(self), "chain-changed", NULL );
+	}
+}
+
+/** Get the source producer.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \return the source producer
+ */
+
+extern mlt_producer mlt_chain_get_source( mlt_chain self )
+{
+	mlt_producer source = NULL;
+	if ( self && self->local )
+	{
+		mlt_chain_base* base = self->local;
+		source = base->source;
+	}
+	return source;
+}
+
+/** Attach a link.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \param link the link to attach
+ * \return true if there was an error
+ */
+
+int mlt_chain_attach( mlt_chain self, mlt_link link )
+{
+	int error = self == NULL || link == NULL;
+	if ( error == 0 )
+	{
+		int i = 0;
+		mlt_chain_base *base = self->local;
+
+		for ( i = 0; error == 0 && i < base->link_count; i ++ )
+			if ( base->links[ i ] == link )
+				error = 1;
+
+		if ( error == 0 )
+		{
+			if ( base->link_count == base->link_size )
+			{
+				base->link_size += 10;
+				base->links = realloc( base->links, base->link_size * sizeof( mlt_link ) );
+			}
+
+			if ( base->links != NULL )
+			{
+				mlt_properties_inc_ref( MLT_LINK_PROPERTIES( link ) );
+				mlt_properties_set_data( MLT_LINK_PROPERTIES( link ), "chain", self, 0, NULL, NULL );
+				base->links[ base->link_count ++ ] = link;
+				relink_chain( self );
+				mlt_events_fire( MLT_CHAIN_PROPERTIES(self), "chain-changed", NULL );
+			}
+			else
+			{
+				error = 2;
+			}
+		}
+	}
+	return error;
+}
+
+/** Detach a link.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \param link the link to detach
+ * \return true if there was an error
+ */
+
+int mlt_chain_detach( mlt_chain self, mlt_link link )
+{
+	int error = self == NULL || link == NULL;
+	if ( error == 0 )
+	{
+		int i = 0;
+		mlt_chain_base *base = self->local;
+
+		for ( i = 0; i < base->link_count; i ++ )
+			if ( base->links[ i ] == link )
+				break;
+
+		if ( i < base->link_count )
+		{
+			base->links[ i ] = NULL;
+			for ( i ++ ; i < base->link_count; i ++ )
+				base->links[ i - 1 ] = base->links[ i ];
+			base->link_count --;
+			mlt_link_close( link );
+			relink_chain( self );
+			mlt_events_fire( MLT_CHAIN_PROPERTIES(self), "chain-changed", NULL );
+		}
+	}
+	return error;
+}
+
+/** Get the number of links attached.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \return the number of attached links or -1 if there was an error
+ */
+
+int mlt_chain_link_count( mlt_chain self )
+{
+	int result = -1;
+	if ( self )
+	{
+		mlt_chain_base *base = self->local;
+		result = base->link_count;
+	}
+	return result;
+}
+
+/** Reorder the attached links.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \param from the current index value of the link to move
+ * \param to the new index value for the link specified in \p from
+ * \return true if there was an error
+ */
+
+int mlt_chain_move_link( mlt_chain self, int from, int to )
+{
+	int error = -1;
+	if ( self )
+	{
+		mlt_chain_base *base = self->local;
+		if ( from < 0 ) from = 0;
+		if ( from >= base->link_count ) from = base->link_count - 1;
+		if ( to < 0 ) to = 0;
+		if ( to >= base->link_count ) to = base->link_count - 1;
+		if ( from != to && base->link_count > 1 )
+		{
+			mlt_link link = base->links[from];
+			int i;
+			if ( from > to )
+			{
+				for ( i = from; i > to; i-- )
+					base->links[i] = base->links[i - 1];
+			}
+			else
+			{
+				for ( i = from; i < to; i++ )
+					base->links[i] = base->links[i + 1];
+			}
+			base->links[to] = link;
+			relink_chain( self );
+			mlt_events_fire( MLT_CHAIN_PROPERTIES(self), "chain-changed", NULL );
+			error = 0;
+		}
+	}
+	return error;
+}
+
+/** Retrieve an attached link.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ * \param index which one of potentially multiple links
+ * \return the link or null if there was an error
+ */
+
+mlt_link mlt_chain_link( mlt_chain self, int index )
+{
+	mlt_link link = NULL;
+	if ( self != NULL )
+	{
+		mlt_chain_base *base = self->local;
+		if ( index >= 0 && index < base->link_count )
+			link = base->links[ index ];
+	}
+	return link;
+}
+
+/** Close the chain and free its resources.
+ *
+ * \public \memberof mlt_chain_s
+ * \param self a chain
+ */
+
+void mlt_chain_close( mlt_chain self )
+{
+	if ( self != NULL && mlt_properties_dec_ref( MLT_CHAIN_PROPERTIES( self ) ) <= 0 )
+	{
+		int i = 0;
+		mlt_chain_base *base = self->local;
+		mlt_events_block( MLT_CHAIN_PROPERTIES( self ), self );
+		for ( i = 0; i < base->link_count; i ++ )
+			mlt_link_close( base->links[ i ] );
+		free( base->links );
+		mlt_profile_close( base->source_profile );
+		free( base );
+		self->parent.close = NULL;
+		mlt_producer_close( &self->parent );
+		free( self );
+	}
+}
+
+static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int index )
+{
+	int result = 1;
+	if ( parent && parent->child )
+	{
+		mlt_chain self = parent->child;
+		if( self )
+		{
+			mlt_chain_base *base = self->local;
+			mlt_producer_seek( base->begin, mlt_producer_frame( parent ) );
+			result = mlt_service_get_frame( MLT_PRODUCER_SERVICE( base->begin ), frame, index );
+			mlt_producer_prepare_next( parent );
+		}
+	}
+	return result;
+}
+
+static void relink_chain( mlt_chain self )
+{
+	mlt_chain_base *base = self->local;
+	mlt_profile profile = mlt_service_profile( MLT_CHAIN_SERVICE(self) );
+
+	if ( base->link_count == 0 )
+	{
+		base->begin = base->source;
+		// If there are no links, the producer can operate in the final frame rate
+		mlt_service_set_profile( MLT_PRODUCER_SERVICE(base->source), profile );
+	}
+	else
+	{
+		// Set the producer to be in native frame rate
+		mlt_service_set_profile( MLT_PRODUCER_SERVICE(base->source), base->source_profile );
+
+		int i = 0;
+		base->begin = MLT_LINK_PRODUCER( base->links[0] );
+		for ( i = 0; i < base->link_count - 1; i++ )
+		{
+			mlt_link_connect_next( base->links[i], MLT_LINK_PRODUCER( base->links[i+1] ), profile );
+		}
+		mlt_link_connect_next( base->links[base->link_count -1], base->source, profile );
+	}
+}
+
+static void chain_property_changed( mlt_service owner, mlt_chain self, char *name )
+{
+	mlt_chain_base *base = self->local;
+	if ( !base->source ) return;
+	if ( mlt_properties_get_int( base->source_parameters, name ) ||
+		 !strncmp( name, "meta.", 5 ) )
+	{
+		// Pass parameter changes from this chain to the encapsulated source producer.
+		mlt_properties chain_properties = MLT_CHAIN_PROPERTIES( self );
+		mlt_properties source_properties = MLT_PRODUCER_PROPERTIES( base->source );
+		mlt_events_block( source_properties, self );
+		mlt_properties_pass_property( source_properties, chain_properties, name );
+		mlt_events_unblock( source_properties, self );
+	}
+}
+
+static void source_property_changed( mlt_service owner, mlt_chain self, char *name )
+{
+	mlt_chain_base *base = self->local;
+	if ( mlt_properties_get_int( base->source_parameters, name ) ||
+		 !strncmp( name, "meta.", 5 ) )
+	{
+		// The source producer might change its own parameters.
+		// Pass those changes to this producer.
+		mlt_properties chain_properties = MLT_CHAIN_PROPERTIES( self );
+		mlt_properties source_properties = MLT_PRODUCER_PROPERTIES( base->source );
+		mlt_events_block( chain_properties, self );
+		mlt_properties_pass_property( chain_properties, source_properties, name );
+		mlt_events_unblock( chain_properties, self );
+	}
+}

--- a/src/framework/mlt_chain.h
+++ b/src/framework/mlt_chain.h
@@ -1,0 +1,56 @@
+/**
+ * \file mlt_chain.h
+ * \brief chain service class
+ * \see mlt_chain_s
+ *
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MLT_CHAIN_H
+#define MLT_CHAIN_H
+
+#include "mlt_link.h"
+#include "mlt_producer.h"
+
+/** \brief Chain class
+ *
+ * The chain is a producer class that that can connect multiple link producers in a sequence.
+ *
+ * \extends mlt_producer_s
+ */
+
+struct mlt_chain_s
+{
+	struct mlt_producer_s parent;
+	void* local; /**< \private instance object */
+};
+
+#define MLT_CHAIN_PRODUCER( chain )		( &( chain )->parent )
+#define MLT_CHAIN_SERVICE( chain )		MLT_PRODUCER_SERVICE( MLT_CHAIN_PRODUCER( chain ) )
+#define MLT_CHAIN_PROPERTIES( chain )	MLT_SERVICE_PROPERTIES( MLT_CHAIN_SERVICE( chain ) )
+
+extern mlt_chain mlt_chain_init( mlt_profile );
+extern void mlt_chain_set_source( mlt_chain self, mlt_producer source );
+extern mlt_producer mlt_chain_get_source( mlt_chain self );
+extern int mlt_chain_attach( mlt_chain self, mlt_link link );
+extern int mlt_chain_detach( mlt_chain self, mlt_link link );
+extern int mlt_chain_link_count( mlt_chain self );
+extern int mlt_chain_move_link( mlt_chain self, int from, int to );
+extern mlt_link mlt_chain_link( mlt_chain self, int index );
+extern void mlt_chain_close( mlt_chain self );
+
+#endif

--- a/src/framework/mlt_factory.c
+++ b/src/framework/mlt_factory.c
@@ -364,7 +364,15 @@ mlt_producer mlt_factory_producer( mlt_profile profile, const char *service, con
 		if ( obj != NULL )
 		{
 			mlt_properties properties = MLT_PRODUCER_PROPERTIES( obj );
-			set_common_properties( properties, profile, "producer", service );
+			if ( mlt_service_identify( MLT_PRODUCER_SERVICE( obj ) ) == chain_type )
+			{
+				// XML producer may return a chain
+				set_common_properties( properties, profile, "chain", service );
+			}
+			else
+			{
+				set_common_properties( properties, profile, "producer", service );
+			}
 		}
 	}
 	return obj;
@@ -395,6 +403,34 @@ mlt_filter mlt_factory_filter( mlt_profile profile, const char *service, const v
 	{
 		mlt_properties properties = MLT_FILTER_PROPERTIES( obj );
 		set_common_properties( properties, profile, "filter", service );
+	}
+	return obj;
+}
+
+/** Fetch a link from the repository.
+ *
+ * \param service the name of the link
+ * \param input an optional argument to the link constructor, typically a string
+ * \return a new link
+ */
+
+mlt_link mlt_factory_link( const char *service, const void *input )
+{
+	mlt_link obj = NULL;
+
+	// Offer the application the chance to 'create'
+	mlt_events_fire( event_object, "link-create-request", service, input, &obj, NULL );
+
+	if ( obj == NULL )
+	{
+		obj = mlt_repository_create( repository, NULL, link_type, service, input );
+		mlt_events_fire( event_object, "link-create-done", service, input, obj, NULL );
+	}
+
+	if ( obj != NULL )
+	{
+		mlt_properties properties = MLT_LINK_PROPERTIES( obj );
+		set_common_properties( properties, NULL, "link", service );
 	}
 	return obj;
 }

--- a/src/framework/mlt_factory.h
+++ b/src/framework/mlt_factory.h
@@ -53,6 +53,7 @@ extern int mlt_environment_set( const char *name, const char *value );
 extern mlt_properties mlt_factory_event_object( );
 extern mlt_producer mlt_factory_producer( mlt_profile profile, const char *service, const void *resource );
 extern mlt_filter mlt_factory_filter( mlt_profile profile, const char *name, const void *input );
+extern mlt_link mlt_factory_link( const char *name, const void *input );
 extern mlt_transition mlt_factory_transition( mlt_profile profile, const char *name, const void *input );
 extern mlt_consumer mlt_factory_consumer( mlt_profile profile, const char *name, const void *input );
 extern void mlt_factory_register_for_clean_up( void *ptr, mlt_destructor destructor );

--- a/src/framework/mlt_link.c
+++ b/src/framework/mlt_link.c
@@ -1,0 +1,130 @@
+/**
+ * \file mlt_link.c
+ * \brief link service class
+ * \see mlt_link_s
+ *
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "mlt_link.h"
+#include "mlt_frame.h"
+#include "mlt_log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Forward references to static methods.
+*/
+
+static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int track );
+
+/** Construct a link.
+ *
+ * Sets the mlt_type to "link"
+ *
+ * \public \memberof mlt_link_s
+ * \return the new link
+ */
+
+mlt_link mlt_link_init( )
+{
+	mlt_link self = calloc( 1, sizeof( struct mlt_link_s ) );
+	if ( self != NULL )
+	{
+		mlt_producer producer = &self->parent;
+		if ( mlt_producer_init( producer, self ) == 0 )
+		{
+			mlt_properties properties = MLT_PRODUCER_PROPERTIES( producer );
+
+			mlt_properties_set( properties, "mlt_type", "link" );
+			mlt_properties_clear( properties, "mlt_service");
+			mlt_properties_clear( properties, "resource");
+			mlt_properties_clear( properties, "in");
+			mlt_properties_clear( properties, "out");
+			mlt_properties_clear( properties, "length");
+			mlt_properties_clear( properties, "eof");
+			producer->get_frame = producer_get_frame;
+			producer->close = ( mlt_destructor )mlt_link_close;
+			producer->close_object = self;
+		}
+		else
+		{
+			free( self );
+			self = NULL;
+		}
+	}
+	return self;
+}
+
+/** Connect this link to the next producer.
+ *
+ * \public \memberof mlt_link_s
+ * \param self a link
+ * \param next the producer to get frames from
+ * \param default_profile a profile to use if needed (some links derive their frame rate from the next producer)
+ * \return true on error
+ */
+
+int mlt_link_connect_next( mlt_link self, mlt_producer next, mlt_profile default_profile )
+{
+	self->next = next;
+	if ( self->configure )
+	{
+		self->configure( self, default_profile );
+	}
+	return 0;
+}
+
+/** Close the link and free its resources.
+ *
+ * \public \memberof mlt_link_s
+ * \param self a link
+ */
+
+void mlt_link_close( mlt_link self )
+{
+	if ( self != NULL && mlt_properties_dec_ref( MLT_LINK_PROPERTIES( self ) ) <= 0 )
+	{
+		if( self->close )
+		{
+			self->close( self );
+		}
+		else
+		{
+			self->parent.close = NULL;
+			mlt_producer_close( &self->parent );
+		}
+	}
+}
+
+static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int index )
+{
+	if ( parent && parent->child )
+	{
+		mlt_link self = parent->child;
+		if ( self->get_frame != NULL )
+		{
+			return self->get_frame( self, frame, index );
+		}
+		else
+		{
+			/* Default implementation: get a frame from the next producer */
+			return mlt_service_get_frame( MLT_PRODUCER_SERVICE( self->next ), frame, index );
+		}
+	}
+	return 1;
+}

--- a/src/framework/mlt_link.h
+++ b/src/framework/mlt_link.h
@@ -1,0 +1,74 @@
+/**
+ * \file mlt_link.h
+ * \brief link service class
+ * \see mlt_link_s
+ *
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MLT_LINK_H
+#define MLT_LINK_H
+
+#include "mlt_producer.h"
+
+/** \brief Link class
+ *
+ * The link is a producer class that that can be connected to other link producers in a Chain.
+ *
+ * \extends mlt_producer_s
+ * \properties \em next holds a reference to the next producer in the chain
+ */
+
+struct mlt_link_s
+{
+	/** \publicsection */
+	struct mlt_producer_s parent;
+
+	/** \protectedsection */
+
+	/** Get a frame of data (virtual function).
+	 *
+	 * \param mlt_link a link
+	 * \param mlt_frame_ptr a frame pointer by reference
+	 * \param int an index
+	 * \return true if there was an error
+	 */
+	int ( *get_frame )( mlt_link, mlt_frame_ptr, int );
+
+	/** Configure the link (virtual function).
+	 *
+	 * \param mlt_link a link
+	 * \param mlt_profile a default profile to use
+	 */
+	void ( *configure )( mlt_link, mlt_profile );
+
+	/** Virtual close function */
+	void ( *close )( mlt_link );
+
+	/** \privatesection */
+	mlt_producer next;
+};
+
+#define MLT_LINK_PRODUCER( link )		( &( link )->parent )
+#define MLT_LINK_SERVICE( link )		MLT_PRODUCER_SERVICE( MLT_LINK_PRODUCER( link ) )
+#define MLT_LINK_PROPERTIES( link )		MLT_SERVICE_PROPERTIES( MLT_LINK_SERVICE( link ) )
+
+extern mlt_link mlt_link_init( );
+extern int mlt_link_connect_next( mlt_link self, mlt_producer next, mlt_profile default_profile );
+extern void mlt_link_close( mlt_link self );
+
+#endif

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -321,7 +321,11 @@ int mlt_producer_seek( mlt_producer self, mlt_position position )
 		mlt_producer_seek( mlt_producer_cut_parent( self ), position + mlt_producer_get_in( self ) );
 
 	// Check bounds
-	if ( position < 0 || mlt_producer_get_playtime( self ) == 0 )
+	if( mlt_service_identify( MLT_PRODUCER_SERVICE(self) ) == link_type )
+	{
+		// Do not bounds check a link.
+	}
+	else if ( position < 0 || mlt_producer_get_playtime( self ) == 0 )
 	{
 		position = 0;
 	}

--- a/src/framework/mlt_repository.c
+++ b/src/framework/mlt_repository.c
@@ -47,6 +47,7 @@ struct mlt_repository_s
 	struct mlt_properties_s parent; /// a list of object files
 	mlt_properties consumers;       /// a list of entry points for consumers
 	mlt_properties filters;         /// a list of entry points for filters
+	mlt_properties links;           /// a list of entry points for links
 	mlt_properties producers;       /// a list of entry points for producers
 	mlt_properties transitions;     /// a list of entry points for transitions
 };
@@ -69,6 +70,7 @@ mlt_repository mlt_repository_init( const char *directory )
 	mlt_properties_init( &self->parent, self );
 	self->consumers = mlt_properties_new();
 	self->filters = mlt_properties_new();
+	self->links = mlt_properties_new();
 	self->producers = mlt_properties_new();
 	self->transitions = mlt_properties_new();
 
@@ -178,6 +180,9 @@ void mlt_repository_register( mlt_repository self, mlt_service_type service_type
 		case filter_type:
 			mlt_properties_set_data( self->filters, service, new_service( symbol ), 0, ( mlt_destructor )mlt_properties_close, NULL );
 			break;
+		case link_type:
+			mlt_properties_set_data( self->links, service, new_service( symbol ), 0, ( mlt_destructor )mlt_properties_close, NULL );
+			break;
 		case producer_type:
 			mlt_properties_set_data( self->producers, service, new_service( symbol ), 0, ( mlt_destructor )mlt_properties_close, NULL );
 			break;
@@ -185,6 +190,7 @@ void mlt_repository_register( mlt_repository self, mlt_service_type service_type
 			mlt_properties_set_data( self->transitions, service, new_service( symbol ), 0, ( mlt_destructor )mlt_properties_close, NULL );
 			break;
 		default:
+			mlt_log_error( NULL, "%s: Unable to register \"%s\"\n", __FUNCTION__, service );
 			break;
 	}
 }
@@ -210,6 +216,9 @@ static mlt_properties get_service_properties( mlt_repository self, mlt_service_t
 			break;
 		case filter_type:
 			service_properties = mlt_properties_get_data( self->filters, service, NULL );
+			break;
+		case link_type:
+			service_properties = mlt_properties_get_data( self->links, service, NULL );
 			break;
 		case producer_type:
 			service_properties = mlt_properties_get_data( self->producers, service, NULL );
@@ -284,6 +293,18 @@ mlt_properties mlt_repository_consumers( mlt_repository self )
 mlt_properties mlt_repository_filters( mlt_repository self )
 {
 	return self->filters;
+}
+
+/** Get the list of registered links.
+ *
+ * \public \memberof mlt_repository_s
+ * \param self a repository
+ * \return a properties list of all of the links
+ */
+
+mlt_properties mlt_repository_links( mlt_repository self )
+{
+	return self->links;
 }
 
 /** Get the list of registered producers.

--- a/src/framework/mlt_repository.h
+++ b/src/framework/mlt_repository.h
@@ -59,6 +59,7 @@ extern void *mlt_repository_create( mlt_repository self, mlt_profile profile, ml
 extern void mlt_repository_close( mlt_repository self );
 extern mlt_properties mlt_repository_consumers( mlt_repository self );
 extern mlt_properties mlt_repository_filters( mlt_repository self );
+extern mlt_properties mlt_repository_links( mlt_repository self );
 extern mlt_properties mlt_repository_producers( mlt_repository self );
 extern mlt_properties mlt_repository_transitions( mlt_repository self );
 extern void mlt_repository_register_metadata( mlt_repository self, mlt_service_type type, const char *service, mlt_metadata_callback, void *callback_data );

--- a/src/framework/mlt_service.c
+++ b/src/framework/mlt_service.c
@@ -179,8 +179,12 @@ mlt_service_type mlt_service_identify( mlt_service self )
 			type = filter_type;
 		else if ( !strcmp( mlt_type, "transition" ) )
 			type = transition_type;
+		else if ( !strcmp( mlt_type, "chain" ) )
+			type = chain_type;
 		else if ( !strcmp( mlt_type, "consumer" ) )
 			type = consumer_type;
+		else if ( !strcmp( mlt_type, "link" ) )
+			type = link_type;
 		else
 			type = unknown_type;
 	}

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -148,7 +148,9 @@ typedef enum
 	filter_type,                /**< Filter class */
 	transition_type,            /**< Transition class */
 	consumer_type,              /**< Consumer class */
-	field_type                  /**< Field class */
+	field_type,                 /**< Field class */
+	link_type,                  /**< Link class */
+	chain_type                  /**< Chain class */
 }
 mlt_service_type;
 
@@ -208,6 +210,8 @@ typedef struct mlt_cache_s *mlt_cache;                  /**< pointer to Cache ob
 typedef struct mlt_cache_item_s *mlt_cache_item;        /**< pointer to CacheItem object */
 typedef struct mlt_animation_s *mlt_animation;          /**< pointer to Property Animation object */
 typedef struct mlt_slices_s *mlt_slices;                /**< pointer to Sliced processing context object */
+typedef struct mlt_link_s *mlt_link;                    /**< pointer to Link object */
+typedef struct mlt_chain_s *mlt_chain;                  /**< pointer to Chain object */
 
 typedef void ( *mlt_destructor )( void * );             /**< pointer to destructor function */
 typedef char *( *mlt_serialiser )( void *, int length );/**< pointer to serialization function */
@@ -221,6 +225,8 @@ typedef char *( *mlt_serialiser )( void *, int length );/**< pointer to serializ
 #define MLT_TRANSITION(x) ( ( mlt_transition )( x ) )   /**< Cast to a Transition pointer */
 #define MLT_CONSUMER(x) ( ( mlt_consumer )( x ) )       /**< Cast to a Consumer pointer */
 #define MLT_FRAME(x)      ( ( mlt_frame )( x ) )        /**< Cast to a Frame pointer */
+#define MLT_LINK(x)       ( ( mlt_link )( x ) )         /**< Cast to a Link pointer */
+#define MLT_CHAIN(x)      ( ( mlt_chain )( x ) )        /**< Cast to a Chain pointer */
 
 #ifndef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))

--- a/src/mlt++/Makefile
+++ b/src/mlt++/Makefile
@@ -28,6 +28,7 @@ endif
 
 OBJS = MltAudio.o \
 	   MltAnimation.o \
+	   MltChain.o \
 	   MltConsumer.o \
 	   MltDeque.o \
 	   MltEvent.o \
@@ -38,6 +39,7 @@ OBJS = MltAudio.o \
 	   MltFilteredProducer.o \
 	   MltFrame.o \
 	   MltGeometry.o \
+	   MltLink.o \
 	   MltMultitrack.o \
 	   MltParser.o \
 	   MltPlaylist.o \

--- a/src/mlt++/MltChain.cpp
+++ b/src/mlt++/MltChain.cpp
@@ -1,0 +1,123 @@
+/**
+ * MltChain.cpp - Chain wrapper
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "MltChain.h"
+
+using namespace Mlt;
+
+Chain::Chain( ) :
+	instance( nullptr )
+{
+}
+
+Chain::Chain( Profile& profile, const char *id, const char *service ) :
+	instance( mlt_chain_init( profile.get_profile() ) )
+{
+	Mlt::Producer source( profile, id, service );
+	mlt_chain_set_source( instance, source.get_producer() );
+}
+
+Chain::Chain( Profile& profile ) :
+	instance( mlt_chain_init( profile.get_profile() ) )
+{
+}
+
+Chain::Chain( mlt_chain chain ) :
+	instance( chain )
+{
+	inc_ref( );
+}
+
+Chain::Chain( Chain& chain ) :
+	Mlt::Producer( chain ),
+	instance( chain.get_chain( ) )
+{
+	inc_ref( );
+}
+
+Chain::Chain( Chain* chain ) :
+	Mlt::Producer( chain ),
+	instance( chain != NULL ? chain->get_chain( ) : NULL )
+{
+	if ( is_valid( ) )
+		inc_ref( );
+}
+
+Chain::Chain( Service& chain ) :
+	instance( NULL )
+{
+	if ( chain.type( ) == chain_type )
+	{
+		instance = ( mlt_chain )chain.get_service( );
+		inc_ref( );
+	}
+}
+
+Chain::~Chain( )
+{
+	mlt_chain_close( instance );
+	instance = nullptr;
+}
+
+mlt_chain Chain::get_chain( )
+{
+	return instance;
+}
+
+mlt_producer Chain::get_producer( )
+{
+	return MLT_CHAIN_PRODUCER( instance );
+}
+
+void Chain::set_source( Mlt::Producer& source )
+{
+	mlt_chain_set_source( instance, source.get_producer() );
+}
+
+Mlt::Producer Chain::get_source( )
+{
+	return Mlt::Producer( mlt_chain_get_source(instance) );
+}
+
+int Chain::attach( Mlt::Link& link )
+{
+	return mlt_chain_attach( instance, link.get_link() );
+}
+
+int Chain::detach( Mlt::Link& link )
+{
+	return mlt_chain_detach( instance, link.get_link() );
+}
+
+int Chain::link_count() const
+{
+	return mlt_chain_link_count( instance );
+}
+
+bool Chain::move_link( int from, int to )
+{
+	return (bool)mlt_chain_move_link( instance, from, to );
+}
+
+Mlt::Link* Chain::link( int index )
+{
+	mlt_link result = mlt_chain_link( instance, index );
+	return result == NULL ? NULL : new Link( result );
+
+}

--- a/src/mlt++/MltChain.h
+++ b/src/mlt++/MltChain.h
@@ -1,0 +1,59 @@
+/**
+ * MltChain.h - Chain wrapper
+ * Copyright (C) 2020 Meltytech, LLC
+  *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MLTPP_CHAIN_H
+#define MLTPP_CHAIN_H
+
+#include "MltConfig.h"
+
+#include <framework/mlt.h>
+
+#include "MltLink.h"
+#include "MltProducer.h"
+#include "MltProfile.h"
+
+namespace Mlt
+{
+	class MLTPP_DECLSPEC Chain : public Producer
+	{
+		private:
+			mlt_chain instance;
+		public:
+			Chain( );
+			Chain( Profile& profile, const char *id, const char *service = NULL );
+			Chain( Mlt::Profile& profile );
+			Chain( mlt_chain chain );
+			Chain( Chain& chain );
+			Chain( Chain* chain );
+			Chain( Service& chain );
+			virtual ~Chain( );
+			virtual mlt_chain get_chain( );
+			mlt_producer get_producer( );
+			void set_source( Mlt::Producer& source );
+			Mlt::Producer get_source( );
+			int attach( Mlt::Link& link );
+			int detach( Mlt::Link& link );
+			int link_count() const;
+			bool move_link( int from, int to );
+			Mlt::Link* link( int index );
+	};
+}
+
+#endif
+

--- a/src/mlt++/MltLink.cpp
+++ b/src/mlt++/MltLink.cpp
@@ -1,0 +1,82 @@
+/**
+ * MltLink.cpp - MLT Wrapper
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "MltLink.h"
+#include "MltProfile.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+using namespace Mlt;
+
+Link::Link( ) :
+	instance( nullptr )
+{
+}
+
+Link::Link( mlt_link link )
+ : instance( link )
+{
+	inc_ref( );
+}
+
+Link::Link( const char *id, const char *arg ) :
+	instance( NULL )
+{
+	if ( arg != NULL )
+	{
+		instance = mlt_factory_link( id, arg );
+	}
+	else
+	{
+		if ( strchr( id, ':' ) )
+		{
+			char *temp = strdup( id );
+			char *arg = strchr( temp, ':' ) + 1;
+			*( arg - 1 ) = '\0';
+			instance = mlt_factory_link( temp, arg );
+			free( temp );
+		}
+		else
+		{
+			instance = mlt_factory_link( id, NULL );
+		}
+	}
+}
+
+Link::~Link( )
+{
+	mlt_link_close( instance );
+}
+
+mlt_link Link::get_link( )
+{
+	return instance;
+}
+
+mlt_producer Link::get_producer( )
+{
+	return MLT_LINK_PRODUCER( instance );
+}
+
+int Link::connect_next( Mlt::Producer& next, Mlt::Profile& default_profile )
+{
+	return mlt_link_connect_next( instance, next.get_producer(), default_profile.get_profile() );
+}
+

--- a/src/mlt++/MltLink.h
+++ b/src/mlt++/MltLink.h
@@ -1,7 +1,6 @@
 /**
- * Mlt.h - Convenience header file for all mlt++ objects
- * Copyright (C) 2004-2015 Meltytech, LLC
- * Author: Charles Yates <charles.yates@gmail.com>
+ * MltLink.h - MLT Wrapper
+ * Copyright (C) 2020 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,32 +17,33 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef MLTPP_H
-#define MLTPP_H
+#ifndef MLTPP_LINK_H
+#define MLTPP_LINK_H
 
-#include "MltAudio.h"
-#include "MltAnimation.h"
-#include "MltChain.h"
-#include "MltConsumer.h"
-#include "MltDeque.h"
-#include "MltEvent.h"
-#include "MltFactory.h"
-#include "MltField.h"
-#include "MltFilter.h"
-#include "MltFilteredConsumer.h"
-#include "MltFrame.h"
-#include "MltGeometry.h"
-#include "MltMultitrack.h"
-#include "MltParser.h"
-#include "MltPlaylist.h"
+#include "MltConfig.h"
 #include "MltProducer.h"
-#include "MltProfile.h"
-#include "MltProperties.h"
-#include "MltPushConsumer.h"
-#include "MltRepository.h"
-#include "MltService.h"
-#include "MltTokeniser.h"
-#include "MltTractor.h"
-#include "MltTransition.h"
+#include "MltProducer.h"
+
+#include <framework/mlt.h>
+
+namespace Mlt
+{
+	class Producer;
+	class Profile;
+
+	class MLTPP_DECLSPEC Link : public Producer
+	{
+		private:
+			mlt_link instance;
+		public:
+			Link( );
+			Link( mlt_link link );
+			Link( const char* id, const char* service = NULL );
+			virtual ~Link( );
+			virtual mlt_link get_link( );
+			mlt_producer get_producer( );
+			int connect_next( Mlt::Producer& next, Mlt::Profile& default_profile );
+	};
+}
 
 #endif

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -51,7 +51,8 @@ Producer::Producer( Service &producer ) :
 {
 	mlt_service_type type = producer.type( );
 	if ( type == producer_type || type == playlist_type || 
-		 type == tractor_type || type == multitrack_type )
+		 type == tractor_type || type == multitrack_type ||
+		 type == chain_type || type == link_type )
 	{
 		instance = ( mlt_producer )producer.get_service( );
 		inc_ref( );

--- a/src/mlt++/MltRepository.cpp
+++ b/src/mlt++/MltRepository.cpp
@@ -58,6 +58,11 @@ Properties *Repository::filters( ) const
 	return new Properties( mlt_repository_filters( instance ) );
 }
 
+Properties *Repository::links( ) const
+{
+	return new Properties( mlt_repository_links( instance ) );
+}
+
 Properties *Repository::producers( ) const
 {
 	return new Properties( mlt_repository_producers( instance ) );

--- a/src/mlt++/MltRepository.h
+++ b/src/mlt++/MltRepository.h
@@ -47,6 +47,7 @@ namespace Mlt
 			void *create( Profile& profile, mlt_service_type type, const char *service, void *arg );
 			Properties *consumers( ) const;
 			Properties *filters( ) const;
+			Properties *links( ) const;
 			Properties *producers( ) const;
 			Properties *transitions( ) const;
 			void register_metadata( mlt_service_type type, const char *service, mlt_metadata_callback, void *callback_data );

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -612,3 +612,34 @@ MLTPP_6.22.0 {
       "Mlt::Audio::set_layout(mlt_channel_layout)";
     };
 } MLTPP_6.20.0;
+
+MLTPP_6.24.0 {
+  global:
+    extern "C++" {
+      "Mlt::Link::Link()";
+      "Mlt::Link::Link(mlt_link)";
+      "Mlt::Link::Link(char const*, char const*)";
+      "Mlt::Link::~Link( )";
+      "Mlt::Link::mlt_link get_link()";
+      "Mlt::Link::mlt_producer get_producer()";
+      "Mlt::Link::connect_next(Mlt::Producer&, Mlt::Profile&)";
+      "Mlt::Chain::Chain()";
+      "Mlt::Chain::Chain(Mlt::Profile&, char const*, char const*)";
+      "Mlt::Chain::Chain(Mlt::Profile&)";
+      "Mlt::Chain::Chain(mlt_chain)";
+      "Mlt::Chain::Chain(Mlt::Chain&)";
+      "Mlt::Chain::Chain(Mlt::Chain*)";
+      "Mlt::Chain::Chain(Mlt::Service&)";
+      "Mlt::Chain::~Chain()";
+      "Mlt::Chain::get_chain()";
+      "Mlt::Chain::get_producer()";
+      "Mlt::Chain::set_source(Mlt::Producer&)";
+      "Mlt::Chain::get_source()";
+      "Mlt::Chain::attach(Mlt::Link&)";
+      "Mlt::Chain::detach(Mlt::Link&)";
+      "Mlt::Chain::link_count() const";
+      "Mlt::Chain::move_link(int, int)";
+      "Mlt::Chain::link(int)";
+      "Mlt::Repository::links() const";
+    };
+} MLTPP_6.22.0;

--- a/src/modules/avformat/factory.c
+++ b/src/modules/avformat/factory.c
@@ -309,6 +309,12 @@ static mlt_properties avformat_metadata( mlt_service_type type, const char *id, 
 		default:
 			return NULL;
 	}
+
+	if ( type == producer_type && !strcmp( id, "avformat-novalidate" ) )
+	{
+		id = "avformat";
+	}
+
 	// Load the yaml file
 	snprintf( file, PATH_MAX, "%s/avformat/%s_%s.yml", mlt_environment( "MLT_DATA" ), service_type, id );
 	result = mlt_properties_parse_yaml( file );
@@ -425,6 +431,7 @@ MLT_REPOSITORY
 	MLT_REGISTER( producer_type, "avformat-novalidate", create_service );
 	MLT_REGISTER_METADATA( consumer_type, "avformat", avformat_metadata, NULL );
 	MLT_REGISTER_METADATA( producer_type, "avformat", avformat_metadata, NULL );
+	MLT_REGISTER_METADATA( producer_type, "avformat-novalidate", avformat_metadata, NULL );
 #endif
 #ifdef FILTERS
 	MLT_REGISTER( filter_type, "avcolour_space", create_service );

--- a/src/modules/core/Makefile
+++ b/src/modules/core/Makefile
@@ -41,6 +41,7 @@ OBJS = factory.o \
 	   filter_resize.o \
 	   filter_transition.o \
 	   filter_watermark.o \
+	   link_timeremap.o \
 	   transition_composite.o \
 	   transition_luma.o \
 	   transition_mix.o \

--- a/src/modules/core/factory.c
+++ b/src/modules/core/factory.c
@@ -49,6 +49,7 @@ extern mlt_filter filter_rescale_init( mlt_profile profile, mlt_service_type typ
 extern mlt_filter filter_resize_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_filter filter_transition_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_filter filter_watermark_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
+extern mlt_link link_timeremap_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_colour_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_consumer_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_hold_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
@@ -103,6 +104,7 @@ MLT_REPOSITORY
 	MLT_REGISTER( filter_type, "resize", filter_resize_init );
 	MLT_REGISTER( filter_type, "transition", filter_transition_init );
 	MLT_REGISTER( filter_type, "watermark", filter_watermark_init );
+	MLT_REGISTER( link_type, "timeremap", link_timeremap_init );
 	MLT_REGISTER( producer_type, "abnormal", producer_loader_init );
 	MLT_REGISTER( producer_type, "color", producer_colour_init );
 	MLT_REGISTER( producer_type, "colour", producer_colour_init );
@@ -145,6 +147,7 @@ MLT_REPOSITORY
 	MLT_REGISTER_METADATA( filter_type, "resize", metadata, "filter_resize.yml" );
 	MLT_REGISTER_METADATA( filter_type, "transition", metadata, "filter_transition.yml" );
 	MLT_REGISTER_METADATA( filter_type, "watermark", metadata, "filter_watermark.yml" );
+	MLT_REGISTER_METADATA( link_type, "timeremap", metadata, "link_timeremap.yml" );
 	MLT_REGISTER_METADATA( producer_type, "colour", metadata, "producer_colour.yml" );
 	MLT_REGISTER_METADATA( producer_type, "color", metadata, "producer_colour.yml" );
 	MLT_REGISTER_METADATA( producer_type, "consumer", metadata, "producer_consumer.yml" );

--- a/src/modules/core/link_timeremap.c
+++ b/src/modules/core/link_timeremap.c
@@ -1,0 +1,421 @@
+/*
+ * link_timeremap.c
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt_link.h>
+#include <framework/mlt_log.h>
+#include <framework/mlt_factory.h>
+#include <framework/mlt_frame.h>
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void link_configure( mlt_link self, mlt_profile default_profile )
+{
+	mlt_service_set_profile( MLT_LINK_SERVICE( self ), default_profile );
+}
+
+static int link_get_audio( mlt_frame frame, void** audio, mlt_audio_format* format, int* frequency, int* channels, int* samples )
+{
+	mlt_link self = (mlt_link)mlt_frame_pop_audio( frame );
+	mlt_properties unique_properties = mlt_frame_get_unique_properties( frame, MLT_LINK_SERVICE(self) );
+	if ( !unique_properties )
+	{
+		return 1;
+	}
+	double source_time = mlt_properties_get_double( unique_properties, "source_time" );
+	double source_duration = mlt_properties_get_double( unique_properties, "source_duration" );
+	double source_fps = mlt_properties_get_double( unique_properties, "source_fps" );
+	double link_fps = mlt_producer_get_fps( MLT_LINK_PRODUCER( self ) );
+	double frame_duration = 1.0 / link_fps;
+	double speed = 0.0;
+	if ( source_duration != 0.0 )
+	{
+		speed = fabs(source_duration) / frame_duration;
+	}
+
+	// Validate the request
+	*channels = *channels <= 0 ? 2 : *channels;
+	int src_frequency = mlt_properties_get_int( MLT_FRAME_PROPERTIES( frame ), "audio_frequency" );
+	if ( src_frequency > 0 )
+	{
+		*frequency = src_frequency;
+	}
+	else if ( *frequency <= 0 )
+	{
+		*frequency = 48000;
+	}
+
+	if ( speed < 0.1 || speed > 10 )
+	{
+		// Return silent samples for speeds less than 0.1 or > 10
+		mlt_position position = mlt_frame_original_position( frame );
+		*samples = mlt_sample_calculator( link_fps, *frequency, position );
+		int size = mlt_audio_format_size( *format, *samples, *channels );
+		*audio = mlt_pool_alloc( size );
+		memset( *audio, 0, size );
+		mlt_frame_set_audio( frame, *audio, *format, size, mlt_pool_release );
+		return 0;
+	}
+	else
+	{
+		int sample_count = mlt_sample_calculator( link_fps, *frequency, mlt_frame_get_position( frame ) );
+		sample_count = lrint( (double)sample_count * speed );
+		mlt_position in_frame_pos = floor( source_time * source_fps );
+
+		// Calculate the samples to get from the input frames
+		int64_t first_out_sample = source_time * (double)*frequency;
+		int64_t first_in_sample = mlt_sample_calculator_to_now( source_fps, *frequency, in_frame_pos );
+		int samples_to_skip = first_out_sample - first_in_sample;
+		if ( samples_to_skip < 0 )
+		{
+			mlt_log_error( MLT_LINK_SERVICE(self), "Audio too late: %d\t%d\n", (int)first_out_sample, (int)first_in_sample );
+			samples_to_skip = 0;
+		}
+
+		// Allocate the out buffer
+		struct mlt_audio_s out;
+		mlt_audio_set_values( &out, NULL, *frequency, *format, sample_count, *channels );
+		mlt_audio_alloc_data( &out );
+
+		// Copy audio from the input frames to the output buffer
+		int samples_copied = 0;
+		int samples_needed = sample_count;
+
+		while ( samples_needed > 0 )
+		{
+			char key[19];
+			sprintf( key, "%d", in_frame_pos );
+			mlt_frame src_frame = (mlt_frame)mlt_properties_get_data( unique_properties, key, NULL );
+			if ( !src_frame )
+			{
+				mlt_log_error( MLT_LINK_SERVICE(self), "Frame not found: %d\n", in_frame_pos );
+				break;
+			}
+
+			int in_samples = mlt_sample_calculator( source_fps, *frequency, in_frame_pos );
+			struct mlt_audio_s in;
+			mlt_audio_set_values( &in, NULL, *frequency, *format, in_samples, *channels );
+
+			int error = mlt_frame_get_audio( src_frame, &in.data, &in.format, &in.frequency, &in.channels, &in.samples );
+			if ( error )
+			{
+				mlt_log_error( MLT_LINK_SERVICE(self), "No audio: %d\n", in_frame_pos );
+				break;
+			}
+
+			int samples_to_copy = in.samples - samples_to_skip;
+			if ( samples_to_copy > samples_needed )
+			{
+				samples_to_copy = samples_needed;
+			}
+			mlt_log_debug( MLT_LINK_SERVICE(self), "Copy: %d\t%d\t%d\t%d\n", samples_to_skip, samples_to_skip + samples_to_copy -1, samples_to_copy, in.samples );
+
+			if ( samples_to_copy > 0 )
+			{
+				mlt_audio_copy( &out, &in, samples_to_copy, samples_to_skip, samples_copied );
+				samples_copied += samples_to_copy;
+				samples_needed -= samples_to_copy;
+			}
+
+			samples_to_skip = 0;
+			in_frame_pos++;
+		}
+
+		if ( samples_copied != sample_count )
+		{
+			mlt_log_error( MLT_LINK_SERVICE(self), "Sample under run: %d\t%d\n", samples_copied, sample_count );
+			mlt_audio_shrink( &out , samples_copied );
+		}
+
+		if ( source_duration < 0.0 )
+		{
+			// Going backwards
+			mlt_audio_reverse( &out );
+		}
+
+		out.frequency = lrint( (double)out.frequency * speed );
+		mlt_frame_set_audio( frame, out.data, out.format, 0, out.release_data );
+		mlt_audio_get_values( &out, audio, frequency, format, samples, channels );
+		return 0;
+	}
+
+	return 1;
+}
+
+static int link_get_image_blend( mlt_frame frame, uint8_t** image, mlt_image_format* format, int* width, int* height, int writable )
+{
+	static const int MAX_BLEND_IMAGES = 10;
+	mlt_link self = (mlt_link)mlt_frame_pop_get_image( frame );
+	mlt_properties unique_properties = mlt_frame_get_unique_properties( frame, MLT_LINK_SERVICE(self) );
+	if ( !unique_properties )
+	{
+		return 1;
+	}
+	double source_time = mlt_properties_get_double( unique_properties, "source_time");
+	double source_fps = mlt_properties_get_double( unique_properties, "source_fps");
+
+	// Get pointers to all the images for this frame
+	uint8_t* images[MAX_BLEND_IMAGES];
+	int image_count = 0;
+	mlt_position in_frame_pos = floor( source_time * source_fps );
+	while ( image_count < MAX_BLEND_IMAGES )
+	{
+		char key[19];
+		sprintf( key, "%d", in_frame_pos );
+		mlt_frame src_frame = (mlt_frame)mlt_properties_get_data( unique_properties, key, NULL );
+		if ( src_frame && !mlt_frame_get_image( src_frame, &images[image_count], format, width, height, 0 ) )
+		{
+			in_frame_pos++;
+			image_count++;
+		}
+		else
+		{
+			break;
+		}
+	}
+
+	if ( image_count <= 0 )
+	{
+		return 1;
+	}
+
+	// Sum all the images into one image with 16 bit components
+	int size = mlt_image_format_size( *format, *width, *height, NULL );
+	*image = mlt_pool_alloc( size );
+	int s = 0;
+	uint8_t* p = *image;
+	for( s = 0; s < size; s++ )
+	{
+		int16_t sum = 0;
+		int i = 0;
+		for( i = 0; i < image_count; i++ )
+		{
+			sum += *(images[i]);
+			images[i]++;
+		}
+		*p = sum / image_count;
+		p++;
+	}
+	mlt_frame_set_image( frame, *image, size, mlt_pool_release );
+	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "format", *format );
+	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "width", *width );
+	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "height", *height );
+
+	return 0;
+}
+
+static int link_get_image_nearest( mlt_frame frame, uint8_t** image, mlt_image_format* format, int* width, int* height, int writable )
+{
+	mlt_link self = (mlt_link)mlt_frame_pop_get_image( frame );
+	mlt_properties unique_properties = mlt_frame_get_unique_properties( frame, MLT_LINK_SERVICE(self) );
+	if ( !unique_properties )
+	{
+		return 1;
+	}
+	double source_time = mlt_properties_get_double( unique_properties, "source_time");
+	double source_fps = mlt_properties_get_double( unique_properties, "source_fps");
+	mlt_position in_frame_pos = floor( source_time * source_fps );
+	char key[19];
+	sprintf( key, "%d", in_frame_pos );
+
+	mlt_frame src_frame = (mlt_frame)mlt_properties_get_data( unique_properties, key, NULL );
+	if ( src_frame )
+	{
+		uint8_t* in_image;
+		if ( !mlt_frame_get_image( src_frame, &in_image, format, width, height, 0 ) )
+		{
+			int size = mlt_image_format_size( *format, *width, *height, NULL );
+			*image = mlt_pool_alloc( size );
+			memcpy( *image, in_image, size );
+			mlt_frame_set_image( frame, *image, size, mlt_pool_release );
+			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "format", *format );
+			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "width", *width );
+			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "height", *height );
+
+			uint8_t* in_alpha = mlt_frame_get_alpha( src_frame );
+			if ( in_alpha )
+			{
+				size = *width * *height;
+				uint8_t* out_alpha = mlt_pool_alloc( size );
+				memcpy( out_alpha, in_alpha, size );
+				mlt_frame_set_alpha( frame, out_alpha, size, mlt_pool_release );
+			};
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+static int link_get_frame( mlt_link self, mlt_frame_ptr frame, int index )
+{
+	mlt_properties properties = MLT_LINK_PROPERTIES( self );
+	mlt_position position = mlt_producer_position( MLT_LINK_PRODUCER( self ) );
+	mlt_position length = mlt_producer_get_length( MLT_LINK_PRODUCER( self ) );
+	double source_time = 0.0;
+	double source_duration = 0.0;
+	double source_fps = mlt_producer_get_fps( self->next );
+
+	int result = 0;
+
+	// Create a  frame
+	*frame = mlt_frame_init( MLT_LINK_SERVICE(self) );
+	mlt_frame_set_position( *frame, mlt_producer_position( MLT_LINK_PRODUCER(self) ) );
+	mlt_properties unique_properties = mlt_frame_unique_properties( *frame, MLT_LINK_SERVICE(self) );
+
+	// Calculate the frames from the next link to be used
+	if ( !mlt_properties_exists( properties, "map" ) )
+	{
+		double link_fps = mlt_producer_get_fps( MLT_LINK_PRODUCER( self ) );
+		source_time = (double)position / link_fps;
+		source_duration = 1.0 / link_fps;
+	}
+	else
+	{
+		source_time = mlt_properties_anim_get_double( properties, "map", position, length );
+		double next_source_time = mlt_properties_anim_get_double( properties, "map", position + 1, length );
+		source_duration = next_source_time - source_time;
+	}
+
+	mlt_properties_set_double( unique_properties, "source_fps", source_fps );
+	mlt_properties_set_double( unique_properties, "source_time", source_time );
+	mlt_properties_set_double( unique_properties, "source_duration", source_duration );
+
+	mlt_log_debug( MLT_LINK_SERVICE(self), "Get Frame: %f -> %f\t%d\n", source_fps, mlt_producer_get_fps( MLT_LINK_PRODUCER(self) ), position );
+
+	// Get frames from the next link and pass them along with the new frame
+	int in_frame_count = 0;
+	mlt_frame src_frame = NULL;
+	mlt_frame prev_frame = mlt_properties_get_data( properties, "_prev_frame", NULL );
+	mlt_position prev_frame_position = prev_frame ? mlt_frame_get_position( prev_frame ) : -1;
+	mlt_position in_frame_pos = floor( source_time * source_fps );
+	double frame_time = (double)in_frame_pos / source_fps;
+	double source_end_time = source_time + fabs(source_duration);
+	if ( frame_time == source_end_time )
+	{
+		// Force one frame to be sent.
+		source_end_time += 0.0000000001;
+	}
+	while ( frame_time < source_end_time )
+	{
+		if( in_frame_pos == prev_frame_position )
+		{
+			// Reuse the previous frame to avoid seeking.
+			src_frame = prev_frame;
+			mlt_properties_inc_ref( MLT_FRAME_PROPERTIES(src_frame) );
+		}
+		else
+		{
+			mlt_producer_seek( self->next, in_frame_pos );
+			result = mlt_service_get_frame( MLT_PRODUCER_SERVICE( self->next ), &src_frame, index );
+			if ( result )
+			{
+				break;
+			}
+		}
+		// Save the source frame on the output frame
+		char key[19];
+		sprintf( key, "%d", in_frame_pos );
+		mlt_properties_set_data( unique_properties, key, src_frame, 0, (mlt_destructor)mlt_frame_close, NULL );
+
+		// Calculate the next frame
+		in_frame_pos++;
+		frame_time = (double)in_frame_pos / source_fps;
+		in_frame_count++;
+	}
+
+	if ( !src_frame )
+	{
+		mlt_frame_close( *frame );
+		*frame = NULL;
+		return 1;
+	}
+
+	// Copy some useful properties from one of the source frames.
+	(*frame)->convert_image = src_frame->convert_image;
+	(*frame)->convert_audio = src_frame->convert_audio;
+	mlt_properties_pass_list( MLT_FRAME_PROPERTIES(*frame), MLT_FRAME_PROPERTIES(src_frame), "audio_frequency" );
+
+	if ( src_frame != prev_frame )
+	{
+		// Save the last source frame because it might be requested for the next frame.
+		mlt_properties_inc_ref( MLT_FRAME_PROPERTIES(src_frame) );
+		mlt_properties_set_data( properties, "_prev_frame", src_frame, 0, (mlt_destructor)mlt_frame_close, NULL );
+	}
+
+	// Setup callbacks
+	char* mode = mlt_properties_get( properties, "image_mode" );
+	mlt_frame_push_get_image( *frame, (void*)self );
+	if ( in_frame_count == 1 || !mode || !strcmp( mode, "nearest" ) )
+	{
+		mlt_frame_push_get_image( *frame, link_get_image_nearest );
+	}
+	else
+	{
+		mlt_frame_push_get_image( *frame, link_get_image_blend );
+	}
+
+	mlt_frame_push_audio( *frame, (void*)self );
+	mlt_frame_push_audio( *frame, link_get_audio );
+
+	// Apply a resampler
+	mlt_filter resampler = (mlt_filter)mlt_properties_get_data( properties, "_resampler", NULL );
+	if ( !resampler )
+	{
+		resampler = mlt_factory_filter( mlt_service_profile( MLT_LINK_SERVICE(self) ), "resample", NULL );
+		if ( !resampler )
+		{
+			resampler = mlt_factory_filter( mlt_service_profile( MLT_LINK_SERVICE(self) ), "swresample", NULL );
+		}
+		if( resampler )
+		{
+			mlt_properties_set_data( properties, "_resampler", resampler, 0, (mlt_destructor)mlt_filter_close, NULL );
+		}
+	}
+	if ( resampler )
+	{
+		mlt_filter_process( resampler, *frame );
+	}
+
+	mlt_producer_prepare_next( MLT_LINK_PRODUCER( self ) );
+
+	return result;
+}
+
+static void link_close( mlt_link self )
+{
+	self->close = NULL;
+	mlt_link_close( self );
+	free( self );
+}
+
+mlt_link link_timeremap_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	mlt_link self = mlt_link_init();
+	if ( self != NULL )
+	{
+		// Callback registration
+		self->configure = link_configure;
+		self->get_frame = link_get_frame;
+		self->close = link_close;
+	}
+	return self;
+}

--- a/src/modules/core/link_timeremap.yml
+++ b/src/modules/core/link_timeremap.yml
@@ -1,0 +1,27 @@
+schema_version: 0.3
+type: link
+identifier: timeremap
+title: Time Remap
+version: 1
+copyright: Meltytech, LLC
+license: LGPLv2.1
+language: en
+tags:
+  - Audio
+  - Video
+description: Remap frames in time.
+parameters:
+  - identifier: map
+    title: Map
+    type: float
+    description: >
+      A map of input frame times to output frame times.
+    mutable: yes
+  - identifier: image_mode
+    title: Image Mode
+    type: string
+    description: The image mode to use.
+    values:
+      - nearest # Output the nearest frame
+      - blend   # Blend the frames that make up the output
+    mutable: yes

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -60,7 +60,9 @@ enum service_type
 	mlt_dummy_filter_type,
 	mlt_dummy_transition_type,
 	mlt_dummy_producer_type,
-	mlt_dummy_consumer_type
+	mlt_dummy_consumer_type,
+	mlt_chain_type,
+	mlt_link_type,
 };
 
 struct deserialise_context_s
@@ -567,6 +569,194 @@ static void on_end_playlist( deserialise_context context, const xmlChar *name )
 	else
 	{
 		mlt_log_error( NULL, "[producer_xml] Invalid state of playlist end %d\n", type );
+	}
+}
+
+static void on_start_chain( deserialise_context context, const xmlChar *name, const xmlChar **atts)
+{
+	mlt_chain chain = mlt_chain_init( context->profile );
+	mlt_service service = MLT_CHAIN_SERVICE( chain );
+	mlt_properties properties = MLT_SERVICE_PROPERTIES( service );
+
+	track_service( context->destructors, service, (mlt_destructor) mlt_chain_close );
+
+	for ( ; atts != NULL && *atts != NULL; atts += 2 )
+	{
+		mlt_properties_set_string( properties, (const char*) atts[0], atts[1] == NULL ? "" : (const char*) atts[1] );
+
+		// Out will be overwritten later as we append, so we need to save it
+		if ( xmlStrcmp( atts[ 0 ], _x("out") ) == 0 )
+			mlt_properties_set_string( properties, "_xml.out", ( const char* )atts[ 1 ] );
+	}
+
+	if ( mlt_properties_get( properties, "id" ) != NULL )
+		mlt_properties_set_data( context->producer_map, mlt_properties_get( properties, "id" ), service, 0, NULL, NULL );
+
+	context_push_service( context, service, mlt_chain_type );
+}
+
+static void on_end_chain( deserialise_context context, const xmlChar *name )
+{
+	// Get the chain from the stack
+	enum service_type type;
+	mlt_service service = context_pop_service( context, &type );
+
+	if ( service != NULL && type == mlt_chain_type )
+	{
+		mlt_chain chain = MLT_CHAIN( service );
+		mlt_properties properties = MLT_SERVICE_PROPERTIES( service );
+		mlt_position in = -1;
+		mlt_position out = -1;
+		mlt_producer source = NULL;
+
+		qualify_property( context, properties, "resource" );
+		char *resource = mlt_properties_get( properties, "resource" );
+
+		// Let Kino-SMIL src be a synonym for resource
+		if ( resource == NULL )
+		{
+			qualify_property( context, properties, "src" );
+			resource = mlt_properties_get( properties, "src" );
+		}
+
+		// Instantiate the producer
+		if ( mlt_properties_get( properties, "mlt_service" ) != NULL )
+		{
+			char *service_name = trim( mlt_properties_get( properties, "mlt_service" ) );
+			if ( resource )
+			{
+				// If a document was saved as +INVALID.txt (see below), then ignore the mlt_service and
+				// try to load it just from the resource. This is an attempt to recover the failed
+				// producer in case, for example, a file returns.
+				if (!strcmp("qtext", service_name)) {
+					const char *text = mlt_properties_get( properties, "text" );
+					if (text && !strcmp("INVALID", text)) {
+						service_name = NULL;
+					}
+				} else if (!strcmp("pango", service_name)) {
+					const char *markup = mlt_properties_get( properties, "markup" );
+					if (markup && !strcmp("INVALID", markup)) {
+						service_name = NULL;
+					}
+				}
+				if (service_name) {
+					char *temp = calloc( 1, strlen( service_name ) + strlen( resource ) + 2 );
+					strcat( temp, service_name );
+					strcat( temp, ":" );
+					strcat( temp, resource );
+					source = mlt_factory_producer( context->profile, NULL, temp );
+					free( temp );
+				}
+			}
+			else
+			{
+				source = mlt_factory_producer( context->profile, NULL, service_name );
+			}
+		}
+
+		// Just in case the plugin requested doesn't exist...
+		if ( !source && resource )
+			source = mlt_factory_producer( context->profile, NULL, resource );
+		if ( !source ) {
+			mlt_log_error( NULL, "[producer_xml] failed to load producer \"%s\"\n", resource );
+			source = mlt_factory_producer( context->profile, NULL, "+INVALID.txt" );
+			if (source) {
+				// Save the original mlt_service for the consumer to serialize it as original.
+				mlt_properties_set_string( properties, "_xml_mlt_service",
+					mlt_properties_get( properties, "mlt_service" ) );
+			}
+		}
+		if ( !source )
+			source = mlt_factory_producer( context->profile, NULL, "colour:red" );
+		// Add the source producer to the chain
+		mlt_chain_set_source( chain, source );
+
+		// See if the chain should be added to a playlist or multitrack
+		if ( mlt_properties_get( properties, "in" ) )
+			in = mlt_properties_get_position( properties, "in" );
+		if ( mlt_properties_get( properties, "out" ) )
+			out = mlt_properties_get_position( properties, "out" );
+		if ( add_producer( context, service, in, out ) == 0 )
+			context_push_service( context, service, type );
+	}
+	else
+	{
+		mlt_log_error( NULL, "[producer_xml] Invalid state of chain end %d\n", type );
+	}
+}
+
+static void on_start_link( deserialise_context context, const xmlChar *name, const xmlChar **atts)
+{
+	// Store properties until the service type is known
+	mlt_service service = calloc( 1, sizeof( struct mlt_service_s ) );
+	mlt_service_init( service, NULL );
+	context_push_service( context, service, mlt_link_type );
+}
+
+static void on_end_link( deserialise_context context, const xmlChar *name )
+{
+	enum service_type type;
+	mlt_service service = context_pop_service( context, &type );
+	mlt_properties properties = MLT_SERVICE_PROPERTIES( service );
+
+	enum service_type parent_type = mlt_invalid_type;
+	mlt_service parent = context_pop_service( context, &parent_type );
+
+	if ( service != NULL && type == mlt_link_type )
+	{
+		char *id = trim( mlt_properties_get( properties, "mlt_service" ) );
+		mlt_service link = MLT_SERVICE( mlt_factory_link( id, NULL ) );
+		mlt_properties link_props = MLT_SERVICE_PROPERTIES( link );
+
+		if ( !link )
+		{
+			mlt_log_error( NULL, "[producer_xml] failed to load link \"%s\"\n", id );
+			if ( parent )
+				context_push_service( context, parent, parent_type );
+			mlt_service_close( service );
+			free( service );
+			return;
+		}
+
+		track_service( context->destructors, link, (mlt_destructor) mlt_link_close );
+		mlt_properties_set_lcnumeric( MLT_SERVICE_PROPERTIES( link ), context->lc_numeric );
+
+		// Do not let XML overwrite these important properties set by mlt_factory.
+		mlt_properties_set_string( properties, "mlt_type", NULL );
+		mlt_properties_set_string( properties, "mlt_service", NULL );
+
+		// Propagate the properties
+		mlt_properties_inherit( link_props, properties );
+
+		// Attach the link to the chain
+		if ( parent != NULL )
+		{
+			if ( parent_type == mlt_chain_type )
+			{
+				mlt_chain_attach( MLT_CHAIN( parent ), MLT_LINK( link ) );
+			}
+			else
+			{
+				mlt_log_error( NULL, "[producer_xml] link can only be added to a chain...\n" );
+			}
+
+			// Put the parent back on the stack
+			context_push_service( context, parent, parent_type );
+		}
+		else
+		{
+			mlt_log_error( NULL, "[producer_xml] link closed with invalid parent...\n" );
+		}
+	}
+	else
+	{
+		mlt_log_error( NULL, "[producer_xml] Invalid top of stack on link close\n" );
+	}
+
+	if ( service )
+	{
+		mlt_service_close( service );
+		free(service);
 	}
 }
 
@@ -1411,6 +1601,10 @@ static void on_start_element( void *ctx, const xmlChar *name, const xmlChar **at
 		on_start_filter( context, name, atts );
 	else if ( xmlStrcmp( name, _x("transition") ) == 0 )
 		on_start_transition( context, name, atts );
+	else if ( xmlStrcmp( name, _x("chain") ) == 0 )
+		on_start_chain( context, name, atts );
+	else if ( xmlStrcmp( name, _x("link") ) == 0 )
+		on_start_link( context, name, atts );
 	else if ( xmlStrcmp( name, _x("property") ) == 0 )
 		on_start_property( context, name, atts );
 	else if ( xmlStrcmp( name, _x("consumer") ) == 0 )
@@ -1452,6 +1646,10 @@ static void on_end_element( void *ctx, const xmlChar *name )
 		on_end_filter( context, name );
 	else if ( xmlStrcmp( name, _x("transition") ) == 0 )
 		on_end_transition( context, name );
+	else if ( xmlStrcmp( name, _x("chain") ) == 0 )
+		on_end_chain( context, name );
+	else if ( xmlStrcmp( name, _x("link") ) == 0 )
+		on_end_link( context, name );
 	else if ( xmlStrcmp( name, _x("consumer") ) == 0 )
 		on_end_consumer( context, name );
 
@@ -1955,9 +2153,9 @@ mlt_producer producer_xml_init( mlt_profile profile, mlt_service_type servtype, 
 	if ( well_formed && service != NULL )
 	{
 		// Verify it is a producer service (mlt_type="mlt_producer")
-		// (producer, playlist, multitrack)
+		// (producer, chain, playlist, multitrack)
 		char *type = mlt_properties_get( MLT_SERVICE_PROPERTIES( service ), "mlt_type" );
-		if ( type == NULL || ( strcmp( type, "mlt_producer" ) != 0 && strcmp( type, "producer" ) != 0 ) )
+		if ( type == NULL || ( strcmp( type, "mlt_producer" ) != 0 && strcmp( type, "producer" ) != 0 && strcmp( type, "chain" ) != 0 ) )
 			service = NULL;
 	}
 


### PR DESCRIPTION
### Purpose
The purpose of this merge request is to create a design and code review for this concept. The code is not expected to be merged without a lot of discussion and probably changes.

### Concept
The concept is to add two new classes to the MLT framework: chain and link. A chain is a type of producer that can contain links. A link is a type of producer that can request frames from the next link that they are connected to. A link could request multiple source frames for one output frame. Or, it could request the same source frame multiple times. The advantage of this (unlilke filters) is that a link can perform temporal effects like speed conversions or motion effects.

This PoC also includes one link implementation: timeremap. The timeremap link allows the user to specify a sequence of keyframes that map input frame times to output frame times. This method allows arbitrary speed and direction changes in real time.

### Example:
First, download the source material.

`wget ftp://vqeg.its.bldrdoc.gov/HDTV/NTIA_source/TouchdownPass_8bit.avi`

This first command demonstrates:
* normal speed leading up to the snap
* smooth speed transition to 0.5x speed during the play
* 0.1x speed during the catch
* smooth transition to normal speed for the celebration
* freeze frame during the jump
* reverse back to the tackle

`melt -profile atsc_1080p_30 -chain TouchdownPass_8bit.avi out=570 -link timeremap map="00:00:00.000=0;00:00:05.000=5;00:00:10.000~=7.5;00:00:15.000~=8;00:00:20.000~=10;00:00:25.000~=15;00:00:30.000=15;;00:00:36.000~=9"`

This next command demonstrates 2x speed with frame blending:

`melt -profile atsc_1080p_30 -chain TouchdownPass_8bit.avi out=570 -link timeremap image_mode=blend map="00:00:00.000=0;00:00:10.000=20"`
