### PR TITLE
Movit's pkgconfig sets include path as ${prefix}/movit

### DIFF
--- a/src/modules/opengl/filter_glsl_manager.cpp
+++ b/src/modules/opengl/filter_glsl_manager.cpp
@@ -21,10 +21,10 @@
 #include <stdlib.h>
 #include <string>
 #include "filter_glsl_manager.h"
-#include <movit/init.h>
-#include <movit/util.h>
-#include <movit/effect_chain.h>
-#include <movit/resource_pool.h>
+#include <init.h>
+#include <util.h>
+#include <effect_chain.h>
+#include <resource_pool.h>
 #include "mlt_movit_input.h"
 #include "mlt_flip_effect.h"
 #include <mlt++/MltEvent.h>

--- a/src/modules/opengl/filter_glsl_manager.h
+++ b/src/modules/opengl/filter_glsl_manager.h
@@ -23,7 +23,7 @@
 // Include a random Movit header file to get in GL.h, without including it
 // ourselves (which might interfere with whatever OpenGL extension library
 // Movit has chosen to use).
-#include <movit/resource_pool.h>
+#include <resource_pool.h>
 
 #include <mlt++/MltFilter.h>
 #include <mlt++/MltDeque.h>

--- a/src/modules/opengl/filter_movit_blur.cpp
+++ b/src/modules/opengl/filter_movit_blur.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/blur_effect.h>
+#include <blur_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_convert.cpp
+++ b/src/modules/opengl/filter_movit_convert.cpp
@@ -24,8 +24,8 @@
 #include <string>
 
 #include "filter_glsl_manager.h"
-#include <movit/effect_chain.h>
-#include <movit/util.h>
+#include <effect_chain.h>
+#include <util.h>
 #include "mlt_movit_input.h"
 #include <mlt++/MltProducer.h>
 #include "mlt_flip_effect.h"

--- a/src/modules/opengl/filter_movit_crop.cpp
+++ b/src/modules/opengl/filter_movit_crop.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/padding_effect.h>
+#include <padding_effect.h>
 #include "optional_effect.h"
 
 using namespace movit;

--- a/src/modules/opengl/filter_movit_deconvolution_sharpen.cpp
+++ b/src/modules/opengl/filter_movit_deconvolution_sharpen.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/deconvolution_sharpen_effect.h>
+#include <deconvolution_sharpen_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_diffusion.cpp
+++ b/src/modules/opengl/filter_movit_diffusion.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/diffusion_effect.h>
+#include <diffusion_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_flip.cpp
+++ b/src/modules/opengl/filter_movit_flip.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/effect.h>
+#include <effect.h>
 #include "mlt_flip_effect.h"
 
 using namespace movit;

--- a/src/modules/opengl/filter_movit_glow.cpp
+++ b/src/modules/opengl/filter_movit_glow.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/glow_effect.h>
+#include <glow_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_lift_gamma_gain.cpp
+++ b/src/modules/opengl/filter_movit_lift_gamma_gain.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/lift_gamma_gain_effect.h>
+#include <lift_gamma_gain_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_mirror.cpp
+++ b/src/modules/opengl/filter_movit_mirror.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/mirror_effect.h>
+#include <mirror_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_opacity.cpp
+++ b/src/modules/opengl/filter_movit_opacity.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/multiply_effect.h>
+#include <multiply_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_resample.cpp
+++ b/src/modules/opengl/filter_movit_resample.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/resample_effect.h>
+#include <resample_effect.h>
 #include "optional_effect.h"
 
 using namespace movit;

--- a/src/modules/opengl/filter_movit_resize.cpp
+++ b/src/modules/opengl/filter_movit_resize.cpp
@@ -24,8 +24,8 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/init.h>
-#include <movit/padding_effect.h>
+#include <init.h>
+#include <padding_effect.h>
 #include "optional_effect.h"
 
 using namespace movit;

--- a/src/modules/opengl/filter_movit_saturation.cpp
+++ b/src/modules/opengl/filter_movit_saturation.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/saturation_effect.h>
+#include <saturation_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_vignette.cpp
+++ b/src/modules/opengl/filter_movit_vignette.cpp
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/vignette_effect.h>
+#include <vignette_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/filter_movit_white_balance.cpp
+++ b/src/modules/opengl/filter_movit_white_balance.cpp
@@ -23,7 +23,7 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/white_balance_effect.h>
+#include <white_balance_effect.h>
 
 using namespace movit;
 

--- a/src/modules/opengl/mlt_movit_input.h
+++ b/src/modules/opengl/mlt_movit_input.h
@@ -22,9 +22,9 @@
 
 #include <framework/mlt_types.h>
 
-#include <movit/flat_input.h>
-#include <movit/ycbcr_input.h>
-#include <movit/effect_chain.h>
+#include <flat_input.h>
+#include <ycbcr_input.h>
+#include <effect_chain.h>
 
 class MltInput
 {

--- a/src/modules/opengl/optional_effect.h
+++ b/src/modules/opengl/optional_effect.h
@@ -1,8 +1,8 @@
 #ifndef OPTIONAL_EFFECT_H
 #define OPTIONAL_EFFECT_H
 
-#include <movit/effect.h>
-#include <movit/effect_chain.h>
+#include <effect.h>
+#include <effect_chain.h>
 #include <assert.h>
 
 // A wrapper effect that, at rewrite time, can remove itself entirely from the loop.

--- a/src/modules/opengl/transition_movit_luma.cpp
+++ b/src/modules/opengl/transition_movit_luma.cpp
@@ -23,11 +23,11 @@
 #include <math.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/init.h>
-#include <movit/effect_chain.h>
-#include <movit/util.h>
-#include <movit/luma_mix_effect.h>
-#include <movit/mix_effect.h>
+#include <init.h>
+#include <effect_chain.h>
+#include <util.h>
+#include <luma_mix_effect.h>
+#include <mix_effect.h>
 #include "mlt_movit_input.h"
 
 using namespace movit;

--- a/src/modules/opengl/transition_movit_mix.cpp
+++ b/src/modules/opengl/transition_movit_mix.cpp
@@ -23,10 +23,10 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/init.h>
-#include <movit/effect_chain.h>
-#include <movit/util.h>
-#include <movit/mix_effect.h>
+#include <init.h>
+#include <effect_chain.h>
+#include <util.h>
+#include <mix_effect.h>
 #include "mlt_movit_input.h"
 #include "mlt_flip_effect.h"
 

--- a/src/modules/opengl/transition_movit_overlay.cpp
+++ b/src/modules/opengl/transition_movit_overlay.cpp
@@ -23,10 +23,10 @@
 #include <assert.h>
 
 #include "filter_glsl_manager.h"
-#include <movit/init.h>
-#include <movit/effect_chain.h>
-#include <movit/util.h>
-#include <movit/overlay_effect.h>
+#include <init.h>
+#include <effect_chain.h>
+#include <util.h>
+#include <overlay_effect.h>
 
 using namespace movit;
 


### PR DESCRIPTION
Hello,
When using dependencies in non-system location (eg using "foreign" package management like Craft), we rely on pkg-config to point to the right include dirs. Movit's CFLAGS only load ${prefix}/include/movit as include dir, not ${prefix}/include, so `#include <movit/*>` don't work.
I checked the change with the standard "configure; make" procedure, it still works in my environment.