### PR TITLE
trivial performance improvement/make lgtm happy

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -2543,13 +2543,13 @@ static void planar_to_interleaved( uint8_t *dest, AVFrame *src, int samples, int
 	}
 }
 
-static int decode_audio( producer_avformat self, int *ignore, AVPacket pkt, int samples, double timecode, double fps )
+static int decode_audio( producer_avformat self, int *ignore, const AVPacket *pkt, int samples, double timecode, double fps )
 {
 	// Fetch the audio_format
 	AVFormatContext *context = self->audio_format;
 
 	// Get the current stream index
-	int index = pkt.stream_index;
+	int index = pkt->stream_index;
 
 	// Get codec context
 	AVCodecContext *codec_context = self->audio_codec[ index ];
@@ -2568,8 +2568,8 @@ static int decode_audio( producer_avformat self, int *ignore, AVPacket pkt, int 
 		self->audio_frame = av_frame_alloc();
 	else
 		av_frame_unref( self->audio_frame );
-	int error = avcodec_send_packet(codec_context, &pkt);
-	mlt_log_debug(MLT_PRODUCER_SERVICE(self->parent), "decoded audio packet with size %d => %d\n", pkt.size, error);
+	int error = avcodec_send_packet(codec_context, pkt);
+	mlt_log_debug(MLT_PRODUCER_SERVICE(self->parent), "decoded audio packet with size %d => %d\n", pkt->size, error);
 	if (error && error != AVERROR(EAGAIN) && error != AVERROR_EOF) {
 		mlt_log_warning(MLT_PRODUCER_SERVICE(self->parent), "audio avcodec_send_packet failed with %d\n", error);
 	} else while (!error) {
@@ -2623,9 +2623,9 @@ static int decode_audio( producer_avformat self, int *ignore, AVPacket pkt, int 
 
 	// If we're behind, ignore this packet
 	// Skip this on non-seekable, audio-only inputs.
-	if ( !discarded && pkt.pts >= 0 && ( self->seekable || self->video_format ) && *ignore == 0 && audio_used > samples / 2 )
+	if ( !discarded && pkt->pts >= 0 && ( self->seekable || self->video_format ) && *ignore == 0 && audio_used > samples / 2 )
 	{
-		int64_t pts = pkt.pts;
+		int64_t pts = pkt->pts;
 		if ( self->first_pts != AV_NOPTS_VALUE )
 			pts -= self->first_pts;
 		else if ( context->start_time != AV_NOPTS_VALUE && self->video_index != -1 )
@@ -2636,8 +2636,8 @@ static int decode_audio( producer_avformat self, int *ignore, AVPacket pkt, int 
 		int64_t req_pts =      llrint( timecode / timebase );
 
 		mlt_log_debug( MLT_PRODUCER_SERVICE(self->parent),
-			"A pkt.pts %"PRId64" pkt.dts %"PRId64" req_pos %"PRId64" cur_pos %"PRId64" pkt_pos %"PRId64"\n",
-			pkt.pts, pkt.dts, req_position, self->current_position, int_position );
+			"A pkt.pts %"PRId64" pkt->dts %"PRId64" req_pos %"PRId64" cur_pos %"PRId64" pkt_pos %"PRId64"\n",
+			pkt->pts, pkt->dts, req_position, self->current_position, int_position );
 
 		if ( self->seekable || int_position > 0 )
 		{
@@ -2814,7 +2814,7 @@ static int producer_get_audio( mlt_frame frame, void **buffer, mlt_audio_format 
 			if ( index < MAX_AUDIO_STREAMS && ret >= 0 && pkt.data && pkt.size > 0 && ( index == self->audio_index ||
 				 ( self->audio_index == INT_MAX && context->streams[ index ]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO ) ) )
 			{
-				ret = decode_audio( self, &ignore[index], pkt, *samples, real_timecode, fps );
+				ret = decode_audio( self, &ignore[index], &pkt, *samples, real_timecode, fps );
 			}
 
 			if ( self->seekable || index != self->video_index )

--- a/src/modules/core/transition_composite.c
+++ b/src/modules/core/transition_composite.c
@@ -360,23 +360,23 @@ static int sliced_composite_proc( int id, int idx, int jobs, void* cookie )
 /** Composite function.
 */
 
-static int composite_yuv( uint8_t *p_dest, int width_dest, int height_dest, uint8_t *p_src, int width_src, int height_src, uint8_t *alpha_b, uint8_t *alpha_a, struct geometry_s geometry, int field, uint16_t *p_luma, double softness, composite_line_fn line_fn, int sliced )
+static int composite_yuv( uint8_t *p_dest, int width_dest, int height_dest, uint8_t *p_src, int width_src, int height_src, uint8_t *alpha_b, uint8_t *alpha_a, const struct geometry_s *geometry, int field, uint16_t *p_luma, double softness, composite_line_fn line_fn, int sliced )
 {
 	int ret = 0;
 	int i;
-	int x_src = -geometry.x_src, y_src = -geometry.y_src;
+	int x_src = -geometry->x_src, y_src = -geometry->y_src;
 	int uneven_x_src = ( x_src % 2 );
 	int step = ( field > -1 ) ? 2 : 1;
 	int bpp = 2;
-	int stride_src = geometry.sw * bpp;
+	int stride_src = geometry->sw * bpp;
 	int stride_dest = width_dest * bpp;
 	int i_softness = ( 1 << 16 ) * softness;
-	int weight = ( ( 1 << 16 ) * geometry.item.mix + 50 ) / 100;
-	uint32_t luma_step = ( ( ( 1 << 16 ) - 1 ) * geometry.item.mix + 50 ) / 100 * ( 1.0 + softness );
+	int weight = ( ( 1 << 16 ) * geometry->item.mix + 50 ) / 100;
+	uint32_t luma_step = ( ( ( 1 << 16 ) - 1 ) * geometry->item.mix + 50 ) / 100 * ( 1.0 + softness );
 
 	// Adjust to consumer scale
-	int x = rint( geometry.item.x * width_dest / geometry.nw );
-	int y = rint( geometry.item.y * height_dest / geometry.nh );
+	int x = rint( geometry->item.x * width_dest / geometry->nw );
+	int y = rint( geometry->item.y * height_dest / geometry->nh );
 	int uneven_x = ( x % 2 );
 
 	// optimization points - no work to do
@@ -391,8 +391,8 @@ static int composite_yuv( uint8_t *p_dest, int width_dest, int height_dest, uint
 	{
 		width_src -= x_src;
 		// and it implies cropping
-		if ( width_src > geometry.item.w )
-			width_src = geometry.item.w;
+		if ( width_src > geometry->item.w )
+			width_src = geometry->item.w;
 	}
 
 	// cropping affects the source height
@@ -400,8 +400,8 @@ static int composite_yuv( uint8_t *p_dest, int width_dest, int height_dest, uint
 	{
 		height_src -= y_src;
 		// and it implies cropping
-		if ( height_src > geometry.item.h )
-			height_src = geometry.item.h;
+		if ( height_src > geometry->item.h )
+			height_src = geometry->item.h;
 	}
 
 	// crop overlay off the left edge of frame
@@ -1292,7 +1292,7 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 
 				// Composite the b_frame on the a_frame
 				mlt_log_timings_begin()
-				composite_yuv( *image, *width, *height, image_b, width_b, height_b, alpha_b, alpha_a, result, field_id, luma_bitmap, luma_softness, line_fn, sliced );
+				composite_yuv( *image, *width, *height, image_b, width_b, height_b, alpha_b, alpha_a, &result, field_id, luma_bitmap, luma_softness, line_fn, sliced );
 				mlt_log_timings_end( NULL, "composite_yuv" )
 			}
 		}


### PR DESCRIPTION
lgtm complains because AVPacket is 88 bytes and therefore suggests it not be passed by value

https://lgtm.com/projects/g/mltframework/mlt/snapshot/817960810f3e92c7d64a23a21c40556078abe148/files/src/modules/avformat/producer_avformat.c?sort=name&dir=ASC&mode=heatmap#x1a9a2013f6c00b6a:1