### PR TITLE
Optimize Qimage producer

### DIFF
--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -64,19 +64,6 @@ mlt_producer producer_qimage_init( mlt_profile profile, mlt_service_type type, c
 		// Get the properties interface
 		mlt_properties properties = MLT_PRODUCER_PROPERTIES( &self->parent );
 	
-		// Initialize KDE image plugins
-		if ( !init_qimage( filename ) )
-		{
-			// Reject if animation.
-			mlt_producer_close( producer );
-			free( self );
-			return NULL;
-		}
-
-		// Callback registration
-		producer->get_frame = producer_get_frame;
-		producer->close = ( mlt_destructor )producer_close;
-
 		// Set the default properties
 		mlt_properties_set( properties, "resource", filename );
 		mlt_properties_set_int( properties, "ttl", 25 );
@@ -87,28 +74,28 @@ mlt_producer producer_qimage_init( mlt_profile profile, mlt_service_type type, c
 		// Validate the resource
 		if ( filename )
 			load_filenames( self, properties );
-		if ( self->count )
+
+		// Initialize KDE image plugins and load first image to define meta.media.width/height
+		if ( self->count == 0 || !init_qimage( mlt_properties_get_value( self->filenames, 0 ), producer ) )
 		{
-			mlt_frame frame = mlt_frame_init( MLT_PRODUCER_SERVICE( producer ) );
-			if ( frame )
-			{
-				mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
-				mlt_properties_set_data( frame_properties, "producer_qimage", self, 0, NULL, NULL );
-				mlt_frame_set_position( frame, mlt_producer_position( producer ) );
-				refresh_qimage( self, frame );
-				mlt_cache_item_close( self->qimage_cache );
-				mlt_frame_close( frame );
-			}
+			// Reject if animation or incorrect image
+			mlt_producer_close( producer );
+			free( self );
+			return NULL;
 		}
-		if ( self->current_width == 0 )
-		{
-			producer_close( producer );
-			producer = NULL;
-		}
-		else
-		{
-			mlt_events_listen( properties, self, "property-changed", (mlt_listener) on_property_changed );
-		}
+
+		// Callback registration
+		producer->get_frame = producer_get_frame;
+		producer->close = ( mlt_destructor )producer_close;
+
+		// Initialize default vars
+		self->qimage_idx = -1;
+		self->image_idx = -1;
+		self->qimage = NULL;
+		self->current_image = NULL;
+
+		mlt_events_listen( properties, self, "property-changed", (mlt_listener) on_property_changed );
+
 		return producer;
 	}
 	free( self );
@@ -234,13 +221,17 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 
 	mlt_service_lock( MLT_PRODUCER_SERVICE( &self->parent ) );
 
-	// Refresh the image
-	self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
-	self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
-	self->image_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.image" );
-	self->current_image = mlt_cache_item_data( self->image_cache, NULL );
-	self->alpha_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha" );
-	self->current_alpha = mlt_cache_item_data( self->alpha_cache, &self->alpha_size );
+	// Don't use cache for 1 frame image sequences
+	if ( self->ttl > 1 )
+	{
+		// Refresh the image
+		self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
+		self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
+		self->image_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.image" );
+		self->current_image = mlt_cache_item_data( self->image_cache, NULL );
+		self->alpha_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha" );
+		self->current_alpha = mlt_cache_item_data( self->alpha_cache, &self->alpha_size );
+	}
 	refresh_image( self, frame, *format, *width, *height );
 
 	// Get width and height (may have changed during the refresh)
@@ -252,24 +243,39 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	// The fault is not in the design of mlt, but in the implementation of the qimage producer...
 	if ( self->current_image )
 	{
-		// Clone the image and the alpha
 		int image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
-		uint8_t *image_copy = mlt_pool_alloc( image_size );
-		memcpy( image_copy, self->current_image, image_size );
-		// Now update properties so we free the copy after
-		mlt_frame_set_image( frame, image_copy, image_size, mlt_pool_release );
-		// We're going to pass the copy on
-		*buffer = image_copy;
-		mlt_log_debug( MLT_PRODUCER_SERVICE( &self->parent ), "%dx%d (%s)\n",
-			self->current_width, self->current_height, mlt_image_format_name( *format ) );
-		// Clone the alpha channel
-		if ( self->current_alpha )
+		if ( self->ttl > 1 )
 		{
-            if ( !self->alpha_size )
-                self->alpha_size = self->current_width * self->current_height;
-			uint8_t * alpha_copy = mlt_pool_alloc( self->alpha_size );
-			memcpy( alpha_copy, self->current_alpha, self->alpha_size );
-			mlt_frame_set_alpha( frame, alpha_copy, self->alpha_size, mlt_pool_release );
+			// Clone the image and the alpha
+			uint8_t *image_copy = mlt_pool_alloc( image_size );
+			memcpy( image_copy, self->current_image, image_size );
+			// Now update properties so we free the copy after
+			mlt_frame_set_image( frame, image_copy, image_size, mlt_pool_release );
+			// We're going to pass the copy on
+			*buffer = image_copy;
+			mlt_log_debug( MLT_PRODUCER_SERVICE( &self->parent ), "%dx%d (%s)\n",
+				self->current_width, self->current_height, mlt_image_format_name( *format ) );
+			// Clone the alpha channel
+			if ( self->current_alpha )
+			{
+				if ( !self->alpha_size )
+					self->alpha_size = self->current_width * self->current_height;
+				uint8_t * alpha_copy = mlt_pool_alloc( self->alpha_size );
+				memcpy( alpha_copy, self->current_alpha, self->alpha_size );
+				mlt_frame_set_alpha( frame, alpha_copy, self->alpha_size, mlt_pool_release );
+			}
+		}
+		else
+		{
+			// For ttl = 1 we recreate self->current_image on each frame, no need to clone
+			mlt_frame_set_image( frame, self->current_image, image_size, mlt_pool_release );
+			*buffer = self->current_image;
+			if ( self->current_alpha )
+			{
+				if ( !self->alpha_size )
+					self->alpha_size = self->current_width * self->current_height;
+				mlt_frame_set_alpha( frame, self->current_alpha, self->alpha_size, mlt_pool_release );
+			}
 		}
 	}
 	else
@@ -278,11 +284,13 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	}
 
 	// Release references and locks
-	mlt_cache_item_close( self->qimage_cache );
-	mlt_cache_item_close( self->image_cache );
-	mlt_cache_item_close( self->alpha_cache );
+	if ( self->ttl > 1 )
+	{
+		mlt_cache_item_close( self->qimage_cache );
+		mlt_cache_item_close( self->image_cache );
+		mlt_cache_item_close( self->alpha_cache );
+	}
 	mlt_service_unlock( MLT_PRODUCER_SERVICE( &self->parent ) );
-
 	return error;
 }
 
@@ -305,17 +313,14 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		// Obtain properties of frame and producer
 		mlt_properties properties = MLT_FRAME_PROPERTIES( *frame );
 
+		// Get the time to live for each frame
+		self->ttl = mlt_properties_get_int( producer_properties, "ttl" );
+
 		// Set the producer on the frame properties
 		mlt_properties_set_data( properties, "producer_qimage", self, 0, NULL, NULL );
 
 		// Update timecode on the frame we're creating
 		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
-
-		// Refresh the image
-		self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
-		self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
-		refresh_qimage( self, *frame );
-		mlt_cache_item_close( self->qimage_cache );
 
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( producer_properties, "progressive" ) );

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -32,7 +32,6 @@
 #include <QtEndian>
 #include <QTemporaryFile>
 #include <QImageReader>
-#include <QDebug>
 
 #ifdef USE_EXIF
 #include <libexif/exif-data.h>

--- a/src/modules/qt/qimage_wrapper.h
+++ b/src/modules/qt/qimage_wrapper.h
@@ -37,6 +37,7 @@ struct producer_qimage_s
 	int count;
 	int image_idx;
 	int qimage_idx;
+	int ttl;
 	uint8_t *current_image;
 	uint8_t *current_alpha;
 	int current_width;
@@ -51,10 +52,9 @@ struct producer_qimage_s
 
 typedef struct producer_qimage_s *producer_qimage;
 
-extern int refresh_qimage( producer_qimage self, mlt_frame frame );
 extern void refresh_image( producer_qimage, mlt_frame, mlt_image_format, int width, int height );
 extern void make_tempfile( producer_qimage, const char *xml );
-extern int init_qimage(const char *filename);
+extern int init_qimage(const char *filename, mlt_producer producer);
 extern int load_sequence_sprintf( producer_qimage self, mlt_properties properties, const char *filename );
 
 


### PR DESCRIPTION
Looking at the QImage producer, I found several bottlenecks that I could improve:

* Slightly faster check if image is readable on producer init (use QImageReader methods only to check image size and ensure it is readable instead of loading full image)

* When transferring the QImage data, use the QImage::Format_RGBA8888 or QImage::Format_RGB888 to copy the image in one pass instead of doing a pixel copy
* Disable caching for ttl=1 (image sequences with 1 image/frame). Caching scaled image does not make sense if we have an image sequence with 1 image/frame. Disable caching for those provides a noticeable speedup, in Kdenlive these sequences can now play at 20fps instead of 7fps on my machine.

Since this touches a rather important MLT component, comments are welcome.