### PR TITLE
docs: fix simple typo, boundies -> boundaries

### DIFF
--- a/src/modules/motion_est/filter_motion_est.c
+++ b/src/modules/motion_est/filter_motion_est.c
@@ -726,7 +726,7 @@ static void show_residual( uint8_t *result,  struct motion_est_context_s *c )
 			if( dx % 2 == 0 )
 				r[1] = 128 + ABS( r[1] - b[1] );
 			else
-				// FIXME: may exceed boundies
+				// FIXME: may exceed boundaries
 				r[1] = 128 + ABS( r[1] - ( *(b-1) + b[3] ) /2 );
 		 }
 		}
@@ -767,7 +767,7 @@ static void show_reconstruction( uint8_t *result, struct motion_est_context_s *c
 			if( dx % 2 == 0 )
 				r[1] = s[1];
 			else
-				// FIXME: may exceed boundies
+				// FIXME: may exceed boundaries
 				r[1] = ( *(s-1) + s[3] ) /2;
 		 }
 		}

--- a/src/modules/motion_est/producer_slowmotion.c
+++ b/src/modules/motion_est/producer_slowmotion.c
@@ -133,10 +133,10 @@ static void motion_interpolate( uint8_t *first_image, uint8_t *second_image, uin
 				else
 				{
 					if( scaled_dx %2 == 0 )
-						// FIXME: may exceed boundies
+						// FIXME: may exceed boundaries
 						r[1] =  ( 1.0 - scale ) * ( (double)(*(f-1) + (double)f[3]) / 2.0 ) + scale * (double) s[1];
 					else
-						// FIXME: may exceed boundies
+						// FIXME: may exceed boundaries
 						*(r-1) =  ( 1.0 - scale ) * ( (double)(*(f-1) + (double)f[3]) / 2.0 ) + scale * (double) s[1];
 				}
 //			 }


### PR DESCRIPTION
There is a small typo in src/modules/motion_est/filter_motion_est.c, src/modules/motion_est/producer_slowmotion.c.

Should read `boundaries` rather than `boundies`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md