### PR TITLE
Add strobing filter

### DIFF
--- a/src/modules/plus/CMakeLists.txt
+++ b/src/modules/plus/CMakeLists.txt
@@ -16,6 +16,7 @@ set(mltplus_src
     filter_spot_remover.c
     filter_text.c
     filter_timer.c
+    filter_strobe.c
     producer_blipflash.c
     producer_count.c
     transition_affine.c)

--- a/src/modules/plus/Makefile
+++ b/src/modules/plus/Makefile
@@ -24,6 +24,7 @@ OBJS = consumer_blipflash.o \
 	   filter_spot_remover.o \
 	   filter_text.o \
 	   filter_timer.o \
+	   filter_strobe.o \
 	   producer_blipflash.o \
 	   producer_count.o \
 	   transition_affine.o

--- a/src/modules/plus/factory.c
+++ b/src/modules/plus/factory.c
@@ -37,6 +37,7 @@ extern mlt_filter filter_sepia_init( mlt_profile profile, mlt_service_type type,
 extern mlt_filter filter_spot_remover_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_filter filter_text_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_filter filter_timer_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
+extern mlt_filter filter_strobe_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_blipflash_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
 extern mlt_producer producer_count_init( const char *arg );
 extern mlt_transition transition_affine_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg );
@@ -71,6 +72,7 @@ MLT_REPOSITORY
 	MLT_REGISTER( filter_type, "spot_remover", filter_spot_remover_init );
 	MLT_REGISTER( filter_type, "text", filter_text_init );
 	MLT_REGISTER( filter_type, "timer", filter_timer_init );
+	MLT_REGISTER( filter_type, "strobe", filter_strobe_init );
 	MLT_REGISTER( producer_type, "blipflash", producer_blipflash_init );
 	MLT_REGISTER( producer_type, "count", producer_count_init );
 	MLT_REGISTER( transition_type, "affine", transition_affine_init );
@@ -95,6 +97,7 @@ MLT_REPOSITORY
 	MLT_REGISTER_METADATA( filter_type, "spot_remover", metadata, "filter_spot_remover.yml" );
 	MLT_REGISTER_METADATA( filter_type, "text", metadata, "filter_text.yml" );
 	MLT_REGISTER_METADATA( filter_type, "timer", metadata, "filter_timer.yml" );
+	MLT_REGISTER_METADATA( filter_type, "strobe", metadata, "filter_strobe.yml" );
 	MLT_REGISTER_METADATA( producer_type, "blipflash", metadata, "producer_blipflash.yml" );
 	MLT_REGISTER_METADATA( producer_type, "count", metadata, "producer_count.yml" );
 	MLT_REGISTER_METADATA( transition_type, "affine", metadata, "transition_affine.yml" );

--- a/src/modules/plus/filter_strobe.c
+++ b/src/modules/plus/filter_strobe.c
@@ -1,0 +1,118 @@
+/*
+ * filter_strobe.c -- simple strobing filter
+ * Copyright (C) 2020 Martin Sandsmark <martin.sandsmark@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt_filter.h>
+#include <framework/mlt_frame.h>
+#include <framework/mlt_producer.h>
+#include <framework/mlt_service.h>
+#include <framework/mlt_factory.h>
+#include <framework/mlt_property.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
+{
+	mlt_filter filter = mlt_frame_pop_service( frame );
+	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
+
+	int error = mlt_frame_get_image( frame, image, format, width, height, 1 );
+	if ( error )
+	{
+		return error;
+	}
+
+	int invert = mlt_properties_get_int( properties, "strobe_invert" );
+	int interval = mlt_properties_get_int( properties, "interval" );
+	mlt_position currentpos = mlt_filter_get_position( filter, frame );
+
+	int do_strobe = ( currentpos % ( interval + 1 ) ) > interval / 2;
+
+	if ( invert )
+	{
+		do_strobe = !do_strobe;
+	}
+
+	if ( do_strobe != 1 )
+	{
+		return 0;
+	}
+
+	assert( *width >= 0 );
+	assert( *height >= 0 );
+	size_t byteCount = *width * *height;
+
+	// We always clear the alpha mask, in case there's some optimizations
+	// that can be applied or other filters modyify the image contents.
+	uint8_t *alpha_buffer = mlt_frame_get_alpha_mask( frame );
+	assert( alpha_buffer != NULL );
+
+	// We assert because the API contract guarantees that we always get a
+	// buffer, but don't want to crash in release build if it is broken.
+	if ( alpha_buffer )
+	{
+		memset( alpha_buffer, 0, byteCount );
+	}
+
+	if ( *format == mlt_image_rgb24a )
+	{
+		for ( size_t i=3; i<byteCount * 4; i+=4 )
+		{
+			image[i] = 0;
+		}
+	}
+
+	return 0;
+
+}
+
+/** Filter processing.
+*/
+
+static mlt_frame filter_process( mlt_filter filter, mlt_frame frame )
+{
+
+	// Push the filter on to the stack
+	mlt_frame_push_service( frame, filter );
+
+	// Push the frame filter
+	mlt_frame_push_get_image( frame, filter_get_image );
+
+	return frame;
+}
+
+/** Constructor for the filter.
+*/
+
+mlt_filter filter_strobe_init( mlt_profile profile, mlt_service_type type, const char *id, char *arg )
+{
+	mlt_filter filter = mlt_filter_new( );
+	if ( filter != NULL )
+	{
+		filter->process = filter_process;
+		// If strobe_invert == 1, the odd number of frames will be filtered out
+		mlt_properties_set( MLT_FILTER_PROPERTIES( filter ), "strobe_invert", "0" );
+		mlt_properties_set( MLT_FILTER_PROPERTIES( filter ), "interval", "1" );
+	}
+	return filter;
+}
+
+
+

--- a/src/modules/plus/filter_strobe.c
+++ b/src/modules/plus/filter_strobe.c
@@ -39,11 +39,13 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 		return error;
 	}
 
-	int invert = mlt_properties_get_int( properties, "strobe_invert" );
-	int interval = mlt_properties_get_int( properties, "interval" );
-	mlt_position currentpos = mlt_filter_get_position( filter, frame );
+	mlt_position position = mlt_filter_get_position( filter, frame );
+	mlt_position length = mlt_filter_get_length2( filter, frame );
 
-	int do_strobe = ( currentpos % ( interval + 1 ) ) > interval / 2;
+	int invert = mlt_properties_anim_get_int( properties, "strobe_invert", position, length );
+	int interval = mlt_properties_anim_get_int( properties, "interval", position, length );
+
+	int do_strobe = ( position % ( interval + 1 ) ) > interval / 2;
 
 	if ( invert )
 	{

--- a/src/modules/plus/filter_strobe.yml
+++ b/src/modules/plus/filter_strobe.yml
@@ -1,0 +1,31 @@
+schema_version: 0.3
+type: filter
+identifier: alpha_strobe
+title: Alpha strobing
+version: 1
+copyright: Martin Sandsmark
+creator: Martin Sandsmark
+license: LGPLv2.1
+language: en
+description: Strobes the alpha channel to 0. Many other filters overwrite the alpha channel, in that case this needs to be last.
+tags:
+  - Video
+parameters:
+  - identifier: strobe_invert
+    title: Invert
+    type: boolean
+    description: Whether to invert which frames are on and which is off
+    default: 0
+    mutable: yes
+
+  - identifier: interval
+    title: Interval
+    type: integer
+    description: >
+      Duration of strobe
+    default: 1
+    minimum: 1
+    maximum: 100
+    readonly: no
+    mutable: yes
+    widget: spinner


### PR DESCRIPTION
Extremely simple filter, just alternates between clearing and forwarding the normal frame.

Could probably be more efficient, but I'm not that familiar with the APIs.

Tested it briefly in kdenlive, and it seems to work fine, except when there's any filters after it that overwrite the alpha (like the transform filter), not sure if that can easily be fixed (short of converting the entire frame to something with an alpha channel and overwriting that, which kills performance pretty badly).