### PR TITLE
Add new Audio object.

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -24,7 +24,8 @@ ifeq ($(targetos), Linux)
 SHFLAGS += -Wl,--version-script=mlt.vers
 endif
 
-OBJS = mlt_frame.o \
+OBJS = mlt_audio.o \
+	   mlt_frame.o \
 	   mlt_version.o \
 	   mlt_geometry.o \
 	   mlt_deque.o \
@@ -52,7 +53,8 @@ OBJS = mlt_frame.o \
 	   mlt_slices.o \
 	   mlt_luma_map.o
 
-INCS = mlt_consumer.h \
+INCS = mlt_audio.h \
+	   mlt_consumer.h \
 	   mlt_version.h \
 	   mlt_factory.h \
 	   mlt_filter.h \

--- a/src/framework/mlt.h
+++ b/src/framework/mlt.h
@@ -37,6 +37,7 @@ extern "C"
 #endif
 
 #include "mlt_animation.h"
+#include "mlt_audio.h"
 #include "mlt_factory.h"
 #include "mlt_frame.h"
 #include "mlt_deque.h"

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -557,6 +557,8 @@ MLT_6.22.0 {
   global:
     mlt_property_is_clear;
     mlt_properties_exists;
+    mlt_audio_new;
+    mlt_audio_close;
     mlt_audio_set_values;
     mlt_audio_get_values;
     mlt_audio_alloc_data;
@@ -567,4 +569,10 @@ MLT_6.22.0 {
     mlt_audio_shrink;
     mlt_audio_reverse;
     mlt_audio_copy;
+    mlt_audio_calculate_frame_samples;
+    mlt_audio_calculate_samples_to_position;
+    mlt_audio_channel_layout_name;
+    mlt_audio_channel_layout_id;
+    mlt_audio_channel_layout_channels;
+    mlt_audio_channel_layout_default;
 } MLT_6.20.0;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -557,4 +557,14 @@ MLT_6.22.0 {
   global:
     mlt_property_is_clear;
     mlt_properties_exists;
+    mlt_audio_set_values;
+    mlt_audio_get_values;
+    mlt_audio_alloc_data;
+    mlt_audio_calculate_size;
+    mlt_audio_plane_count;
+    mlt_audio_plane_size;
+    mlt_audio_get_planes;
+    mlt_audio_shrink;
+    mlt_audio_reverse;
+    mlt_audio_copy;
 } MLT_6.20.0;

--- a/src/framework/mlt_audio.c
+++ b/src/framework/mlt_audio.c
@@ -24,13 +24,47 @@
 
 #include "mlt_log.h"
 
+#include <stdlib.h>
 #include <string.h>
+
+/** Allocate a new Audio object.
+ *
+ * \return a new audio object with default values set
+ */
+
+mlt_audio mlt_audio_new()
+{
+	mlt_audio self = calloc( 1, sizeof(struct mlt_audio_s) );
+	self->close = free;
+	return self;
+}
+
+/** Destroy an audio object created by mlt_audio_new().
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ */
+
+void mlt_audio_close( mlt_audio self )
+{
+	if ( self)
+	{
+		if ( self->release_data )
+		{
+			self->release_data( self->data );
+		}
+		if ( self->close )
+		{
+			self->close( self );
+		}
+	}
+}
 
 /** Set the most common values for the audio.
  *
  * Less common values will be set to reasonable defaults.
  *
- * You should use the \p mlt_sample_calculator to determine the number of samples you want.
+ * You should use the \p mlt_audio_calculate_frame_samples to determine the number of samples you want.
  * \public \memberof mlt_audio_s
  * \param self the Audio object
  * \param data the buffer that contains the audio data
@@ -49,6 +83,7 @@ void mlt_audio_set_values( mlt_audio self, void* data, int frequency, mlt_audio_
 	self->channels = channels;
 	self->layout = mlt_channel_auto;
 	self->release_data = NULL;
+	self->close = NULL;
 }
 
 /** Get the most common values for the audio.
@@ -86,7 +121,7 @@ void mlt_audio_get_values( mlt_audio self, void** data, int* frequency, mlt_audi
 
 void mlt_audio_alloc_data( mlt_audio self )
 {
-	if (!self ) return;
+	if ( !self ) return;
 
 	if ( self->release_data )
 	{
@@ -107,19 +142,8 @@ void mlt_audio_alloc_data( mlt_audio self )
 
 int mlt_audio_calculate_size( mlt_audio self )
 {
-	if (!self ) return 0;
-
-	switch ( self->format )
-	{
-		case mlt_audio_none:   return 0;
-		case mlt_audio_s16:    return self->samples * self->channels * sizeof( int16_t );
-		case mlt_audio_s32le:
-		case mlt_audio_s32:    return self->samples * self->channels * sizeof( int32_t );
-		case mlt_audio_f32le:
-		case mlt_audio_float:  return self->samples * self->channels * sizeof( float );
-		case mlt_audio_u8:     return self->samples * self->channels;
-	}
-	return 0;
+	if ( !self ) return 0;
+	return mlt_audio_format_size( self->format, self->samples, self->channels );
 }
 
 /** Get the number of planes for the audio type
@@ -172,7 +196,6 @@ int mlt_audio_plane_size( mlt_audio self )
  * \param self the Audio object
  * \param[out] planes the array of pointers to populate
  */
-
 
 void mlt_audio_get_planes( mlt_audio self, uint8_t** planes )
 {
@@ -411,3 +434,278 @@ void mlt_audio_copy( mlt_audio dst, mlt_audio src, int samples, int src_start, i
 	}
 }
 
+/** Determine the number of samples that belong in a frame at a time position.
+ *
+ * \public \memberof mlt_frame_s
+ * \param fps the frame rate
+ * \param frequency the sample rate
+ * \param position the time position
+ * \return the number of samples per channel
+ */
+
+int mlt_audio_calculate_frame_samples( float fps, int frequency, int64_t position )
+{
+	/* Compute the cumulative number of samples until the start of this frame and the
+	cumulative number of samples until the start of the next frame. Round each to the
+	nearest integer and take the difference to determine the number of samples in
+	this frame.
+
+	This approach should prevent rounding errors that can accumulate over a large number
+	of frames causing A/V sync problems. */
+	return mlt_audio_calculate_samples_to_position( fps, frequency, position + 1 )
+		 - mlt_audio_calculate_samples_to_position( fps, frequency, position );
+}
+
+/** Determine the number of samples that belong before a time position.
+ *
+ * \public \memberof mlt_frame_s
+ * \param fps the frame rate
+ * \param frequency the sample rate
+ * \param position the time position
+ * \return the number of samples per channel
+ */
+
+int64_t mlt_audio_calculate_samples_to_position( float fps, int frequency, int64_t position )
+{
+	int64_t samples = 0;
+
+	if ( fps )
+	{
+		samples = (int64_t)( (double) position * (double) frequency / (double) fps +
+			( position < 0 ? -0.5 : 0.5 ) );
+	}
+
+	return samples;
+}
+
+/** Get the short name for an audio format.
+ *
+ * You do not need to deallocate the returned string.
+ * \public \memberof mlt_frame_s
+ * \param format an audio format enum
+ * \return a string for the name of the image format
+ */
+
+const char * mlt_audio_format_name( mlt_audio_format format )
+{
+	switch ( format )
+	{
+		case mlt_audio_none:   return "none";
+		case mlt_audio_s16:    return "s16";
+		case mlt_audio_s32:    return "s32";
+		case mlt_audio_s32le:  return "s32le";
+		case mlt_audio_float:  return "float";
+		case mlt_audio_f32le:  return "f32le";
+		case mlt_audio_u8:     return "u8";
+	}
+	return "invalid";
+}
+
+/** Get the amount of bytes needed for a block of audio.
+  *
+  * \public \memberof mlt_frame_s
+  * \param format an audio format enum
+  * \param samples the number of samples per channel
+  * \param channels the number of channels
+  * \return the number of bytes
+  */
+
+int mlt_audio_format_size( mlt_audio_format format, int samples, int channels )
+{
+	switch ( format )
+	{
+		case mlt_audio_none:   return 0;
+		case mlt_audio_s16:    return samples * channels * sizeof( int16_t );
+		case mlt_audio_s32le:
+		case mlt_audio_s32:    return samples * channels * sizeof( int32_t );
+		case mlt_audio_f32le:
+		case mlt_audio_float:  return samples * channels * sizeof( float );
+		case mlt_audio_u8:     return samples * channels;
+	}
+	return 0;
+}
+
+/** Get the short name for a channel layout.
+ *
+ * You do not need to deallocate the returned string.
+ * \public \member of mlt_frame_s
+ * \param layout the channel layout
+ * \return a string for the name of the channel layout
+ */
+
+const char* mlt_audio_channel_layout_name( mlt_channel_layout layout )
+{
+	switch ( layout )
+	{
+		case mlt_channel_auto:           return "auto";
+		case mlt_channel_independent:    return "independent";
+		case mlt_channel_mono:           return "mono";
+		case mlt_channel_stereo:         return "stereo";
+		case mlt_channel_2p1:            return "2.1";
+		case mlt_channel_3p0:            return "3.0";
+		case mlt_channel_3p0_back:       return "3.0(back)";
+		case mlt_channel_4p0:            return "4.0";
+		case mlt_channel_quad_back:      return "quad";
+		case mlt_channel_quad_side:      return "quad(side)";
+		case mlt_channel_3p1:            return "3.1";
+		case mlt_channel_5p0_back:       return "5.0";
+		case mlt_channel_5p0:            return "5.0(side)";
+		case mlt_channel_4p1:            return "4.1";
+		case mlt_channel_5p1_back:       return "5.1";
+		case mlt_channel_5p1:            return "5.1(side)";
+		case mlt_channel_6p0:            return "6.0";
+		case mlt_channel_6p0_front:      return "6.0(front)";
+		case mlt_channel_hexagonal:      return "hexagonal";
+		case mlt_channel_6p1:            return "6.1";
+		case mlt_channel_6p1_back:       return "6.1(back)";
+		case mlt_channel_6p1_front:      return "6.1(front)";
+		case mlt_channel_7p0:            return "7.0";
+		case mlt_channel_7p0_front:      return "7.0(front)";
+		case mlt_channel_7p1:            return "7.1";
+		case mlt_channel_7p1_wide_side:  return "7.1(wide-side)";
+		case mlt_channel_7p1_wide_back:  return "7.1(wide)";
+	}
+	return "invalid";
+}
+
+/** Get the id of channel layout from short name.
+ *
+ * \public \memberof mlt_frame_s
+ * \param name the channel layout short name
+ * \return a channel layout
+ */
+
+mlt_channel_layout mlt_audio_channel_layout_id( const char * name )
+{
+	if( name )
+	{
+		mlt_channel_layout c;
+		for( c = mlt_channel_auto; c <= mlt_channel_7p1_wide_back; c++ )
+		{
+			const char * v = mlt_audio_channel_layout_name( c );
+			if( !strcmp( v, name ) )
+				return c;
+		}
+	}
+	return mlt_channel_auto;
+}
+
+/** Get the number of channels for a channel layout.
+ *
+ * \public \memberof mlt_frame_s
+ * \param layout the channel layout
+ * \return the number of channels for the channel layout
+ */
+
+int mlt_audio_channel_layout_channels( mlt_channel_layout layout )
+{
+	switch ( layout )
+	{
+		case mlt_channel_auto:           return 0;
+		case mlt_channel_independent:    return 0;
+		case mlt_channel_mono:           return 1;
+		case mlt_channel_stereo:         return 2;
+		case mlt_channel_2p1:            return 3;
+		case mlt_channel_3p0:            return 3;
+		case mlt_channel_3p0_back:       return 3;
+		case mlt_channel_4p0:            return 4;
+		case mlt_channel_quad_back:      return 4;
+		case mlt_channel_quad_side:      return 4;
+		case mlt_channel_3p1:            return 4;
+		case mlt_channel_5p0_back:       return 5;
+		case mlt_channel_5p0:            return 5;
+		case mlt_channel_4p1:            return 5;
+		case mlt_channel_5p1_back:       return 6;
+		case mlt_channel_5p1:            return 6;
+		case mlt_channel_6p0:            return 6;
+		case mlt_channel_6p0_front:      return 6;
+		case mlt_channel_hexagonal:      return 6;
+		case mlt_channel_6p1:            return 7;
+		case mlt_channel_6p1_back:       return 7;
+		case mlt_channel_6p1_front:      return 7;
+		case mlt_channel_7p0:            return 7;
+		case mlt_channel_7p0_front:      return 7;
+		case mlt_channel_7p1:            return 8;
+		case mlt_channel_7p1_wide_back:  return 8;
+		case mlt_channel_7p1_wide_side:  return 8;
+	}
+	return 0;
+}
+
+/** Get a default channel layout for a given number of channels.
+ *
+ * \public \memberof mlt_frame_s
+ * \param channels the number of channels
+ * \return the default channel layout
+ */
+
+mlt_channel_layout mlt_audio_channel_layout_default( int channels )
+{
+	mlt_channel_layout c;
+	for( c = mlt_channel_mono; c <= mlt_channel_7p1_wide_back; c++ )
+	{
+		if( mlt_audio_channel_layout_channels( c ) == channels )
+			return c;
+	}
+	return mlt_channel_independent;
+}
+
+/** Determine the number of samples that belong in a frame at a time position.
+ *
+ * \deprecated since 6.22. Prefer mlt_audio_calculate_samples()
+ */
+
+int mlt_sample_calculator( float fps, int frequency, int64_t position )
+{
+	return mlt_audio_calculate_frame_samples( fps, frequency, position );
+}
+
+/** Determine the number of samples that belong before a time position.
+ *
+ * \deprecated since 6.22. Prefer mlt_audio_calculate_samples_to_position()
+ */
+
+int64_t mlt_sample_calculator_to_now( float fps, int frequency, int64_t position )
+{
+	return mlt_audio_calculate_samples_to_position( fps, frequency, position );
+}
+
+/** Get the short name for a channel layout.
+ *
+ * \deprecated since 6.22. Prefer mlt_audio_channel_layout_name()
+ */
+
+const char * mlt_channel_layout_name( mlt_channel_layout layout )
+{
+	return mlt_audio_channel_layout_name( layout );
+}
+
+/** Get the id of channel layout from short name.
+ *
+ * \deprecated since 6.22. Prefer mlt_audio_channel_layout_id()
+ */
+
+mlt_channel_layout mlt_channel_layout_id( const char * name )
+{
+	return mlt_audio_channel_layout_id( name );
+}
+
+/** Get the number of channels for a channel layout.
+ *
+ * \deprecated since 6.22. Prefer mlt_audio_channel_layout_channels()
+ */
+
+int mlt_channel_layout_channels( mlt_channel_layout layout )
+{
+	return mlt_audio_channel_layout_channels( layout );
+}
+
+/** Get a default channel layout for a given number of channels.
+ *
+ * \deprecated since 6.22. Prefer mlt_audio_channel_layout_default()
+ */
+
+mlt_channel_layout mlt_channel_layout_default( int channels )
+{
+	return mlt_audio_channel_layout_default( channels );
+}

--- a/src/framework/mlt_audio.c
+++ b/src/framework/mlt_audio.c
@@ -1,0 +1,413 @@
+/**
+ * \file mlt_audio.c
+ * \brief Audio class
+ * \see mlt_mlt_audio_s
+ *
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "mlt_audio.h"
+
+#include "mlt_log.h"
+
+#include <string.h>
+
+/** Set the most common values for the audio.
+ *
+ * Less common values will be set to reasonable defaults.
+ *
+ * You should use the \p mlt_sample_calculator to determine the number of samples you want.
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \param data the buffer that contains the audio data
+ * \param frequency the sample rate
+ * \param format the audio format
+ * \param samples the number of samples in the data
+ * \param channels the number of audio channels
+ */
+
+void mlt_audio_set_values( mlt_audio self, void* data, int frequency, mlt_audio_format format, int samples, int channels )
+{
+	self->data = data;
+	self->frequency = frequency;
+	self->format = format;
+	self->samples = samples;
+	self->channels = channels;
+	self->layout = mlt_channel_auto;
+	self->release_data = NULL;
+}
+
+/** Get the most common values for the audio.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \param[out] data the buffer that contains the audio data
+ * \param[out] frequency the sample rate
+ * \param[out] format the audio format
+ * \param[out] samples the number of samples in the data
+ * \param[out] channels the number of audio channels
+ */
+
+void mlt_audio_get_values( mlt_audio self, void** data, int* frequency, mlt_audio_format* format, int* samples, int* channels )
+{
+	*data = self->data;
+	*frequency = self->frequency;
+	*format = self->format;
+	*samples = self->samples;
+	*channels = self->channels;
+}
+
+/** Allocate the data field based on the other properties of the Audio.
+ *
+ * If the data field is already set, and a destructor function exists, the data
+ * will be released. Else, the data pointer will be overwritten without being
+ * released.
+ *
+ * After this function call, the release_data field will be set and can be used
+ * to release the data when necessary.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ */
+
+void mlt_audio_alloc_data( mlt_audio self )
+{
+	if (!self ) return;
+
+	if ( self->release_data )
+	{
+		self->release_data( self->data );
+	}
+
+	int size = mlt_audio_calculate_size( self );
+	self->data = mlt_pool_alloc( size );
+	self->release_data = mlt_pool_release;
+}
+
+/** Calculate the number of bytes needed for the Audio data.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \return the number of bytes
+ */
+
+int mlt_audio_calculate_size( mlt_audio self )
+{
+	if (!self ) return 0;
+
+	switch ( self->format )
+	{
+		case mlt_audio_none:   return 0;
+		case mlt_audio_s16:    return self->samples * self->channels * sizeof( int16_t );
+		case mlt_audio_s32le:
+		case mlt_audio_s32:    return self->samples * self->channels * sizeof( int32_t );
+		case mlt_audio_f32le:
+		case mlt_audio_float:  return self->samples * self->channels * sizeof( float );
+		case mlt_audio_u8:     return self->samples * self->channels;
+	}
+	return 0;
+}
+
+/** Get the number of planes for the audio type
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \return the number of planes.
+ */
+
+int mlt_audio_plane_count( mlt_audio self )
+{
+	switch ( self->format )
+	{
+		case mlt_audio_none:  return 0;
+		case mlt_audio_s16:   return 1;
+		case mlt_audio_s32le: return 1;
+		case mlt_audio_s32:   return self->channels;
+		case mlt_audio_f32le: return 1;
+		case mlt_audio_float: return self->channels;
+		case mlt_audio_u8:    return 1;
+	}
+	return 0;
+}
+
+/** Get the size of an audio plane.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \return the size of a plane.
+ */
+
+int mlt_audio_plane_size( mlt_audio self )
+{
+	switch ( self->format )
+	{
+		case mlt_audio_none:  return 0;
+		case mlt_audio_s16:   return self->samples * self->channels * sizeof( int16_t );
+		case mlt_audio_s32le: return self->samples * self->channels * sizeof( int32_t );
+		case mlt_audio_s32:   return self->samples * sizeof( int32_t );
+		case mlt_audio_f32le: return self->samples * self->channels * sizeof( float );
+		case mlt_audio_float: return self->samples * sizeof( float );
+		case mlt_audio_u8:    return self->samples * self->channels;
+	}
+	return 0;
+}
+
+/** Populate an array of pointers each pointing to the beginning of an audio plane.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \param[out] planes the array of pointers to populate
+ */
+
+
+void mlt_audio_get_planes( mlt_audio self, uint8_t** planes )
+{
+	int plane_count = mlt_audio_plane_count( self );
+	int plane_size = mlt_audio_plane_size( self );
+	int p = 0;
+	for( p = 0; p < plane_count; p++ )
+	{
+		planes[p] = (uint8_t*)self->data + ( p * plane_size );
+	}
+}
+
+/** Shrink the audio to the new number of samples.
+ *
+ * Existing samples will be moved as necessary to ensure that the audio planes
+ * immediately follow each other. The samples field will be updated to match the
+ * new number.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ * \param samples the new number of samples to shrink to
+ */
+
+void mlt_audio_shrink( mlt_audio self , int samples )
+{
+	int plane_count = mlt_audio_plane_count( self );
+	if ( samples >= self->samples || samples < 0 )
+	{
+		// Nothing to do;
+	}
+	else if ( plane_count == 1 || samples == 0 )
+	{
+		// No need to move any data.
+		self->samples = samples;
+	}
+	if ( plane_count > 1 )
+	{
+		// Move data to remove gaps between planes.
+		size_t src_plane_size = mlt_audio_plane_size( self );
+		self->samples = samples;
+		size_t dst_plane_size = mlt_audio_plane_size( self );
+		// The first channel will always be in the correct place (0).
+		int p = 1;
+		for( p = 1; p < plane_count; p++ )
+		{
+			uint8_t* src = (uint8_t*)self->data + ( p * src_plane_size );
+			uint8_t* dst = (uint8_t*)self->data + ( p * dst_plane_size );
+			memmove( dst, src, dst_plane_size );
+		}
+	}
+}
+
+/** Reverse the audio samples.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ */
+
+void mlt_audio_reverse( mlt_audio self )
+{
+	int c = 0;
+
+	if ( !self || !self->data || self->samples <= 0 ) return;
+
+	switch ( self->format )
+	{
+		// Interleaved 8bit formats
+		case mlt_audio_u8:
+		{
+			int8_t tmp;
+			for ( c = 0; c < self->channels; c++ )
+			{
+				// Pointer to first sample
+				int8_t* a = (int8_t*)self->data + c;
+				// Pointer to last sample
+				int8_t* b = (int8_t*)self->data + ((self->samples - 1) * self->channels) + c;
+				while( a < b )
+				{
+					tmp = *a;
+					*a = *b;
+					*b = tmp;
+					a += self->channels;
+					b -= self->channels;
+				}
+			}
+			break;
+		}
+		// Interleaved 16bit formats
+		case mlt_audio_s16:
+		{
+			int16_t tmp;
+			for ( c = 0; c < self->channels; c++ )
+			{
+				// Pointer to first sample
+				int16_t *a = (int16_t*)self->data + c;
+				// Pointer to last sample
+				int16_t *b = (int16_t*)self->data + ((self->samples - 1) * self->channels) + c;
+				while( a < b )
+				{
+					tmp = *a;
+					*a = *b;
+					*b = tmp;
+					a += self->channels;
+					b -= self->channels;
+				}
+			}
+			break;
+		}
+		// Interleaved 32bit formats
+		case mlt_audio_s32le:
+		case mlt_audio_f32le:
+		{
+			int32_t tmp;
+			for ( c = 0; c < self->channels; c++ )
+			{
+				// Pointer to first sample
+				int32_t *a = (int32_t*)self->data + c;
+				// Pointer to last sample
+				int32_t *b = (int32_t*)self->data + ((self->samples - 1)* self->channels) + c;
+				while( a < b )
+				{
+					tmp = *a;
+					*a = *b;
+					*b = tmp;
+					a += self->channels;
+					b -= self->channels;
+				}
+			}
+			break;
+		}
+		// Planer 32bit formats
+		case mlt_audio_s32:
+		case mlt_audio_float:
+		{
+			int32_t tmp;
+			for ( c = 0; c < self->channels; c++ )
+			{
+				// Pointer to first sample
+				int32_t *a = (int32_t*)self->data + (c * self->samples);
+				// Pointer to last sample
+				int32_t *b = (int32_t*)self->data + ((c + 1) * self->samples) - 1;
+				while( a < b )
+				{
+					tmp = *a;
+					*a = *b;
+					*b = tmp;
+					a++;
+					b--;
+				}
+			}
+			break;
+		}
+		case mlt_audio_none:
+			break;
+	}
+}
+
+/** Copy audio samples from src to dst.
+ *
+ * \public \memberof mlt_frame_s
+ * \param dst the destination object
+ * \param src the source object
+ * \param samples the number of samples to copy
+ * \param src_offset the number of samples to skip from the source
+ * \param dst_offset the number of samples to skip from the destination
+ * \return none
+ */
+
+void mlt_audio_copy( mlt_audio dst, mlt_audio src, int samples, int src_start, int dst_start )
+{
+	if ( ( dst_start + samples ) > dst->samples )
+	{
+		mlt_log_error( NULL, "mlt_audio_copy: avoid dst buffer overrun\n" );
+		return;
+	}
+
+	if ( ( src_start + samples ) > src->samples )
+	{
+		mlt_log_error( NULL, "mlt_audio_copy: avoid src buffer overrun\n" );
+		return;
+	}
+
+	if ( src->format != dst->format || src->channels != dst->channels )
+	{
+		mlt_log_error( NULL, "mlt_audio_copy: src/dst mismatch\n" );
+		return;
+	}
+
+	switch ( src->format )
+	{
+		case mlt_audio_none:
+			mlt_log_error( NULL, "mlt_audio_copy: mlt_audio_none\n" );
+			return;
+		// Interleaved 8bit formats
+		case mlt_audio_u8:
+		{
+			int8_t* s = (int8_t*)src->data + ( src_start * src->channels );
+			int8_t* d = (int8_t*)dst->data + ( dst_start * dst->channels );
+			int size = src->channels * samples * sizeof(int8_t);
+			memcpy( d, s, size );
+			return;
+		}
+		// Interleaved 16bit formats
+		case mlt_audio_s16:
+		{
+			int16_t* s = (int16_t*)src->data + ( src_start * src->channels );
+			int16_t* d = (int16_t*)dst->data + ( dst_start * dst->channels );
+			int size = src->channels * samples * sizeof(int16_t);
+			memcpy( d, s, size );
+			return;
+		}
+		// Interleaved 32bit formats
+		case mlt_audio_s32le:
+		case mlt_audio_f32le:
+		{
+			int32_t* s = (int32_t*)src->data + ( src_start * src->channels );
+			int32_t* d = (int32_t*)dst->data + ( dst_start * dst->channels );
+			int size = src->channels * samples * sizeof(int32_t);
+			memcpy( d, s, size );
+			return;
+		}
+		// Planer 32bit formats
+		case mlt_audio_s32:
+		case mlt_audio_float:
+		{
+			int p = 0;
+			for ( p = 0; p < src->channels; p++ )
+			{
+				int32_t* s = (int32_t*)src->data + (p * src->samples) + src_start;
+				int32_t* d = (int32_t*)dst->data + (p * dst->samples) + dst_start;
+				int size = samples * sizeof(int32_t);
+				memcpy( d, s, size );
+			}
+			return;
+		}
+	}
+}
+

--- a/src/framework/mlt_audio.h
+++ b/src/framework/mlt_audio.h
@@ -1,0 +1,55 @@
+/**
+ * \file mlt_audio.h
+ * \brief Audio class
+ * \see mlt_audio_s
+ *
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MLT_AUDIO_H
+#define MLT_AUDIO_H
+
+#include "mlt_types.h"
+
+/** \brief Audio class
+ *
+ * Audio is the data object that represents audio for a period of time.
+ */
+
+struct mlt_audio_s
+{
+	void* data;
+	int frequency;
+	mlt_audio_format format;
+	int samples;
+	int channels;
+	mlt_channel_layout layout;
+	mlt_destructor release_data;
+};
+
+extern void mlt_audio_set_values( mlt_audio self, void* data, int frequency, mlt_audio_format format, int samples, int channels );
+extern void mlt_audio_get_values( mlt_audio self, void** data, int* frequency, mlt_audio_format* format, int* samples, int* channels );
+extern void mlt_audio_alloc_data( mlt_audio self );
+extern int mlt_audio_calculate_size( mlt_audio self );
+extern int mlt_audio_plane_count( mlt_audio self );
+extern int mlt_audio_plane_size( mlt_audio self );
+extern void mlt_audio_get_planes( mlt_audio self, uint8_t** planes );
+extern void mlt_audio_shrink( mlt_audio self , int samples );
+extern void mlt_audio_reverse( mlt_audio self );
+extern void mlt_audio_copy( mlt_audio dst, mlt_audio src, int samples, int src_start, int dst_start );
+
+#endif

--- a/src/framework/mlt_audio.h
+++ b/src/framework/mlt_audio.h
@@ -39,8 +39,11 @@ struct mlt_audio_s
 	int channels;
 	mlt_channel_layout layout;
 	mlt_destructor release_data;
+	mlt_destructor close;
 };
 
+extern mlt_audio mlt_audio_new();
+extern void mlt_audio_close( mlt_audio self );
 extern void mlt_audio_set_values( mlt_audio self, void* data, int frequency, mlt_audio_format format, int samples, int channels );
 extern void mlt_audio_get_values( mlt_audio self, void** data, int* frequency, mlt_audio_format* format, int* samples, int* channels );
 extern void mlt_audio_alloc_data( mlt_audio self );
@@ -51,5 +54,21 @@ extern void mlt_audio_get_planes( mlt_audio self, uint8_t** planes );
 extern void mlt_audio_shrink( mlt_audio self , int samples );
 extern void mlt_audio_reverse( mlt_audio self );
 extern void mlt_audio_copy( mlt_audio dst, mlt_audio src, int samples, int src_start, int dst_start );
+extern int mlt_audio_calculate_frame_samples( float fps, int frequency, int64_t position );
+extern int64_t mlt_audio_calculate_samples_to_position( float fps, int frequency, int64_t position );
+extern const char * mlt_audio_format_name( mlt_audio_format format );
+extern int mlt_audio_format_size( mlt_audio_format format, int samples, int channels );
+extern const char * mlt_audio_channel_layout_name( mlt_channel_layout layout );
+extern mlt_channel_layout mlt_audio_channel_layout_id( const char * name );
+extern int mlt_audio_channel_layout_channels( mlt_channel_layout layout );
+extern mlt_channel_layout mlt_audio_channel_layout_default( int channels );
+
+// Deprecated functions
+extern int mlt_sample_calculator( float fps, int frequency, int64_t position );
+extern int64_t mlt_sample_calculator_to_now( float fps, int frequency, int64_t position );
+extern const char * mlt_channel_layout_name( mlt_channel_layout layout );
+extern mlt_channel_layout mlt_channel_layout_id( const char * name );
+extern int mlt_channel_layout_channels( mlt_channel_layout layout );
+extern mlt_channel_layout mlt_channel_layout_default( int channels );
 
 #endif

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -817,7 +817,7 @@ static void *consumer_read_ahead_thread( void *arg )
 		// Get the audio of the first frame
 		if ( !audio_off )
 		{
-			samples = mlt_sample_calculator( priv->fps, priv->frequency, priv->aud_counter++ );
+			samples = mlt_audio_calculate_frame_samples( priv->fps, priv->frequency, priv->aud_counter++ );
 			mlt_frame_get_audio( frame, &audio, &priv->audio_format, &priv->frequency, &priv->channels, &samples );
 		}
 
@@ -878,7 +878,7 @@ static void *consumer_read_ahead_thread( void *arg )
 		// Always process audio
 		if ( !audio_off )
 		{
-			samples = mlt_sample_calculator( priv->fps, priv->frequency, priv->aud_counter++ );
+			samples = mlt_audio_calculate_frame_samples( priv->fps, priv->frequency, priv->aud_counter++ );
 			mlt_frame_get_audio( frame, &audio, &priv->audio_format, &priv->frequency, &priv->channels, &samples );
 		}
 
@@ -1411,7 +1411,7 @@ static mlt_frame worker_get_frame( mlt_consumer self, mlt_properties properties 
 				// Process the audio
 				if ( !audio_off )
 				{
-					samples = mlt_sample_calculator( priv->fps, priv->frequency, priv->aud_counter++ );
+					samples = mlt_audio_calculate_frame_samples( priv->fps, priv->frequency, priv->aud_counter++ );
 					mlt_frame_get_audio( frame, &audio, &priv->audio_format, &priv->frequency, &priv->channels, &samples );
 				}
 				pthread_mutex_lock( &priv->queue_mutex );
@@ -1445,7 +1445,7 @@ static mlt_frame worker_get_frame( mlt_consumer self, mlt_properties properties 
 			// Process the audio
 			if ( !audio_off )
 			{
-				samples = mlt_sample_calculator( priv->fps, priv->frequency, priv->aud_counter++ );
+				samples = mlt_audio_calculate_frame_samples( priv->fps, priv->frequency, priv->aud_counter++ );
 				mlt_frame_get_audio( frame, &audio, &priv->audio_format, &priv->frequency, &priv->channels, &samples );
 			}
 			pthread_mutex_lock( &priv->queue_mutex );

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -23,6 +23,7 @@
 #ifndef MLT_FRAME_H
 #define MLT_FRAME_H
 
+#include "mlt_audio.h"
 #include "mlt_properties.h"
 #include "mlt_deque.h"
 #include "mlt_service.h"
@@ -144,19 +145,11 @@ extern mlt_properties mlt_frame_get_unique_properties( mlt_frame self, mlt_servi
 extern mlt_frame mlt_frame_clone( mlt_frame self, int is_deep );
 
 /* convenience functions */
-extern int mlt_sample_calculator( float fps, int frequency, int64_t position );
-extern int64_t mlt_sample_calculator_to_now( float fps, int frequency, int64_t position );
 extern const char * mlt_image_format_name( mlt_image_format format );
 extern int mlt_image_format_size( mlt_image_format format, int width, int height, int *bpp );
-extern const char * mlt_audio_format_name( mlt_audio_format format );
-extern int mlt_audio_format_size( mlt_audio_format format, int samples, int channels );
 extern void mlt_frame_write_ppm( mlt_frame frame );
 extern int mlt_image_format_planes( mlt_image_format format, int width, int height, void* data, unsigned char *planes[4], int strides[4]);
 extern mlt_image_format mlt_image_format_id( const char * name );
-extern const char * mlt_channel_layout_name( mlt_channel_layout layout );
-extern mlt_channel_layout mlt_channel_layout_id( const char * name );
-extern int mlt_channel_layout_channels( mlt_channel_layout layout );
-extern mlt_channel_layout mlt_channel_layout_default( int channels );
 
 /** This macro scales RGB into the YUV gamut - y is scaled by 219/255 and uv by 224/255. */
 #define RGB2YUV_601_SCALED(r, g, b, y, u, v)\

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -184,6 +184,7 @@ typedef struct {
 }
 mlt_color;
 
+typedef struct mlt_audio_s *mlt_audio;                  /**< pointer to Audio object */
 typedef struct mlt_frame_s *mlt_frame, **mlt_frame_ptr; /**< pointer to Frame object */
 typedef struct mlt_property_s *mlt_property;            /**< pointer to Property object */
 typedef struct mlt_properties_s *mlt_properties;        /**< pointer to Properties object */

--- a/src/mlt++/Makefile
+++ b/src/mlt++/Makefile
@@ -26,7 +26,8 @@ ifeq ($(targetos), Linux)
 LDFLAGS += -Wl,--version-script=mlt++.vers
 endif
 
-OBJS = MltAnimation.o \
+OBJS = MltAudio.o \
+	   MltAnimation.o \
 	   MltConsumer.o \
 	   MltDeque.o \
 	   MltEvent.o \

--- a/src/mlt++/MltAudio.cpp
+++ b/src/mlt++/MltAudio.cpp
@@ -1,0 +1,97 @@
+/**
+ * MltAudio.cpp - MLT Wrapper
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "MltAudio.h"
+
+using namespace Mlt;
+
+Audio::Audio( )
+{
+	instance = mlt_audio_new();
+}
+
+Audio::Audio( mlt_audio audio )
+ : instance( audio )
+{
+}
+
+Audio::~Audio( )
+{
+	mlt_audio_close( instance );
+}
+
+void* Audio::data()
+{
+	return instance->data;
+}
+
+void Audio::set_data( void* data )
+{
+	instance->data = data;
+}
+
+int Audio::frequency()
+{
+	return instance->frequency;
+}
+
+void Audio::set_frequency( int frequency )
+{
+	instance->frequency = frequency;
+}
+
+mlt_audio_format Audio::format()
+{
+	return instance->format;
+}
+
+void Audio::set_format( mlt_audio_format format )
+{
+	instance->format = format;
+}
+
+int Audio::samples()
+{
+	return instance->samples;
+}
+
+void Audio::set_samples( int samples )
+{
+	instance->samples = samples;
+}
+
+int Audio::channels()
+{
+	return instance->channels;
+}
+
+void Audio::set_channels( int channels )
+{
+	instance->channels = channels;
+}
+
+mlt_channel_layout Audio::layout()
+{
+	return instance->layout;
+}
+
+void Audio::set_layout( mlt_channel_layout layout )
+{
+	instance->layout = layout;
+}

--- a/src/mlt++/MltAudio.h
+++ b/src/mlt++/MltAudio.h
@@ -1,7 +1,6 @@
 /**
- * Mlt.h - Convenience header file for all mlt++ objects
- * Copyright (C) 2004-2015 Meltytech, LLC
- * Author: Charles Yates <charles.yates@gmail.com>
+ * MltAudio.h - MLT Wrapper
+ * Copyright (C) 2020 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,31 +17,36 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef MLTPP_H
-#define MLTPP_H
+#ifndef MLTPP_AUDIO_H
+#define MLTPP_AUDIO_H
 
-#include "MltAudio.h"
-#include "MltAnimation.h"
-#include "MltConsumer.h"
-#include "MltDeque.h"
-#include "MltEvent.h"
-#include "MltFactory.h"
-#include "MltField.h"
-#include "MltFilter.h"
-#include "MltFilteredConsumer.h"
-#include "MltFrame.h"
-#include "MltGeometry.h"
-#include "MltMultitrack.h"
-#include "MltParser.h"
-#include "MltPlaylist.h"
-#include "MltProducer.h"
-#include "MltProfile.h"
-#include "MltProperties.h"
-#include "MltPushConsumer.h"
-#include "MltRepository.h"
-#include "MltService.h"
-#include "MltTokeniser.h"
-#include "MltTractor.h"
-#include "MltTransition.h"
+#include "MltConfig.h"
+
+#include <framework/mlt.h>
+
+namespace Mlt
+{
+	class MLTPP_DECLSPEC Audio
+	{
+		private:
+			mlt_audio instance;
+		public:
+			Audio();
+			Audio( mlt_audio audio );
+			virtual ~Audio( );
+			void* data();
+			void set_data( void* data );
+			int frequency();
+			void set_frequency( int frequency );
+			mlt_audio_format format();
+			void set_format( mlt_audio_format format );
+			int samples();
+			void set_samples( int samples );
+			int channels();
+			void set_channels( int channels );
+			mlt_channel_layout layout();
+			void set_layout( mlt_channel_layout layout );
+	};
+}
 
 #endif

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -595,5 +595,20 @@ MLTPP_6.22.0 {
   global:
     extern "C++" {
       "Mlt::Properties::property_exists(char const*)";
+      "Mlt::Audio::Audio()";
+      "Mlt::Audio::Audio(mlt_audio_s*)";
+      "Mlt::Audio::~Audio()";
+      "Mlt::Audio::data()";
+      "Mlt::Audio::set_data(void*)";
+      "Mlt::Audio::frequency()";
+      "Mlt::Audio::set_frequency(int)";
+      "Mlt::Audio::format()";
+      "Mlt::Audio::set_format(mlt_audio_format)";
+      "Mlt::Audio::samples()";
+      "Mlt::Audio::set_samples(int)";
+      "Mlt::Audio::channels()";
+      "Mlt::Audio::set_channels(int)";
+      "Mlt::Audio::layout()";
+      "Mlt::Audio::set_layout(mlt_channel_layout)";
     };
 } MLTPP_6.20.0;

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -109,7 +109,7 @@ int64_t mlt_to_av_channel_layout( mlt_channel_layout layout )
 	{
 		case mlt_channel_auto:
 		case mlt_channel_independent:
-			mlt_log_error( NULL, "[avformat] No matching channel layout: %s\n", mlt_channel_layout_name( layout ) );
+			mlt_log_error( NULL, "[avformat] No matching channel layout: %s\n", mlt_audio_channel_layout_name( layout ) );
 			return 0;
 		case mlt_channel_mono:           return AV_CH_LAYOUT_MONO;
 		case mlt_channel_stereo:         return AV_CH_LAYOUT_STEREO;
@@ -179,11 +179,11 @@ mlt_channel_layout av_channel_layout_to_mlt( int64_t layout )
 
 mlt_channel_layout mlt_get_channel_layout_or_default( const char* name, int channels )
 {
-	mlt_channel_layout layout = mlt_channel_layout_id( name );
+	mlt_channel_layout layout = mlt_audio_channel_layout_id( name );
 	if( layout == mlt_channel_auto ||
-		( layout != mlt_channel_independent && mlt_channel_layout_channels( layout ) != channels ) )
+		( layout != mlt_channel_independent && mlt_audio_channel_layout_channels( layout ) != channels ) )
 	{
-		layout = mlt_channel_layout_default( channels );
+		layout = mlt_audio_channel_layout_default( channels );
 	}
 	return layout;
 }

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1664,12 +1664,12 @@ static void *consumer_thread( void *arg )
 		// single track
 		if ( !is_multi )
 		{
-			mlt_channel_layout layout = mlt_channel_layout_id( mlt_properties_get( properties, "channel_layout" ) );
+			mlt_channel_layout layout = mlt_audio_channel_layout_id( mlt_properties_get( properties, "channel_layout" ) );
 			if( layout == mlt_channel_auto ||
 				layout == mlt_channel_independent ||
-				mlt_channel_layout_channels( layout ) != enc_ctx->channels )
+				mlt_audio_channel_layout_channels( layout ) != enc_ctx->channels )
 			{
-				layout = mlt_channel_layout_default( enc_ctx->channels );
+				layout = mlt_audio_channel_layout_default( enc_ctx->channels );
 			}
 			enc_ctx->audio_st[0] = add_audio_stream( consumer, enc_ctx->oc, audio_codec, enc_ctx->channels, mlt_to_av_channel_layout( layout ) );
 			enc_ctx->total_channels = enc_ctx->channels;
@@ -1852,7 +1852,7 @@ static void *consumer_thread( void *arg )
 			// Get audio and append to the fifo
 			if ( !enc_ctx->terminated && enc_ctx->audio_st[0] )
 			{
-				samples = mlt_sample_calculator( fps, enc_ctx->frequency, count ++ );
+				samples = mlt_audio_calculate_frame_samples( fps, enc_ctx->frequency, count ++ );
 				enc_ctx->channels = enc_ctx->total_channels;
 				mlt_frame_get_audio( frame, &pcm, &aud_fmt, &enc_ctx->frequency, &enc_ctx->channels, &samples );
 

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -573,7 +573,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	mlt_filter filter = mlt_frame_pop_audio( frame );
 	private_data* pdata = (private_data*)filter->child;
 	double fps = mlt_profile_fps( mlt_service_profile(MLT_FILTER_SERVICE(filter)) );
-	int64_t samplepos = mlt_sample_calculator_to_now( fps, *frequency, get_position(filter, frame) );
+	int64_t samplepos = mlt_audio_calculate_samples_to_position( fps, *frequency, get_position(filter, frame) );
 	int bufsize = 0;
 	int ret;
 

--- a/src/modules/avformat/filter_swresample.c
+++ b/src/modules/avformat/filter_swresample.c
@@ -48,7 +48,7 @@ static int configure_swr_context( mlt_filter filter )
 	int error = 0;
 
 	mlt_log_info( MLT_FILTER_SERVICE(filter), "%d(%s) %s %dHz -> %d(%s) %s %dHz\n",
-				   pdata->in_channels, mlt_channel_layout_name( pdata->in_layout ), mlt_audio_format_name( pdata->in_format ), pdata->in_frequency, pdata->out_channels, mlt_channel_layout_name( pdata->out_layout ), mlt_audio_format_name( pdata->out_format ), pdata->out_frequency );
+				   pdata->in_channels, mlt_audio_channel_layout_name( pdata->in_layout ), mlt_audio_format_name( pdata->in_format ), pdata->in_frequency, pdata->out_channels, mlt_audio_channel_layout_name( pdata->out_layout ), mlt_audio_format_name( pdata->out_format ), pdata->out_frequency );
 
 	swr_free( &pdata->ctx );
 	pdata->ctx = swr_alloc();
@@ -217,7 +217,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 			mlt_audio_shrink( &out, received_samples );
 			mlt_frame_set_audio( frame, out.data, out.format, 0, out.release_data );
 			mlt_audio_get_values( &out, buffer, frequency, format, samples, channels );
-			mlt_properties_set( frame_properties, "channel_layout", mlt_channel_layout_name( out.layout ) );
+			mlt_properties_set( frame_properties, "channel_layout", mlt_audio_channel_layout_name( out.layout ) );
 		}
 		else
 		{

--- a/src/modules/avformat/filter_swresample.c
+++ b/src/modules/avformat/filter_swresample.c
@@ -42,64 +42,6 @@ typedef struct
 	mlt_channel_layout out_layout;
 } private_data;
 
-static int audio_plane_count( mlt_audio_format format, int channels )
-{
-	switch ( format )
-	{
-		case mlt_audio_none:  return 0;
-		case mlt_audio_s16:   return 1;
-		case mlt_audio_s32le: return 1;
-		case mlt_audio_s32:   return channels;
-		case mlt_audio_f32le: return 1;
-		case mlt_audio_float: return channels;
-		case mlt_audio_u8:    return 1;
-	}
-	return 0;
-}
-
-static int audio_plane_size( mlt_audio_format format, int samples, int channels )
-{
-	switch ( format )
-	{
-		case mlt_audio_none:  return 0;
-		case mlt_audio_s16:   return samples * channels * sizeof( int16_t );
-		case mlt_audio_s32le: return samples * channels * sizeof( int32_t );
-		case mlt_audio_s32:   return samples * sizeof( int32_t );
-		case mlt_audio_f32le: return samples * channels * sizeof( float );
-		case mlt_audio_float: return samples * sizeof( float );
-		case mlt_audio_u8:    return samples * channels;
-	}
-	return 0;
-}
-
-static void audio_format_planes( mlt_audio_format format, int samples, int channels, uint8_t* buffer, uint8_t** planes )
-{
-	int plane_count = audio_plane_count( format, channels );
-	size_t plane_size = audio_plane_size( format, samples, channels );
-	int p = 0;
-	for( p = 0; p < plane_count; p++ )
-	{
-		planes[p] = buffer + ( p * plane_size );
-	}
-}
-
-static void collapse_channels( mlt_audio_format format, int channels, int allocated_samples, int used_samples, uint8_t* buffer )
-{
-	int plane_count = audio_plane_count( format, channels );
-	if( plane_count > 1 && allocated_samples != used_samples )
-	{
-		size_t src_plane_size = audio_plane_size( format, allocated_samples, channels );
-		size_t dst_plane_size = audio_plane_size( format, used_samples, channels );
-		int p = 0;
-		for( p = 0; p < plane_count; p++ )
-		{
-			uint8_t* src = buffer + ( p * src_plane_size );
-			uint8_t* dst = buffer + ( p * dst_plane_size );
-			memmove( dst, src, dst_plane_size );
-		}
-	}
-}
-
 static int configure_swr_context( mlt_filter filter )
 {
 	private_data* pdata = (private_data*)filter->child;
@@ -189,46 +131,42 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	mlt_filter filter = mlt_frame_pop_audio( frame );
 	private_data* pdata = (private_data*)filter->child;
 	mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
-	mlt_audio_format in_format = *format;
-	mlt_audio_format out_format = *format;
-	int in_frequency = *frequency;
-	int out_frequency = *frequency;
-	int in_channels = *channels;
-	int out_channels = *channels;
-	mlt_channel_layout in_layout;
-	mlt_channel_layout out_layout;
+	struct mlt_audio_s in;
+	struct mlt_audio_s out;
+
+	mlt_audio_set_values( &in, *buffer, *frequency, *format, *samples, *channels );
+	mlt_audio_set_values( &out, NULL, *frequency, *format, *samples, *channels );
 
 	// Get the producer's audio
-	int error = mlt_frame_get_audio( frame, buffer, &in_format, &in_frequency, &in_channels, samples );
+	int error = mlt_frame_get_audio( frame, &in.data, &in.format, &in.frequency, &in.channels, &in.samples );
 	if ( error ||
-			in_format == mlt_audio_none || out_format == mlt_audio_none ||
-			in_frequency <= 0 || out_frequency <= 0 ||
-			in_channels <= 0 || out_channels <= 0 )
+			in.format == mlt_audio_none || out.format == mlt_audio_none ||
+			in.frequency <= 0 || out.frequency <= 0 ||
+			in.channels <= 0 || out.channels <= 0 )
 	{
 		// Error situation. Do not attempt to convert.
-		*format = in_format;
-		*frequency = in_frequency;
-		*channels = in_channels;
-		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid Parameters: %dS - %dHz %dC %s -> %dHz %dC %s\n", *samples, in_frequency, in_channels, mlt_audio_format_name( in_format ), out_frequency, out_channels, mlt_audio_format_name( out_format ) );
+		mlt_audio_get_values( &in, buffer, frequency, format, samples, channels );
+		mlt_log_error( MLT_FILTER_SERVICE(filter), "Invalid Parameters: %dS - %dHz %dC %s -> %dHz %dC %s\n", in.samples, in.frequency, in.channels, mlt_audio_format_name( in.format ), out.frequency, out.channels, mlt_audio_format_name( out.format ) );
 		return error;
 	}
 
-	if (*samples == 0)
+	if (in.samples == 0)
 	{
 		// Noting to convert.
 		return error;
 	}
 
 	// Determine the input/output channel layout.
-	in_layout = mlt_get_channel_layout_or_default( mlt_properties_get( frame_properties, "channel_layout" ), in_channels );
-	out_layout = mlt_get_channel_layout_or_default( mlt_properties_get( frame_properties, "consumer_channel_layout" ), out_channels );
+	in.layout = mlt_get_channel_layout_or_default( mlt_properties_get( frame_properties, "channel_layout" ), in.channels );
+	out.layout = mlt_get_channel_layout_or_default( mlt_properties_get( frame_properties, "consumer_channel_layout" ), out.channels );
 
-	if( in_format == out_format &&
-		in_frequency == out_frequency &&
-		in_channels == out_channels &&
-		in_layout == out_layout )
+	if( in.format == out.format &&
+		in.frequency == out.frequency &&
+		in.channels == out.channels &&
+		in.layout == out.layout )
 	{
 		// No change necessary
+		mlt_audio_get_values( &in, buffer, frequency, format, samples, channels );
 		return error;
 	}
 
@@ -236,62 +174,55 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 
 	// Detect configuration change
 	if( !pdata->ctx ||
-		pdata->in_format != in_format ||
-		pdata->out_format != out_format ||
-		pdata->in_frequency != in_frequency ||
-		pdata->out_frequency != out_frequency ||
-		pdata->in_channels != in_channels ||
-		pdata->out_channels != out_channels ||
-		pdata->in_layout != in_layout ||
-		pdata->out_layout != out_layout )
+		pdata->in_format != in.format ||
+		pdata->out_format != out.format ||
+		pdata->in_frequency != in.frequency ||
+		pdata->out_frequency != out.frequency ||
+		pdata->in_channels != in.channels ||
+		pdata->out_channels != out.channels ||
+		pdata->in_layout != in.layout ||
+		pdata->out_layout != out.layout )
 	{
 		// Save the configuration
-		pdata->in_format = in_format;
-		pdata->out_format = out_format;
-		pdata->in_frequency = in_frequency;
-		pdata->out_frequency = out_frequency;
-		pdata->in_channels = in_channels;
-		pdata->out_channels = out_channels;
-		pdata->in_layout = in_layout;
-		pdata->out_layout = out_layout;
+		pdata->in_format = in.format;
+		pdata->out_format = out.format;
+		pdata->in_frequency = in.frequency;
+		pdata->out_frequency = out.frequency;
+		pdata->in_channels = in.channels;
+		pdata->out_channels = out.channels;
+		pdata->in_layout = in.layout;
+		pdata->out_layout = out.layout;
 		// Reconfigure the context
 		error = configure_swr_context( filter );
 	}
 
 	if( !error )
 	{
-		int in_samples = *samples;
-		int out_samples = 0;
-		int alloc_samples = in_samples;
-		if( in_frequency != out_frequency )
+		if( in.frequency != out.frequency )
 		{
 			// Number of output samples will change if sampling frequency changes.
-			uint64_t tmp = (uint64_t)in_samples * (uint64_t)out_frequency / (uint64_t)in_frequency;
-			alloc_samples = (int)tmp;
+			uint64_t tmp = (uint64_t)in.samples * (uint64_t)out.frequency / (uint64_t)in.frequency;
+			out.samples = (int)tmp;
 			// Round up to make sure all available samples are received from swresample.
-			alloc_samples += 1;
+			out.samples += 1;
 		}
-		int size = mlt_audio_format_size( out_format, alloc_samples, out_channels );
-		uint8_t* out_buffer = mlt_pool_alloc( size );
+		mlt_audio_alloc_data( &out );
 
-		audio_format_planes( in_format, in_samples, in_channels, *buffer, pdata->in_buffers );
-		audio_format_planes( out_format, alloc_samples, out_channels, out_buffer, pdata->out_buffers );
+		mlt_audio_get_planes( &in, pdata->in_buffers );
+		mlt_audio_get_planes( &out, pdata->out_buffers );
 
-		out_samples = swr_convert( pdata->ctx, pdata->out_buffers, alloc_samples, (const uint8_t**)pdata->in_buffers, in_samples );
-		if( out_samples > 0 )
+		int received_samples = swr_convert( pdata->ctx, pdata->out_buffers, out.samples, (const uint8_t**)pdata->in_buffers, in.samples );
+		if( received_samples > 0 )
 		{
-			collapse_channels( out_format, out_channels, alloc_samples, out_samples, out_buffer );
-			mlt_frame_set_audio( frame, out_buffer, out_format, size, mlt_pool_release );
-			*buffer = out_buffer;
-			*samples = out_samples;
-			*format = out_format;
-			*channels = out_channels;
-			mlt_properties_set( frame_properties, "channel_layout", mlt_channel_layout_name( pdata->out_layout ) );
+			mlt_audio_shrink( &out, received_samples );
+			mlt_frame_set_audio( frame, out.data, out.format, 0, out.release_data );
+			mlt_audio_get_values( &out, buffer, frequency, format, samples, channels );
+			mlt_properties_set( frame_properties, "channel_layout", mlt_channel_layout_name( out.layout ) );
 		}
 		else
 		{
-			mlt_log_error( MLT_FILTER_SERVICE(filter), "swr_convert() failed. Alloc: %d\tIn: %d\tOut: %d\n", alloc_samples, in_samples, out_samples );
-			mlt_pool_release( out_buffer );
+			mlt_log_error( MLT_FILTER_SERVICE(filter), "swr_convert() failed. Alloc: %d\tIn: %d\tOut: %d\n", out.samples, in.samples, received_samples );
+			out.release_data( out.data );
 			error = 1;
 		}
 	}

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -2619,7 +2619,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 		index = 0;
 		index_max = FFMIN( MAX_AUDIO_STREAMS, context->nb_streams );
 		*channels = self->total_channels;
-		*samples = mlt_sample_calculator( fps, self->max_frequency, position );
+		*samples = mlt_audio_calculate_frame_samples( fps, self->max_frequency, position );
 		*frequency = self->max_frequency;
 	}
 
@@ -2656,7 +2656,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 		
 		// Caller requested number samples based on requested sample rate.
 		if ( self->audio_index != INT_MAX )
-			*samples = mlt_sample_calculator( fps, self->audio_codec[ self->audio_index ]->sample_rate, position );
+			*samples = mlt_audio_calculate_frame_samples( fps, self->audio_codec[ self->audio_index ]->sample_rate, position );
 
 		while ( ret >= 0 && !got_audio )
 		{
@@ -2761,7 +2761,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 					break;
 				}
 		}
-		mlt_properties_set( MLT_FRAME_PROPERTIES(frame), "channel_layout", mlt_channel_layout_name( layout ) );
+		mlt_properties_set( MLT_FRAME_PROPERTIES(frame), "channel_layout", mlt_audio_channel_layout_name( layout ) );
 
 		// Allocate and set the frame's audio buffer
 		int size = mlt_audio_format_size( *format, *samples, *channels );

--- a/src/modules/core/consumer_multi.c
+++ b/src/modules/core/consumer_multi.c
@@ -367,7 +367,7 @@ static void foreach_consumer_put( mlt_consumer consumer, mlt_frame frame )
 			mlt_audio_format format = mlt_audio_s16;
 			int channels = mlt_properties_get_int( properties, "channels" );
 			int frequency = mlt_properties_get_int( properties, "frequency" );
-			int current_samples = mlt_sample_calculator( self_fps, frequency, self_pos );
+			int current_samples = mlt_audio_calculate_frame_samples( self_fps, frequency, self_pos );
 			mlt_frame_get_audio( frame, (void**) &buffer, &format, &frequency, &channels, &current_samples );
 			int current_size = mlt_audio_format_size( format, current_samples, channels );
 
@@ -391,7 +391,7 @@ static void foreach_consumer_put( mlt_consumer consumer, mlt_frame frame )
 				int deeply = index > 1 ? 1 : 0;
 				mlt_frame clone_frame = mlt_frame_clone( frame, deeply );
 				mlt_properties clone_props = MLT_FRAME_PROPERTIES( clone_frame );
-				int nested_samples = mlt_sample_calculator( nested_fps, frequency, nested_pos );
+				int nested_samples = mlt_audio_calculate_frame_samples( nested_fps, frequency, nested_pos );
 				// -10 is an optimization to avoid tiny amounts of leftover samples
 				nested_samples = nested_samples > current_samples - 10 ? current_samples : nested_samples;
 				int nested_size = mlt_audio_format_size( format, nested_samples, channels );

--- a/src/modules/core/producer_consumer.c
+++ b/src/modules/core/producer_consumer.c
@@ -85,7 +85,7 @@ static int get_audio( mlt_frame frame, void **buffer, mlt_audio_format *format, 
 			fps = mlt_producer_get_fps( cx->self );
 			mlt_properties_set_double( MLT_FRAME_PROPERTIES(nested_frame), "producer_consumer_fps", fps );
 		}
-		*samples = mlt_sample_calculator( fps, *frequency, cx->audio_counter++ );
+		*samples = mlt_audio_calculate_frame_samples( fps, *frequency, cx->audio_counter++ );
 		result = mlt_frame_get_audio( nested_frame, buffer, format, frequency, channels, samples );
 		int size = mlt_audio_format_size( *format, *samples, *channels );
 		int16_t *new_buffer = mlt_pool_alloc( size );

--- a/src/modules/core/producer_tone.c
+++ b/src/modules/core/producer_tone.c
@@ -36,7 +36,7 @@ static int producer_get_audio( mlt_frame frame, int16_t** buffer, mlt_audio_form
 	*format = mlt_audio_float;
 	*frequency = *frequency <= 0 ? 48000 : *frequency;
 	*channels = *channels <= 0 ? 2 : *channels;
-	*samples = *samples <= 0 ? mlt_sample_calculator( fps, *frequency, position ) : *samples;
+	*samples = *samples <= 0 ? mlt_audio_calculate_frame_samples( fps, *frequency, position ) : *samples;
 
 	// Allocate the buffer
 	int size = *samples * *channels * sizeof( float );
@@ -45,7 +45,7 @@ static int producer_get_audio( mlt_frame frame, int16_t** buffer, mlt_audio_form
 	// Fill the buffer
 	int s = 0;
 	int c = 0;
-	long double first_sample = mlt_sample_calculator_to_now( fps, *frequency, position );
+	long double first_sample = mlt_audio_calculate_samples_to_position( fps, *frequency, position );
 	float a = mlt_properties_anim_get_double( producer_properties, "level", position, length );
 	long double f = mlt_properties_anim_get_double( producer_properties, "frequency", position, length );
 	long double p = mlt_properties_anim_get_double( producer_properties, "phase", position, length );

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -710,7 +710,7 @@ protected:
 			uint64_t m_count = mlt_properties_get_int64( properties, "m_count" );
 			mlt_audio_format format = mlt_audio_s16;
 			int frequency = bmdAudioSampleRate48kHz;
-			int samples = mlt_sample_calculator( m_fps, frequency, m_count );
+			int samples = mlt_audio_calculate_frame_samples( m_fps, frequency, m_count );
 			int16_t *pcm = 0;
 
 			if ( !mlt_frame_get_audio( frame, (void**) &pcm, &format, &frequency, &m_inChannels, &samples ) )

--- a/src/modules/dv/consumer_libdv.c
+++ b/src/modules/dv/consumer_libdv.c
@@ -275,7 +275,7 @@ static void consumer_encode_audio( mlt_consumer this, uint8_t *dv_frame, mlt_fra
 		mlt_audio_format fmt = mlt_audio_s16;
 		int channels = 2;
 		int frequency = mlt_properties_get_int( this_properties, "frequency" );
-		int samples = mlt_sample_calculator( mlt_properties_get_double( this_properties, "fps" ), frequency, count );
+		int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( this_properties, "fps" ), frequency, count );
 		int16_t *pcm = NULL;
 
 		// Get the frame number

--- a/src/modules/jackrack/consumer_jack.c
+++ b/src/modules/jackrack/consumer_jack.c
@@ -310,7 +310,7 @@ static int consumer_play_audio( consumer_jack self, mlt_frame frame, int init_au
 	int channels = mlt_properties_get_int( properties, "channels" );
 	int frequency = mlt_properties_get_int( properties, "frequency" );
 	int scrub = mlt_properties_get_int( properties, "scrub_audio" );
-	int samples = mlt_sample_calculator( mlt_properties_get_double( properties, "fps" ), frequency, self->counter++ );
+	int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( properties, "fps" ), frequency, self->counter++ );
 	float *buffer;
 
 	mlt_frame_get_audio( frame, (void**) &buffer, &afmt, &frequency, &channels, &samples );

--- a/src/modules/linsys/consumer_SDIstream.c
+++ b/src/modules/linsys/consumer_SDIstream.c
@@ -451,7 +451,7 @@ static void *consumer_thread(void *arg) {
 				mlt_frame_get_image(frame, &video_buffer, &this->pix_fmt, &this->width, &this->height, 1);
 
 				// Get the audio from this frame and save it to our audio_buffer
-				samples = mlt_sample_calculator(fps, frequency, count++);
+				samples = mlt_audio_calculate_frame_samples(fps, frequency, count++);
 				mlt_frame_get_audio(frame, (void**) &audio_buffer_tmp, &this->audio_format.aformat, &frequency, &channels, &samples);
 
 				this->audio_format.sample_rate = frequency;

--- a/src/modules/ndi/consumer_ndi.c
+++ b/src/modules/ndi/consumer_ndi.c
@@ -190,7 +190,7 @@ static void* consumer_ndi_feeder( void* p )
 				mlt_audio_format aformat = mlt_audio_s16;
 				int frequency = 48000;
 				int m_channels = 2;
-				int samples = mlt_sample_calculator( mlt_profile_fps( profile ), frequency, self->count );
+				int samples = mlt_audio_calculate_frame_samples( mlt_profile_fps( profile ), frequency, self->count );
 				int16_t *pcm = 0;
 
 				if ( !mlt_frame_get_audio( frm, (void**) &pcm, &aformat, &frequency, &m_channels, &samples ) )

--- a/src/modules/plus/consumer_blipflash.c
+++ b/src/modules/plus/consumer_blipflash.c
@@ -195,7 +195,7 @@ static void detect_flash( mlt_frame frame, mlt_position pos, double fps, avsync_
 	if( stats->flash )
 	{
 		stats->flash_history[1] = stats->flash_history[0];
-		stats->flash_history[0] = mlt_sample_calculator_to_now( fps, SAMPLE_FREQ, pos );
+		stats->flash_history[0] = mlt_audio_calculate_samples_to_position( fps, SAMPLE_FREQ, pos );
 		if( stats->flash_history_count < 2 )
 		{
 			stats->flash_history_count++;
@@ -207,7 +207,7 @@ static void detect_blip( mlt_frame frame, mlt_position pos, double fps, avsync_s
 {
 	int frequency = SAMPLE_FREQ;
 	int channels = 1;
-	int samples = mlt_sample_calculator( fps, frequency, pos );
+	int samples = mlt_audio_calculate_frame_samples( fps, frequency, pos );
 	mlt_audio_format format = mlt_audio_float;
 	float* buffer = NULL;
 	int error = mlt_frame_get_audio( frame, (void**) &buffer, &format, &frequency, &channels, &samples );
@@ -227,7 +227,7 @@ static void detect_blip( mlt_frame frame, mlt_position pos, double fps, avsync_s
 					stats->samples_since_blip = 0;
 
 					stats->blip_history[1] = stats->blip_history[0];
-					stats->blip_history[0] = mlt_sample_calculator_to_now( fps, SAMPLE_FREQ, pos );
+					stats->blip_history[0] = mlt_audio_calculate_samples_to_position( fps, SAMPLE_FREQ, pos );
 					stats->blip_history[0] += i;
 					if( stats->blip_history_count < 2 )
 					{

--- a/src/modules/plus/producer_blipflash.c
+++ b/src/modules/plus/producer_blipflash.c
@@ -78,7 +78,7 @@ static int producer_get_audio( mlt_frame frame, int16_t** buffer, mlt_audio_form
 	*format = mlt_audio_float;
 	*frequency = *frequency <= 0 ? 48000 : *frequency;
 	*channels = *channels <= 0 ? 2 : *channels;
-	*samples = *samples <= 0 ? mlt_sample_calculator( fps, *frequency, frames ) : *samples;
+	*samples = *samples <= 0 ? mlt_audio_calculate_frame_samples( fps, *frequency, frames ) : *samples;
 
 	// Allocate the buffer
 	*buffer = mlt_pool_alloc( size );

--- a/src/modules/plus/producer_count.c
+++ b/src/modules/plus/producer_count.c
@@ -134,7 +134,7 @@ static int producer_get_audio( mlt_frame frame, int16_t** buffer, mlt_audio_form
 	*format = mlt_audio_float;
 	*frequency = *frequency <= 0 ? 48000 : *frequency;
 	*channels = *channels <= 0 ? 2 : *channels;
-	*samples = *samples <= 0 ? mlt_sample_calculator( fps, *frequency, position ) : *samples;
+	*samples = *samples <= 0 ? mlt_audio_calculate_frame_samples( fps, *frequency, position ) : *samples;
 
 	// Allocate the buffer
 	size = *samples * *channels * sizeof( float );

--- a/src/modules/qt/filter_audiowaveform.cpp
+++ b/src/modules/qt/filter_audiowaveform.cpp
@@ -105,7 +105,7 @@ static int filter_get_audio( mlt_frame frame, void** buffer, mlt_audio_format* f
 		mlt_log_info( MLT_FILTER_SERVICE(filter), "Reset window buffer: %d.\n", mlt_properties_get_int( MLT_FILTER_PROPERTIES( filter ), "window" ) );
 		mlt_profile profile = mlt_service_profile( MLT_FILTER_SERVICE( filter ) );
 		double fps = mlt_profile_fps( profile );
-		int frame_samples = mlt_sample_calculator( fps, *frequency, mlt_frame_get_position( frame ) );
+		int frame_samples = mlt_audio_calculate_frame_samples( fps, *frequency, mlt_frame_get_position( frame ) );
 		int window_ms = mlt_properties_get_int( MLT_FILTER_PROPERTIES( filter ), "window" );
 		pdata->window_frequency = *frequency;
 		pdata->window_channels = *channels;

--- a/src/modules/rtaudio/consumer_rtaudio.cpp
+++ b/src/modules/rtaudio/consumer_rtaudio.cpp
@@ -573,7 +573,7 @@ public:
 		int frequency = mlt_properties_get_int( properties, "frequency" );
 		int scrub = mlt_properties_get_int( properties, "scrub_audio" );
 		static int counter = 0;
-		int samples = mlt_sample_calculator( mlt_properties_get_double( properties, "fps" ), frequency, counter++ );
+		int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( properties, "fps" ), frequency, counter++ );
 		int16_t *pcm;
 
 		mlt_frame_get_audio( frame, (void**) &pcm, &afmt, &frequency, &channels, &samples );

--- a/src/modules/sdl/consumer_sdl.c
+++ b/src/modules/sdl/consumer_sdl.c
@@ -411,7 +411,7 @@ static int consumer_play_audio( consumer_sdl self, mlt_frame frame, int init_aud
 	int scrub = mlt_properties_get_int( properties, "scrub_audio" );
 	static int counter = 0;
 
-	int samples = mlt_sample_calculator( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
+	int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
 	int16_t *pcm;
 	mlt_frame_get_audio( frame, (void**) &pcm, &afmt, &frequency, &channels, &samples );
 	*duration = ( ( samples * 1000 ) / frequency );

--- a/src/modules/sdl/consumer_sdl_audio.c
+++ b/src/modules/sdl/consumer_sdl_audio.c
@@ -311,7 +311,7 @@ static int consumer_play_audio( consumer_sdl self, mlt_frame frame, int init_aud
 	int scrub = mlt_properties_get_int( properties, "scrub_audio" );
 	static int counter = 0;
 
-	int samples = mlt_sample_calculator( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
+	int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
 	int16_t *pcm;
 	mlt_frame_get_audio( frame, (void**) &pcm, &afmt, &frequency, &channels, &samples );
 	*duration = ( ( samples * 1000 ) / frequency );

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -368,7 +368,7 @@ static int consumer_play_audio( consumer_sdl self, mlt_frame frame, int init_aud
 	int scrub = mlt_properties_get_int( properties, "scrub_audio" );
 	static int counter = 0;
 
-	int samples = mlt_sample_calculator( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
+	int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
 	int16_t *pcm;
 	mlt_frame_get_audio( frame, (void**) &pcm, &afmt, &frequency, &channels, &samples );
 	*duration = ( ( samples * 1000 ) / frequency );

--- a/src/modules/sdl2/consumer_sdl2_audio.c
+++ b/src/modules/sdl2/consumer_sdl2_audio.c
@@ -311,7 +311,7 @@ static int consumer_play_audio( consumer_sdl self, mlt_frame frame, int init_aud
 	int scrub = mlt_properties_get_int( properties, "scrub_audio" );
 	static int counter = 0;
 
-	int samples = mlt_sample_calculator( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
+	int samples = mlt_audio_calculate_frame_samples( mlt_properties_get_double( self->properties, "fps" ), frequency, counter++ );
 	int16_t *pcm;
 	mlt_frame_get_audio( frame, (void**) &pcm, &afmt, &frequency, &channels, &samples );
 	*duration = 1000000LL * samples / frequency;

--- a/src/modules/vorbis/producer_vorbis.c
+++ b/src/modules/vorbis/producer_vorbis.c
@@ -289,7 +289,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 		int current_section;
 
 		// Get the number of samples for the current frame
-		*samples = mlt_sample_calculator( fps, *frequency, expected ++ );
+		*samples = mlt_audio_calculate_frame_samples( fps, *frequency, expected ++ );
 
 		while( *samples > audio_used  )
 		{
@@ -309,7 +309,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 				ignore --;
 				audio_used -= *samples;
 				memmove( audio_buffer, &audio_buffer[ *samples * *channels ], audio_used * sizeof( int16_t ) * *channels );
-				*samples = mlt_sample_calculator( fps, *frequency, expected ++ );
+				*samples = mlt_audio_calculate_frame_samples( fps, *frequency, expected ++ );
 			}
 		}
 
@@ -337,7 +337,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 	else
 	{
 		// Get silence and don't touch the context
-		*samples = mlt_sample_calculator( fps, *frequency, position );
+		*samples = mlt_audio_calculate_frame_samples( fps, *frequency, position );
 		mlt_frame_get_audio( frame, buffer, format, frequency, channels, samples );
 	}
 

--- a/src/tests/test_audio/test_audio.cpp
+++ b/src/tests/test_audio/test_audio.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with consumer library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <QString>
+#include <QtTest>
+
+#include <mlt++/Mlt.h>
+using namespace Mlt;
+
+class TestAudio : public QObject
+{
+	Q_OBJECT
+
+private Q_SLOTS:
+
+	void DefaultConstructor()
+	{
+		Audio a;
+		QVERIFY(a.samples() == 0);
+	}
+
+	void ConstructFromAudio()
+	{
+		mlt_audio audio = mlt_audio_new();
+		audio->samples = 500;
+		Audio a(audio);
+		QVERIFY(a.samples() == 500);
+	}
+
+	void GetSetData()
+	{
+		Audio a;
+		void* data = malloc(500);
+		a.set_data(data);
+		QVERIFY(a.data() == data);
+		free(data);
+		a.set_data(nullptr);
+	}
+};
+
+QTEST_APPLESS_MAIN(TestAudio)
+
+#include "test_audio.moc"

--- a/src/tests/test_audio/test_audio.pro
+++ b/src/tests/test_audio/test_audio.pro
@@ -1,0 +1,3 @@
+include(../common.pri)
+TARGET = test_audio
+SOURCES += test_audio.cpp

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -1,5 +1,6 @@
 TEMPLATE = subdirs
-SUBDIRS = test_filter \
+SUBDIRS = test_audio \
+    test_filter \
     test_events \
     test_frame \
     test_playlist \


### PR DESCRIPTION
This is a proposal in response to this comment:
https://github.com/mltframework/mlt/pull/546#discussion_r411089520
In the future, the various interface functions could be modified to pass a pointer to this audio object instead of passing many variables. In addition, the channel layout is added, so it does not need to be passed "out of band" as a frame property.

I chose to implement it in some of the filters to demonstrate all the function reuse that would benefit from something like this.