### PR TITLE
DYLD_LIBRARY_PATH is required on Darwin for tests

### DIFF
--- a/setenv
+++ b/setenv
@@ -11,6 +11,6 @@ export LD_LIBRARY_PATH=\
 `pwd`/src/mlt++:\
 $LD_LIBRARY_PATH
 
-#[ $(uname -s) = Darwin ] && export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+[ $(uname -s) = Darwin ] && export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 export PATH=`pwd`/src/melt:$PATH


### PR DESCRIPTION
On Mac OS(Darwin), setting DYLD_LIBRARY_PATH should *always* be done with setenv, otherwise melt will attempt to link against the expected system install location for libmlt (i.e. /usr/local/lib/libmlt.6.dylib) which will either break or yield unexpected results (testing against older library).  

Without  DYLD_LIBRARY_PATH being set on a clean system, melt will fail to run:
```
bash-3.2$ pwd
/Users/deftdawg/source/mlt
bash-3.2$ which melt
bash-3.2$ . setenv
bash-3.2$ melt
dyld: Library not loaded: /usr/local/lib/libmlt.6.dylib
  Referenced from: /Users/deftdawg/source/mlt/src/melt/melt
  Reason: image not found
Abort trap: 6
bash-3.2$ find . | grep libmlt.6.dylib
./src/framework/libmlt.6.dylib
```

On a system that has libmlt.6.dylib, strange errors may occur as the new executable you wish to test trys to work with an older library:
```
bash-3.2$ pwd
/Users/deftdawg/source/mlt
bash-3.2$ which melt
/usr/local/bin/melt
bash-3.2$ . setenv
bash-3.2$ melt -query filters | grep qt
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltcore.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltcore.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltcore.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
``` 
^---  This is not the library that should be linked when testing a new build
``` 
in /Users/deftdawg/source/mlt/src/modules/libmltcore.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltsdl2.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltsdl2.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltsdl2.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltsdl2.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltdecklink.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltdecklink.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltdecklink.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltdecklink.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltqt.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltqt.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltqt.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltqt.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltplus.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltplus.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltplus.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltplus.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltavformat.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltavformat.dylib, 2): Symbol not found: _mlt_audio_alloc_data
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltavformat.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltavformat.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltvorbis.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltvorbis.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltvorbis.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltvorbis.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltrubberband.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltrubberband.dylib, 2): Symbol not found: _mlt_audio_alloc_data
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltrubberband.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltrubberband.dylib)
mlt_repository_init: failed to dlopen /Users/deftdawg/source/mlt/src/modules/libmltrtaudio.dylib
  (dlopen(/Users/deftdawg/source/mlt/src/modules/libmltrtaudio.dylib, 2): Symbol not found: _mlt_audio_calculate_frame_samples
  Referenced from: /Users/deftdawg/source/mlt/src/modules/libmltrtaudio.dylib
  Expected in: /usr/local/lib/libmlt.6.dylib
 in /Users/deftdawg/source/mlt/src/modules/libmltrtaudio.dylib)
```