### PR TITLE
Typewriter: Fixes assertation problem with step_sigma == 0

### DIFF
--- a/src/modules/qt/typewriter.cpp
+++ b/src/modules/qt/typewriter.cpp
@@ -71,7 +71,8 @@ int TypeWriter::parse()
     clear();
 
     gen.seed(step_seed);
-    d = std::normal_distribution<>{0, step_sigma};
+    if (step_sigma > 0.)
+        d = std::normal_distribution<>{0, step_sigma};
 
     previous_total_frame = -1;
     int start_frame = 0;
@@ -109,7 +110,7 @@ uint TypeWriter::getOrInsertFrame(uint frame)
     uint n = frames.size();
     if (!n)
     {
-        int s = std::round(d(gen));
+        int s = step_sigma > 0. ? std::round(d(gen)) : 0;
 
         if ((s + real_frame) > 0)
             real_frame += s;
@@ -124,7 +125,7 @@ uint TypeWriter::getOrInsertFrame(uint frame)
     if (frames[n-1].frame >= frame)
         return n-1;
 
-    int s = std::round(d(gen));
+    int s = step_sigma > 0. ? std::round(d(gen)) : 0;
 
     if ((s + real_frame) > 0)
         real_frame += s;


### PR DESCRIPTION
Reported in flatpak version of kdenlive:
https://invent.kde.org/multimedia/kdenlive/-/issues/789#note_201930

Probably caused by different asserations flag used for flatpak release of mlt.