### PR TITLE
v7: fix cmake

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -78,4 +78,4 @@ jobs:
           LD_LIBRARY_PATH: /usr/local/lib
         run: |
           sudo locale-gen de_DE.UTF-8
-          cd build && ctest
+          cd build && ctest --output-on-failure

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(mlt SHARED
   mlt_animation.c
   mlt_audio.c
   mlt_cache.c
+  mlt_chain.c
   mlt_consumer.c
   mlt_deque.c
   mlt_events.c
@@ -10,6 +11,7 @@ add_library(mlt SHARED
   mlt_filter.c
   mlt_frame.c
   mlt_geometry.c
+  mlt_link.c
   mlt_log.c
   mlt_luma_map.c
   mlt_multitrack.c
@@ -58,6 +60,7 @@ set(MLT_PUPLIC_HEADERS
   mlt_animation.h
   mlt_audio.h
   mlt_cache.h
+  mlt_chain.h
   mlt_consumer.h
   mlt_deque.h
   mlt_events.h
@@ -66,6 +69,7 @@ set(MLT_PUPLIC_HEADERS
   mlt_filter.h
   mlt_frame.h
   mlt_geometry.h
+  mlt_link.h
   mlt_log.h
   mlt_luma_map.h
   mlt_multitrack.h

--- a/src/mlt++/CMakeLists.txt
+++ b/src/mlt++/CMakeLists.txt
@@ -34,12 +34,10 @@ target_include_directories(mlt++ PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/mlt++>
 )
 
-set(MLTPP_SOVERSION "3")
-
-set_target_properties(mlt++ PROPERTIES SOVERSION ${MLTPP_SOVERSION} VERSION ${MLT_VERSION})
+set_target_properties(mlt++ PROPERTIES SOVERSION ${MLT_VERSION_MAJOR} VERSION ${MLT_VERSION})
 
 if(WIN32)
-  set_target_properties(mlt++ PROPERTIES OUTPUT_NAME "mlt++-${MLTPP_SOVERSION}")
+  set_target_properties(mlt++ PROPERTIES OUTPUT_NAME "mlt++-${MLT_VERSION_MAJOR}")
   target_compile_definitions(mlt++ PUBLIC MLTPP_EXPORTS)
 endif()
 

--- a/src/mlt++/CMakeLists.txt
+++ b/src/mlt++/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(mlt++ SHARED
   MltAnimation.cpp
   MltAudio.cpp
+  MltChain.cpp
   MltConsumer.cpp
   MltDeque.cpp
   MltEvent.cpp
@@ -11,6 +12,7 @@ add_library(mlt++ SHARED
   MltFilteredProducer.cpp
   MltFrame.cpp
   MltGeometry.cpp
+  MltLink.cpp
   MltMultitrack.cpp
   MltParser.cpp
   MltPlaylist.cpp
@@ -45,6 +47,7 @@ set(MLTPP_PUPLIC_HEADERS
   Mlt.h
   MltAnimation.h
   MltAudio.h
+  MltChain.h
   MltConfig.h
   MltConsumer.h
   MltDeque.h
@@ -56,6 +59,7 @@ set(MLTPP_PUPLIC_HEADERS
   MltFilteredProducer.h
   MltFrame.h
   MltGeometry.h
+  MltLink.h
   MltMultitrack.h
   MltParser.h
   MltPlaylist.h

--- a/src/modules/core/CMakeLists.txt
+++ b/src/modules/core/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(mltcore MODULE
   filter_resize.c
   filter_transition.c
   filter_watermark.c
+  link_timeremap.c
   producer_colour.c
   producer_consumer.c
   producer_hold.c
@@ -82,6 +83,7 @@ install(FILES
   filter_resize.yml
   filter_transition.yml
   filter_watermark.yml
+  link_timeremap.yml
   producer_colour.yml
   producer_consumer.yml
   producer_hold.yml


### PR DESCRIPTION
After file globbing was removed in https://github.com/mltframework/mlt/commit/69521d53974f6738adc62799c30c618a946f0db6, new files now need to be added to the build system explicitly.