### PR TITLE
Fix crash with files having more than 32 streams

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -2941,7 +2941,8 @@ static void producer_set_up_audio( producer_avformat self, mlt_frame frame )
 	{
 		pthread_mutex_lock( &self->open_mutex );
 		unsigned i = 0;
-		for (i = 0; i < context->nb_streams; i++) {
+		int index_max = FFMIN( MAX_AUDIO_STREAMS, context->nb_streams );
+		for (i = 0; i < index_max; i++) {
 			if (self->audio_codec[i]) {
 				avcodec_close(self->audio_codec[i]);
 				self->audio_codec[i] = NULL;


### PR DESCRIPTION
When using a file with more than 32 streams (a user had a file with many subtitle streams), MLT crashes when setting audio_index=-1. This is reproducible with the file attached to the Kdenlive bug (426640) report:
https://bugs.kde.org/attachment.cgi?id=133701&action=edit

SImply do:
melt out.mkv audio_index=-1
will crash. Patch adds a check to prevent accessing an invalid array index.