### PR TITLE
Clear animation cache

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -594,4 +594,5 @@ MLT_7.0.0 {
     mlt_link_close;
     mlt_repository_links;
     mlt_animation_shift_frames;
+    mlt_animation_get_string;
 } MLT_6.22.0;

--- a/src/framework/mlt_animation.c
+++ b/src/framework/mlt_animation.c
@@ -54,6 +54,8 @@ struct mlt_animation_s
 	animation_node nodes; /**< a linked list of keyframes (and possibly non-keyframe values) */
 };
 
+static void mlt_animation_clear_string( mlt_animation self );
+
 /** Create a new animation object.
  *
  * \public \memberof mlt_animation_s
@@ -301,8 +303,10 @@ int mlt_animation_get_length( mlt_animation self )
 
 void mlt_animation_set_length( mlt_animation self, int length )
 {
-	if ( self )
+	if ( self ) {
 		self->length = length;
+		mlt_animation_clear_string( self );
+	}
 }
 
 /** Parse a string representing an animation keyframe=value.
@@ -519,6 +523,7 @@ int mlt_animation_insert( mlt_animation self, mlt_animation_item item )
 		// Set the first item
 		self->nodes = node;
 	}
+	mlt_animation_clear_string( self );
 
 	return error;
 }
@@ -543,6 +548,8 @@ int mlt_animation_remove( mlt_animation self, int position )
 
 	if ( node && position == node->item.frame )
 		error = mlt_animation_drop( self, node );
+
+	mlt_animation_clear_string( self );
 
 	return error;
 }
@@ -897,6 +904,7 @@ int mlt_animation_key_set_type(mlt_animation self, int index, mlt_keyframe_type 
 	if ( node ) {
 		node->item.keyframe_type = type;
 		mlt_animation_interpolate(self);
+		mlt_animation_clear_string( self );
 	} else {
 		error = 1;
 	}
@@ -928,6 +936,7 @@ int mlt_animation_key_set_frame(mlt_animation self, int index, int frame)
 	if ( node ) {
 		node->item.frame = frame;
 		mlt_animation_interpolate(self);
+		mlt_animation_clear_string( self );
 	} else {
 		error = 1;
 	}
@@ -949,5 +958,34 @@ void mlt_animation_shift_frames( mlt_animation self, int shift )
 		node->item.frame += shift;
 		node = node->next;
 	}
+	mlt_animation_clear_string( self );
 	mlt_animation_interpolate(self);
+}
+
+/** Get the cached serialization string.
+ *
+ * This can be used to determine if the animation has been modified because the
+ * string is cleared whenever the animation is changed.
+ * \public \memberof mlt_animation_s
+ * \param self an animation
+ * \return the cached serialization string
+ */
+
+const char* mlt_animation_get_string( mlt_animation self )
+{
+	if (!self) return NULL;
+	return self->data;
+}
+
+/** Clear the cached serialization string.
+ *
+ * \private \memberof mlt_animation_s
+ * \param self an animation
+ */
+
+void mlt_animation_clear_string( mlt_animation self )
+{
+	if (!self) return;
+	free( self->data );
+	self->data = NULL;
 }

--- a/src/framework/mlt_animation.h
+++ b/src/framework/mlt_animation.h
@@ -70,6 +70,7 @@ extern void mlt_animation_close( mlt_animation self );
 extern int mlt_animation_key_set_type( mlt_animation self, int index, mlt_keyframe_type type );
 extern int mlt_animation_key_set_frame( mlt_animation self, int index, int frame );
 extern void mlt_animation_shift_frames( mlt_animation self, int shift );
+extern const char* mlt_animation_get_string( mlt_animation self );
 
 #endif
 

--- a/src/tests/test_properties/test_properties.cpp
+++ b/src/tests/test_properties/test_properties.cpp
@@ -919,6 +919,65 @@ private Q_SLOTS:
         QCOMPARE(p.anim_get("key", 45), "hello world");
     }
 
+
+    void PropertyRefreshOnAnimationChange()
+    {
+        // Create an animation property from string and see that it works.
+        // Get the animation and modify the first position.
+        // Ensure that change affects other get() functions
+
+        {
+            Properties p;
+            p.set("foo", "10=100; 20=200");
+            QCOMPARE(p.get_double("foo"), 10.0);
+            // Call anim_get_double() to create the animation
+            QCOMPARE(p.anim_get_double("foo", 15, 20 ), 150.0);
+            Mlt::Animation animation = p.get_animation("foo");
+            animation.key_set_frame(0, 15);
+            QCOMPARE(p.get_double("foo"), 15.0);
+        }
+
+        {
+            Properties p;
+            p.set("foo", "10=100;20=200");
+            QCOMPARE(p.anim_get_double("foo", 15, 20 ), 150.0);
+            Mlt::Animation animation = p.get_animation("foo");
+            animation.key_set_frame(0, 15);
+            QCOMPARE(p.anim_get_double("foo", 15, 0 ), 100.0);
+        }
+
+        {
+            Properties p;
+            p.set("foo", "10=100; 20=200");
+            QCOMPARE(p.get_int("foo"), 10);
+            // Call anim_get_int() to create the animation
+            QCOMPARE(p.anim_get_int("foo", 15, 20 ), 150);
+            Mlt::Animation animation = p.get_animation("foo");
+            animation.key_set_frame(0, 15);
+            QCOMPARE(p.get_int("foo"), 15);
+        }
+
+        {
+            Properties p;
+            p.set("foo", "10=100; 20=200");
+            QCOMPARE(p.anim_get_int("foo", 15, 20 ), 150);
+            Mlt::Animation animation = p.get_animation("foo");
+            animation.key_set_frame(0, 15);
+            QCOMPARE(p.anim_get_int("foo", 15, 0 ), 100);
+        }
+
+        {
+            Properties p;
+            p.set("foo", "10=100;20=200");
+            // Call anim_get_int() to create the animation
+            QCOMPARE(p.anim_get_int("foo", 15, 20 ), 150);
+            Mlt::Animation animation = p.get_animation("foo");
+            QCOMPARE(p.get("foo"), "10=100;20=200");
+            animation.key_set_frame(0, 15);
+            QCOMPARE(p.get("foo"), "15=100;20=200");
+        }
+    }
+
     void test_mlt_rect()
     {
         mlt_property p = mlt_property_init();


### PR DESCRIPTION
This is an alternative proposal to solve https://github.com/mltframework/mlt/pull/664

In this proposal, the initial string is preserved unless the animation is changed. If the animation is changed, the string is destroyed and recreated if/when needed.

All the proposed tests in this patch failed before the changes.