### PR TITLE
Delete the animation string after parsing it

### DIFF
--- a/src/framework/mlt_property.c
+++ b/src/framework/mlt_property.c
@@ -1322,6 +1322,11 @@ static void refresh_animation( mlt_property self, double fps, locale_t locale, i
 		self->animation = mlt_animation_new();
 		self->serialiser = (mlt_serialiser) mlt_animation_serialize_tf;
 		mlt_animation_parse( self->animation, self->prop_string, length, fps, locale );
+		// Delete the string and interact with the animation from now on.
+		self->types &= !mlt_prop_string;
+		if ( self->prop_string )
+			free( self->prop_string );
+		self->prop_string = NULL;
 	}
 	else if ( ( self->types & mlt_prop_string ) && self->prop_string )
 	{

--- a/src/framework/mlt_property.c
+++ b/src/framework/mlt_property.c
@@ -496,6 +496,8 @@ int mlt_property_get_int( mlt_property self, double fps, locale_t locale )
 		result = ( int ) ( (mlt_rect*) self->data )->x;
 	else if ( ( self->types & mlt_prop_string ) && self->prop_string )
 		result = mlt_property_atoi( self, fps, locale );
+	else if ( self->animation )
+		result = mlt_property_anim_get_int( self, fps, locale, 0, 0 );
 	pthread_mutex_unlock( &self->mutex );
 	return result;
 }
@@ -589,6 +591,8 @@ double mlt_property_get_double( mlt_property self, double fps, locale_t locale )
 		result = ( (mlt_rect*) self->data )->x;
 	else if ( ( self->types & mlt_prop_string ) && self->prop_string )
 		result = mlt_property_atof( self, fps, locale );
+	else if ( self->animation )
+		result = mlt_property_anim_get_double( self, fps, locale, 0, 0 );
 	pthread_mutex_unlock( &self->mutex );
 	return result;
 }
@@ -619,6 +623,8 @@ mlt_position mlt_property_get_position( mlt_property self, double fps, locale_t 
 		result = ( mlt_position ) ( (mlt_rect*) self->data )->x;
 	else if ( ( self->types & mlt_prop_string ) && self->prop_string )
 		result = ( mlt_position )mlt_property_atoi( self, fps, locale );
+	else if ( self->animation )
+		result = mlt_property_anim_get_int( self, fps, locale, 0, 0 );
 	pthread_mutex_unlock( &self->mutex );
 	return result;
 }

--- a/src/tests/test_properties/test_properties.cpp
+++ b/src/tests/test_properties/test_properties.cpp
@@ -811,7 +811,7 @@ private Q_SLOTS:
         mlt_property p = mlt_property_init();
         mlt_property_set_string(p, "10=100; 20=200");
         mlt_property_anim_set_double(p, 1.5, fps, locale, 30, len, mlt_keyframe_linear);
-        QCOMPARE(mlt_property_get_double(p, fps, locale), 10.0);
+        QCOMPARE(mlt_property_get_double(p, fps, locale), 100.0);
         QCOMPARE(mlt_property_anim_get_double(p, fps, locale,  0, len), 100.0);
         QCOMPARE(mlt_property_anim_get_double(p, fps, locale, 15, len), 150.0);
         QCOMPARE(mlt_property_anim_get_double(p, fps, locale, 20, len), 200.0);
@@ -827,7 +827,7 @@ private Q_SLOTS:
         mlt_property p = mlt_property_init();
         mlt_property_set_string(p, "10=100; 20=200");
         mlt_property_anim_set_int(p, 300, fps, locale, 30, len, mlt_keyframe_linear);
-        QCOMPARE(mlt_property_get_int(p, fps, locale), 10);
+        QCOMPARE(mlt_property_get_int(p, fps, locale), 100);
         QCOMPARE(mlt_property_anim_get_int(p, fps, locale,  0, len), 100);
         QCOMPARE(mlt_property_anim_get_int(p, fps, locale, 15, len), 150);
         QCOMPARE(mlt_property_anim_get_int(p, fps, locale, 20, len), 200);


### PR DESCRIPTION
In some cases, the string would be re-parsed and changes to the animation would be lost.

While testing Shotcut from the MLTv7 branch, I see a problem when when I open a .mlt file with filters having animations - when trying to manipulate those keyframes they will stubbornly return to the initial state from when the file was opened. Debugging revealed that the initial string persists and parsing it would overwrite any changes made to the animation.

I do not know if some recent changes may have exposed this. But intuitively, the change makes sense to me. Maybe you know of a reason that the original string should be kept after it has been parsed.