### PR TITLE
Remove deprecated functions in mlt_slices

### DIFF
--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -3,7 +3,7 @@
  * \brief sliced threading processing helper
  * \see mlt_slices_s
  *
- * Copyright (C) 2016-2017 Meltytech, LLC
+ * Copyright (C) 2016-2021 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -136,14 +136,13 @@ static void* mlt_slices_worker( void* p )
 /** Initialize a sliced threading context
  *
  * \public \memberof mlt_slices_s
- * \deprecated
  * \param threads number of threads to use for job list, 0 for #cpus
  * \param policy scheduling policy of processing threads, -1 for normal
  * \param priority priority value that can be used with the scheduling algorithm, -1 for maximum
  * \return the context pointer
  */
 
-mlt_slices mlt_slices_init( int threads, int policy, int priority )
+static mlt_slices mlt_slices_init( int threads, int policy, int priority )
 {
 	pthread_attr_t tattr;
 	struct sched_param param;
@@ -220,11 +219,10 @@ mlt_slices mlt_slices_init( int threads, int policy, int priority )
 /** Destroy sliced threading context
  *
  * \public \memberof mlt_slices_s
- * \deprecated
  * \param ctx context pointer
  */
 
-void mlt_slices_close( mlt_slices ctx )
+static void mlt_slices_close( mlt_slices ctx )
 {
 	int j;
 
@@ -265,13 +263,12 @@ void mlt_slices_close( mlt_slices ctx )
 /** Run sliced execution
  *
  * \public \memberof mlt_slices_s
- * \deprecated
  * \param ctx context pointer
  * \param jobs number of jobs to process
  * \param proc number of jobs to process
  */
 
-void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cookie )
+static void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cookie )
 {
 	struct mlt_slices_runtime_s runtime, *r = &runtime;
 

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -3,7 +3,7 @@
  * \brief sliced threading processing helper
  * \see mlt_slices_s
  *
- * Copyright (C) 2016-2017 Meltytech, LLC
+ * Copyright (C) 2016-2021 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,12 +33,6 @@
 struct mlt_slices_s;
 
 typedef int (*mlt_slices_proc)( int id, int idx, int jobs, void* cookie );
-
-extern mlt_slices mlt_slices_init( int threads, int policy, int priority );
-
-extern void mlt_slices_close( mlt_slices ctx );
-
-extern void mlt_slices_run( mlt_slices ctx, int jobs, mlt_slices_proc proc, void* cookie );
 
 extern int mlt_slices_count_normal();
 


### PR DESCRIPTION
The functions are still used internally so they have been removed
from the public interface.