### PR TITLE
QImage: speedup by disabling cache for 1 frame image sequence

### DIFF
--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -95,8 +95,12 @@ mlt_producer producer_qimage_init( mlt_profile profile, mlt_service_type type, c
 				mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
 				mlt_properties_set_data( frame_properties, "producer_qimage", self, 0, NULL, NULL );
 				mlt_frame_set_position( frame, mlt_producer_position( producer ) );
-				refresh_qimage( self, frame );
-				mlt_cache_item_close( self->qimage_cache );
+				int enable_caching = self->count == 1;
+				refresh_qimage( self, frame, enable_caching );
+				if ( enable_caching )
+				{
+					mlt_cache_item_close( self->qimage_cache );
+				}
 				mlt_frame_close( frame );
 			}
 		}
@@ -231,17 +235,20 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 		*width = mlt_properties_get_int( properties, "rescale_width" );
 	if ( mlt_properties_get_int( properties, "rescale_height" ) > 0 )
 		*height = mlt_properties_get_int( properties, "rescale_height" );
-
 	mlt_service_lock( MLT_PRODUCER_SERVICE( &self->parent ) );
+	int enable_caching = ( self->count <= 1 || mlt_properties_get_int( MLT_PRODUCER_PROPERTIES( producer ), "ttl" ) > 1 );
 
 	// Refresh the image
-	self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
-	self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
-	self->image_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.image" );
-	self->current_image = mlt_cache_item_data( self->image_cache, NULL );
-	self->alpha_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha" );
-	self->current_alpha = mlt_cache_item_data( self->alpha_cache, &self->alpha_size );
-	refresh_image( self, frame, *format, *width, *height );
+	if ( enable_caching )
+	{
+		self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
+		self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
+		self->image_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.image" );
+		self->current_image = mlt_cache_item_data( self->image_cache, NULL );
+		self->alpha_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha" );
+		self->current_alpha = mlt_cache_item_data( self->alpha_cache, &self->alpha_size );
+	}
+	refresh_image( self, frame, *format, *width, *height, enable_caching );
 
 	// Get width and height (may have changed during the refresh)
 	*width = mlt_properties_get_int( properties, "width" );
@@ -252,24 +259,39 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	// The fault is not in the design of mlt, but in the implementation of the qimage producer...
 	if ( self->current_image )
 	{
-		// Clone the image and the alpha
 		int image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
-		uint8_t *image_copy = mlt_pool_alloc( image_size );
-		memcpy( image_copy, self->current_image, image_size );
-		// Now update properties so we free the copy after
-		mlt_frame_set_image( frame, image_copy, image_size, mlt_pool_release );
-		// We're going to pass the copy on
-		*buffer = image_copy;
-		mlt_log_debug( MLT_PRODUCER_SERVICE( &self->parent ), "%dx%d (%s)\n",
-			self->current_width, self->current_height, mlt_image_format_name( *format ) );
-		// Clone the alpha channel
-		if ( self->current_alpha )
+		if ( enable_caching )
 		{
-            if ( !self->alpha_size )
-                self->alpha_size = self->current_width * self->current_height;
-			uint8_t * alpha_copy = mlt_pool_alloc( self->alpha_size );
-			memcpy( alpha_copy, self->current_alpha, self->alpha_size );
-			mlt_frame_set_alpha( frame, alpha_copy, self->alpha_size, mlt_pool_release );
+			// Clone the image and the alpha
+			uint8_t *image_copy = mlt_pool_alloc( image_size );
+			memcpy( image_copy, self->current_image, image_size );
+			// Now update properties so we free the copy after
+			mlt_frame_set_image( frame, image_copy, image_size, mlt_pool_release );
+			// We're going to pass the copy on
+			*buffer = image_copy;
+			mlt_log_debug( MLT_PRODUCER_SERVICE( &self->parent ), "%dx%d (%s)\n",
+				self->current_width, self->current_height, mlt_image_format_name( *format ) );
+			// Clone the alpha channel
+			if ( self->current_alpha )
+			{
+				if ( !self->alpha_size )
+					self->alpha_size = self->current_width * self->current_height;
+				uint8_t * alpha_copy = mlt_pool_alloc( self->alpha_size );
+				memcpy( alpha_copy, self->current_alpha, self->alpha_size );
+				mlt_frame_set_alpha( frame, alpha_copy, self->alpha_size, mlt_pool_release );
+			}
+		}
+		else
+		{
+			// For image sequences with ttl = 1 we recreate self->current_image on each frame, no need to clone
+			mlt_frame_set_image( frame, self->current_image, image_size, mlt_pool_release );
+			*buffer = self->current_image;
+			if ( self->current_alpha )
+			{
+				if ( !self->alpha_size )
+					self->alpha_size = self->current_width * self->current_height;
+				mlt_frame_set_alpha( frame, self->current_alpha, self->alpha_size, mlt_pool_release );
+			}
 		}
 	}
 	else
@@ -277,10 +299,13 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 		error = 1;
 	}
 
-	// Release references and locks
-	mlt_cache_item_close( self->qimage_cache );
-	mlt_cache_item_close( self->image_cache );
-	mlt_cache_item_close( self->alpha_cache );
+	if ( enable_caching )
+	{
+		// Release references and locks
+		mlt_cache_item_close( self->qimage_cache );
+		mlt_cache_item_close( self->image_cache );
+		mlt_cache_item_close( self->alpha_cache );
+	}
 	mlt_service_unlock( MLT_PRODUCER_SERVICE( &self->parent ) );
 
 	return error;
@@ -312,10 +337,13 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
 
 		// Refresh the image
-		self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
-		self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
-		refresh_qimage( self, *frame );
-		mlt_cache_item_close( self->qimage_cache );
+		if ( self->count == 1 || mlt_properties_get_int( properties, "ttl" ) > 1 )
+		{
+			self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
+			self->qimage = mlt_cache_item_data( self->qimage_cache, NULL );
+			refresh_qimage( self, *frame, 1 );
+			mlt_cache_item_close( self->qimage_cache );
+		}
 
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( producer_properties, "progressive" ) );

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -286,11 +286,7 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 		{
 			image_size = 3 * width * height;
 			self->format = mlt_image_rgb24;
-#if QT_VERSION >= 0x051300
-			scaled.convertTo( QImage::Format_RGB888 );
-#else
 			scaled = scaled.convertToFormat( QImage::Format_RGB888 );
-#endif
 		}
 		self->current_image = ( uint8_t * )mlt_pool_alloc( image_size );
 		memcpy( self->current_image, scaled.constBits(), image_size);
@@ -300,7 +296,6 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 		self->format = has_alpha ? mlt_image_rgb24a : mlt_image_rgb24;
 		image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
 		self->current_image = ( uint8_t * )mlt_pool_alloc( image_size );
-		image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
 		int y = self->current_height + 1;
 		uint8_t *dst = self->current_image;
 		while ( --y )

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -138,7 +138,7 @@ static QImage* reorient_with_exif( producer_qimage self, int image_idx, QImage *
 	return qimage;
 }
 
-int refresh_qimage( producer_qimage self, mlt_frame frame )
+int refresh_qimage( producer_qimage self, mlt_frame frame, int enable_caching )
 {
 	// Obtain properties of frame and producer
 	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
@@ -153,15 +153,12 @@ int refresh_qimage( producer_qimage self, mlt_frame frame )
 		mlt_properties_set_int( producer_props, "force_reload", 0 );
 	}
 
-	// Get the time to live for each frame
-	double ttl = mlt_properties_get_int( producer_props, "ttl" );
-
 	// Get the original position of this frame
 	mlt_position position = mlt_frame_original_position( frame );
 	position += mlt_producer_get_in( producer );
 
 	// Image index
-	int image_idx = ( int )floor( ( double )position / ttl ) % self->count;
+	int image_idx = ( int )floor( ( double )position / mlt_properties_get_int( producer_props, "ttl" ) ) % self->count;
 
 	int disable_exif = mlt_properties_get_int( producer_props, "disable_exif" );
 
@@ -169,7 +166,9 @@ int refresh_qimage( producer_qimage self, mlt_frame frame )
 		return -1;
 
 	if ( image_idx != self->qimage_idx )
+	{
 		self->qimage = NULL;
+	}
 	if ( !self->qimage || mlt_properties_get_int( producer_props, "_disable_exif" ) != disable_exif )
 	{
 		self->current_image = NULL;
@@ -188,12 +187,23 @@ int refresh_qimage( producer_qimage self, mlt_frame frame )
 #if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
 			// Read the exif value for this file
 			if ( !disable_exif )
+			{
 				qimage = reorient_with_exif( self, image_idx, qimage );
+				self->qimage = qimage;
+			}
 #endif
-			// Register qimage for destruction and reuse
-			mlt_cache_item_close( self->qimage_cache );
-			mlt_service_cache_put( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage", qimage, 0, ( mlt_destructor )qimage_delete );
-			self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
+			if ( enable_caching )
+			{
+				// Register qimage for destruction and reuse
+				mlt_cache_item_close( self->qimage_cache );
+				mlt_service_cache_put( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage", qimage, 0, ( mlt_destructor )qimage_delete );
+				self->qimage_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.qimage" );
+			}
+			else
+			{
+				// Ensure original image data will be deleted
+				mlt_properties_set_data( producer_props, "qimage.qimage", qimage, 0, ( mlt_destructor )qimage_delete, NULL );
+			}
 			self->qimage_idx = image_idx;
 
 			// Store the width/height of the qimage
@@ -220,17 +230,17 @@ int refresh_qimage( producer_qimage self, mlt_frame frame )
 	return image_idx;
 }
 
-void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format format, int width, int height )
+void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format format, int width, int height, int enable_caching )
 {
 	// Obtain properties of frame and producer
 	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
 	mlt_producer producer = &self->parent;
 
 	// Get index and qimage
-	int image_idx = refresh_qimage( self, frame );
+	int image_idx = refresh_qimage( self, frame, enable_caching );
 
 	// optimization for subsequent iterations on single picture
-	if ( image_idx != self->image_idx || width != self->current_width || height != self->current_height )
+	if (!enable_caching || image_idx != self->image_idx || width != self->current_width || height != self->current_height )
 		self->current_image = NULL;
 
 	// If we have a qimage and need a new scaled image
@@ -243,7 +253,7 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 		QImage::Format qimageFormat = has_alpha ? QImage::Format_ARGB32 : QImage::Format_RGB32;
 
 		// Note - the original qimage is already safe and ready for destruction
-		if ( qimage->format() != qimageFormat )
+		if ( enable_caching && qimage->format() != qimageFormat )
 		{
 			QImage temp = qimage->convertToFormat( qimageFormat );
 			qimage = new QImage( temp );
@@ -255,21 +265,42 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 		QImage scaled = interp? qimage->scaled( QSize( width, height ), Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) :
 			qimage->scaled( QSize(width, height) );
 
-		// Convert scaled image to target format (it might be premultiplied after scaling).
-		scaled = scaled.convertToFormat( qimageFormat );
-
 		// Store width and height
 		self->current_width = width;
 		self->current_height = height;
 
 		// Allocate/define image
-		self->format = has_alpha ? mlt_image_rgb24a : mlt_image_rgb24;
-		int image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
-		self->current_image = ( uint8_t * )mlt_pool_alloc( image_size );
 		self->current_alpha = NULL;
 		self->alpha_size = 0;
 
 		// Copy the image
+		int image_size;
+#if QT_VERSION >= 0x050200
+		if ( has_alpha )
+		{
+			image_size = 4 * width * height;
+			self->format = mlt_image_rgb24a;
+			scaled = scaled.convertToFormat( QImage::Format_RGBA8888 );
+		}
+		else
+		{
+			image_size = 3 * width * height;
+			self->format = mlt_image_rgb24;
+#if QT_VERSION >= 0x051300
+			scaled.convertTo( QImage::Format_RGB888 );
+#else
+			scaled = scaled.convertToFormat( QImage::Format_RGB888 );
+#endif
+		}
+		self->current_image = ( uint8_t * )mlt_pool_alloc( image_size );
+		memcpy( self->current_image, scaled.constBits(), image_size);
+#else
+		// Convert scaled image to target format (it might be premultiplied after scaling).
+		scaled = scaled.convertToFormat( qimageFormat );
+		self->format = has_alpha ? mlt_image_rgb24a : mlt_image_rgb24;
+		image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
+		self->current_image = ( uint8_t * )mlt_pool_alloc( image_size );
+		image_size = mlt_image_format_size( self->format, self->current_width, self->current_height, NULL );
 		int y = self->current_height + 1;
 		uint8_t *dst = self->current_image;
 		while ( --y )
@@ -285,9 +316,9 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 				++src;
 			}
 		}
-
+#endif
 		// Convert image to requested format
-		if ( format != mlt_image_none && format != mlt_image_glsl && format != self->format )
+		if ( format != mlt_image_none && format != mlt_image_glsl && format != self->format && enable_caching )
 		{
 			uint8_t *buffer = NULL;
 
@@ -317,17 +348,20 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 			}
 		}
 
-		// Update the cache
-		mlt_cache_item_close( self->image_cache );
-		mlt_service_cache_put( MLT_PRODUCER_SERVICE( producer ), "qimage.image", self->current_image, image_size, mlt_pool_release );
-		self->image_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.image" );
 		self->image_idx = image_idx;
-		mlt_cache_item_close( self->alpha_cache );
-		self->alpha_cache = NULL;
-		if ( self->current_alpha )
+		if ( enable_caching )
 		{
-			mlt_service_cache_put( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha", self->current_alpha, self->alpha_size, mlt_pool_release );
-			self->alpha_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha" );
+			// Update the cache
+			mlt_cache_item_close( self->image_cache );
+			mlt_service_cache_put( MLT_PRODUCER_SERVICE( producer ), "qimage.image", self->current_image, image_size, mlt_pool_release );
+			self->image_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.image" );
+			mlt_cache_item_close( self->alpha_cache );
+			self->alpha_cache = NULL;
+			if ( self->current_alpha )
+			{
+				mlt_service_cache_put( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha", self->current_alpha, self->alpha_size, mlt_pool_release );
+				self->alpha_cache = mlt_service_cache_get( MLT_PRODUCER_SERVICE( producer ), "qimage.alpha" );
+			}
 		}
 	}
 

--- a/src/modules/qt/qimage_wrapper.h
+++ b/src/modules/qt/qimage_wrapper.h
@@ -51,8 +51,8 @@ struct producer_qimage_s
 
 typedef struct producer_qimage_s *producer_qimage;
 
-extern int refresh_qimage( producer_qimage self, mlt_frame frame );
-extern void refresh_image( producer_qimage, mlt_frame, mlt_image_format, int width, int height );
+extern int refresh_qimage( producer_qimage self, mlt_frame frame, int enable_caching );
+extern void refresh_image( producer_qimage, mlt_frame, mlt_image_format, int width, int height, int enable_caching );
 extern void make_tempfile( producer_qimage, const char *xml );
 extern int init_qimage(const char *filename);
 extern int load_sequence_sprintf( producer_qimage self, mlt_properties properties, const char *filename );


### PR DESCRIPTION
This is a cleanup of my previous #573 patch that contains only the necessary changes to disable caching on image sequences with ttl =1, and uses Qt's image format to transfer data to MLT frame instead of doing a per pixel copy.

Doing a quick comparative performance, I get these fps on a 1 frame image sequence in Kdenlive:
* without this patch: around 7fps
* disable caching only: around 15fps
* disabling caching and using Qt's image methods to copy data: 20fps
