### PR TITLE
[WIP] Frame image

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -600,10 +600,14 @@ MLT_7.0.0 {
     mlt_image_set_values;
     mlt_image_get_values;
     mlt_image_alloc_data;
+    mlt_image_clear_data;
     mlt_image_alloc_alpha;
+    mlt_image_clear_alpha;
     mlt_image_calculate_size;
     mlt_image_fill_black;
     mlt_image_fill_opaque;
+    mlt_image_copy_deep;
+    mlt_image_copy_shallow;
     mlt_audio_silence;
     mlt_event_data_none;
     mlt_event_data_from_int;

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -97,6 +97,8 @@ struct mlt_frame_s
 	mlt_deque stack_audio;   /**< \private the audio processing stack of operations and data */
 	mlt_deque stack_service; /**< \private a general purpose data stack */
 	int is_processing;       /**< \private indicates if a frame is or was processed by the parallel consumer */
+	struct mlt_image_s image;        /**< \private the frame image */
+	struct mlt_audio_s audio;        /**< \private the frame audio */
 };
 
 #define MLT_FRAME_PROPERTIES( frame )		( &( frame )->parent )

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -51,10 +51,14 @@ extern void mlt_image_close( mlt_image self );
 extern void mlt_image_set_values( mlt_image self, void* data, mlt_image_format format, int width, int height );
 extern void mlt_image_get_values( mlt_image self, void** data, mlt_image_format* format, int* width, int* height );
 extern void mlt_image_alloc_data( mlt_image self );
+extern void mlt_image_clear_data( mlt_image self );
 extern void mlt_image_alloc_alpha( mlt_image self );
+extern void mlt_image_clear_alpha( mlt_image self );
 extern int mlt_image_calculate_size( mlt_image self );
 extern void mlt_image_fill_black( mlt_image self );
 extern void mlt_image_fill_opaque( mlt_image self );
+extern void mlt_image_copy_deep( mlt_image src, mlt_image dst );
+extern void mlt_image_copy_shallow( mlt_image src, mlt_image dst );
 extern const char * mlt_image_format_name( mlt_image_format format );
 extern mlt_image_format mlt_image_format_id( const char * name );
 

--- a/src/framework/mlt_tractor.c
+++ b/src/framework/mlt_tractor.c
@@ -354,7 +354,6 @@ mlt_producer mlt_tractor_get_track( mlt_tractor self, int index )
 static int producer_get_image( mlt_frame self, uint8_t **buffer, mlt_image_format *format, int *width, int *height, int writable )
 {
 	uint8_t *data = NULL;
-	int size = 0;
 	mlt_properties properties = MLT_FRAME_PROPERTIES( self );
 	mlt_frame frame = mlt_frame_pop_service( self );
 	mlt_properties frame_properties = MLT_FRAME_PROPERTIES( frame );
@@ -371,9 +370,9 @@ static int producer_get_image( mlt_frame self, uint8_t **buffer, mlt_image_forma
 	mlt_frame_get_image( frame, buffer, format, width, height, writable );
 	mlt_frame_set_image( self, *buffer, 0, NULL );
 
-	mlt_properties_set_int( properties, "width", *width );
-	mlt_properties_set_int( properties, "height", *height );
-	mlt_properties_set_int( properties, "format", *format );
+	frame->image.width = *width;
+	frame->image.height = *height;
+	frame->image.format = *format;
 	mlt_properties_set_double( properties, "aspect_ratio", mlt_frame_get_aspect_ratio( frame ) );
 	mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( frame_properties, "progressive" ) );
 	mlt_properties_set_int( properties, "distort", mlt_properties_get_int( frame_properties, "distort" ) );
@@ -402,8 +401,7 @@ static int producer_get_image( mlt_frame self, uint8_t **buffer, mlt_image_forma
 	data = mlt_frame_get_alpha( frame );
 	if ( data )
 	{
-		mlt_properties_get_data( frame_properties, "alpha", &size );
-		mlt_frame_set_alpha( self, data, size, NULL );
+		mlt_frame_set_alpha( self, data, 0, NULL );
 	};
 	self->convert_image = frame->convert_image;
 	self->convert_audio = frame->convert_audio;
@@ -571,8 +569,8 @@ static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int tra
 				mlt_properties video_properties = MLT_FRAME_PROPERTIES( first_video );
 				mlt_frame_push_service( *frame, video );
 				mlt_frame_push_service( *frame, producer_get_image );
-				mlt_properties_set_int( frame_properties, "width", mlt_properties_get_int( video_properties, "width" ) );
-				mlt_properties_set_int( frame_properties, "height", mlt_properties_get_int( video_properties, "height" ) );
+				(*frame)->image.width = mlt_properties_get_int( video_properties, "width" );
+				(*frame)->image.width = mlt_properties_get_int( video_properties, "height" );
 				mlt_properties_pass_list( frame_properties, video_properties, "meta.media.width, meta.media.height" );
 				mlt_properties_set_int( frame_properties, "progressive", mlt_properties_get_int( video_properties, "progressive" ) );
 				mlt_properties_set_double( frame_properties, "aspect_ratio", mlt_properties_get_double( video_properties, "aspect_ratio" ) );

--- a/src/mlt++/MltFrame.cpp
+++ b/src/mlt++/MltFrame.cpp
@@ -133,3 +133,10 @@ int Frame::set_alpha( uint8_t *alpha, int size, mlt_destructor destroy )
 {
 	return mlt_frame_set_alpha( get_frame(), alpha, size, destroy );
 }
+
+Image Frame::image()
+{
+	mlt_image clone = mlt_image_new();
+	mlt_image_copy_shallow( &(get_frame()->image), clone );
+	return Image( clone );
+}

--- a/src/mlt++/MltFrame.h
+++ b/src/mlt++/MltFrame.h
@@ -24,6 +24,7 @@
 #include "MltConfig.h"
 
 #include <framework/mlt.h>
+#include "MltImage.h"
 #include "MltProperties.h"
 
 namespace Mlt
@@ -54,6 +55,7 @@ namespace Mlt
 			mlt_properties get_unique_properties( Service &service );
 			int set_image( uint8_t *image, int size, mlt_destructor destroy );
 			int set_alpha( uint8_t *alpha, int size, mlt_destructor destroy );
+			Image image();
 	};
 }
 

--- a/src/mlt++/MltPushConsumer.cpp
+++ b/src/mlt++/MltPushConsumer.cpp
@@ -132,15 +132,3 @@ int PushConsumer::drain( )
 {
 	return 0;
 }
-
-// Convenience function - generates a frame with an image of a given size
-Frame *PushConsumer::construct( int size )
-{
-	mlt_frame f = mlt_frame_init( get_service() );
-	Frame *frame = new Frame( f );
-	uint8_t *buffer = ( uint8_t * )mlt_pool_alloc( size );
-	frame->set( "image", buffer, size, mlt_pool_release );
-	mlt_frame_close( f );
-	return frame;
-}
-

--- a/src/mlt++/MltPushConsumer.h
+++ b/src/mlt++/MltPushConsumer.h
@@ -44,7 +44,6 @@ namespace Mlt
 			int push( Frame *frame );
 			int push( Frame &frame );
 			int drain( );
-			Frame *construct( int );
 	};
 }
 

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -683,5 +683,6 @@ MLTPP_7.0.0 {
       "Mlt::EventData::to_string() const";
       "Mlt::EventData::to_frame() const";
       "Mlt::EventData::to_object() const";
+      "Mlt::Frame::image()";
     };
 } MLTPP_6.22.0;

--- a/src/modules/avformat/filter_avcolour_space.c
+++ b/src/modules/avformat/filter_avcolour_space.c
@@ -130,8 +130,8 @@ static int convert_image( mlt_frame frame, uint8_t **image, mlt_image_format *fo
 		int profile_colorspace = profile ? profile->colorspace : 601;
 		int colorspace = mlt_properties_get_int( properties, "colorspace" );
 		int force_full_luma = 0;
-		int width = mlt_properties_get_int( properties, "width" );
-		int height = mlt_properties_get_int( properties, "height" );
+		int width = frame->image.width;
+		int height = frame->image.height;
 
 		if (out_width <= 0)
 			out_width = width;
@@ -179,7 +179,7 @@ static int convert_image( mlt_frame frame, uint8_t **image, mlt_image_format *fo
 			}
 		} else {
 			// Scaling
-			mlt_properties_clear(properties, "alpha");
+			mlt_image_clear_alpha( &frame->image );
 		}
 
 		// Update the output
@@ -195,18 +195,15 @@ static int convert_image( mlt_frame frame, uint8_t **image, mlt_image_format *fo
 		}
 		*image = output;
 		*format = output_format;
-		mlt_frame_set_image( frame, output, size, mlt_pool_release );
-		mlt_properties_set_int( properties, "format", output_format );
-		mlt_properties_set_int(properties, "width", out_width);
-		mlt_properties_set_int(properties, "height", out_height);
+		mlt_image_set_values( &frame->image, output, output_format, out_width, out_height );
+		frame->image.release_data = mlt_pool_release;
 
 		if (out_width == width && out_height == height)
 		if ( output_format == mlt_image_rgba )
 		{
 			register int len = width * height;
-			int alpha_size = 0;
+			int alpha_size = frame->image.width * frame->image.height;
 			uint8_t *alpha = mlt_frame_get_alpha( frame );
-			mlt_properties_get_data( properties, "alpha", &alpha_size );
 
 			if ( alpha && alpha_size >= len )
 			{

--- a/src/modules/avformat/filter_swscale.c
+++ b/src/modules/avformat/filter_swscale.c
@@ -133,8 +133,7 @@ static int filter_scale( mlt_frame frame, uint8_t **image, mlt_image_format *for
 		*image = outbuf;
 	
 		// Scale the alpha channel only if exists and not correct size
-		int alpha_size = 0;
-		mlt_properties_get_data( properties, "alpha", &alpha_size );
+		int alpha_size = frame->image.width * frame->image.height;
 		if ( alpha_size > 0 && alpha_size != ( owidth * oheight ) )
 		{
 			// Create the context and output image

--- a/src/modules/core/consumer_multi.c
+++ b/src/modules/core/consumer_multi.c
@@ -416,10 +416,8 @@ static void foreach_consumer_put( mlt_consumer consumer, mlt_frame frame )
 				buffer += nested_size;
 
 				// Fix some things
-				mlt_properties_set_int( clone_props, "meta.media.width",
-					mlt_properties_get_int( MLT_FRAME_PROPERTIES(frame), "width" ) );
-				mlt_properties_set_int( clone_props, "meta.media.height",
-					mlt_properties_get_int( MLT_FRAME_PROPERTIES(frame), "height" ) );
+				mlt_properties_set_int( clone_props, "meta.media.width", frame->image.width );
+				mlt_properties_set_int( clone_props, "meta.media.height", frame->image.height );
 
 				// send frame to nested consumer
 				mlt_consumer_put_frame( nested, clone_frame );

--- a/src/modules/core/filter_brightness.c
+++ b/src/modules/core/filter_brightness.c
@@ -51,8 +51,10 @@ static int sliced_proc(int id, int index, int jobs, void* cookie)
 			uint8_t* p = ctx->image->planes[0] + ( (slice_line_start + line) * ctx->image->strides[0]);
 			for ( int pixel = 0; pixel < ctx->image->width; pixel++ )
 			{
-				*p++ = CLAMP((*p * m) >> 16, 16, 235);
-				*p++ = CLAMP((*p * m + n) >> 16, 16, 240);
+				*p = CLAMP((*p * m) >> 16, 16, 235);
+				p++;
+				*p = CLAMP((*p * m + n) >> 16, 16, 240);
+				p++;
 			}
 		}
 
@@ -77,7 +79,8 @@ static int sliced_proc(int id, int index, int jobs, void* cookie)
 				uint8_t* p = ctx->image->planes[3] + ( (slice_line_start + line) * ctx->image->strides[3]);
 				for ( int pixel = 0; pixel < ctx->image->width; pixel++ )
 				{
-					*p++ = (*p * m) >> 16;
+					*p = (*p * m) >> 16;
+					p++;
 				}
 			}
 		}

--- a/src/modules/core/filter_choppy.c
+++ b/src/modules/core/filter_choppy.c
@@ -47,31 +47,8 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		} else {
 			mlt_service_unlock(MLT_FILTER_SERVICE(filter));
 			error = mlt_frame_get_image(frame, image, format, width, height, writable);
-			if (!error) {
-				mlt_properties cloned_props = MLT_FRAME_PROPERTIES(cloned_frame);
-				int size = 0;
-				void *data = mlt_properties_get_data(cloned_props, "image", &size);
-				if (data) {
-					*width = mlt_properties_get_int(cloned_props, "width");
-					*height = mlt_properties_get_int(cloned_props, "height");
-					*format = mlt_properties_get_int(cloned_props, "format");
-					if (!size) {
-						size = mlt_image_format_size(*format, *width, *height, NULL);
-					}
-					*image = mlt_pool_alloc(size);
-					memcpy(*image, data, size);
-					mlt_frame_set_image(frame, *image, size, mlt_pool_release);
-
-					data = mlt_properties_get_data(cloned_props, "alpha", &size);
-					if (data) {
-						if (!size) {
-							size = (*width) * (*height);
-						}
-						void *copy = mlt_pool_alloc(size);
-						memcpy(copy, data, size);
-						mlt_frame_set_alpha(frame, copy, size, mlt_pool_release);
-					}
-				}
+			if (!error && cloned_frame && cloned_frame->image.data) {
+				mlt_image_copy_deep( &cloned_frame->image, &frame->image );
 			}
 		}
 	} else {

--- a/src/modules/core/filter_crop.c
+++ b/src/modules/core/filter_crop.c
@@ -113,8 +113,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 
 		// We should resize the alpha too
 		uint8_t *alpha = mlt_frame_get_alpha( frame );
-		int alpha_size = 0;
-		mlt_properties_get_data( properties, "alpha", &alpha_size );
+		int alpha_size = frame->image.width * frame->image.height;
 		if ( alpha && alpha_size >= ( *width * *height ) )
 		{
 			uint8_t *newalpha = mlt_pool_alloc( owidth * oheight );

--- a/src/modules/core/filter_imageconvert.c
+++ b/src/modules/core/filter_imageconvert.c
@@ -462,9 +462,8 @@ static conversion_function conversion_matrix[ mlt_image_invalid - 1 ][ mlt_image
 static int convert_image( mlt_frame frame, uint8_t **buffer, mlt_image_format *format, mlt_image_format requested_format )
 {
 	int error = 0;
-	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
-	int width = mlt_properties_get_int( properties, "width" );
-	int height = mlt_properties_get_int( properties, "height" );
+	int width = frame->image.width;
+	int height = frame->image.height;
 
 	if ( *format != requested_format )
 	{

--- a/src/modules/core/filter_mask_apply.c
+++ b/src/modules/core/filter_mask_apply.c
@@ -27,11 +27,7 @@
 
 static int dummy_get_image(mlt_frame frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable)
 {
-	mlt_properties properties = MLT_FRAME_PROPERTIES(frame);
-	*image = mlt_properties_get_data(properties, "image", NULL);
-	*format = mlt_properties_get_int(properties, "format");
-	*width = mlt_properties_get_int(properties, "width");
-	*height = mlt_properties_get_int(properties, "height");
+	mlt_image_get_values( &frame->image, (void**)image, format, width, height );
 	return 0;
 }
 

--- a/src/modules/core/filter_rescale.c
+++ b/src/modules/core/filter_rescale.c
@@ -244,7 +244,9 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 			}
 			// Scale the alpha channel only if exists and not correct size
 			int alpha_size = 0;
-			mlt_properties_get_data( properties, "alpha", &alpha_size );
+			if( frame->image.planes[3] ) {
+				alpha_size = frame->image.width * frame->image.height;
+			}
 			if ( alpha_size > 0 && alpha_size != ( owidth * oheight ) && alpha_size != ( owidth * ( oheight + 1 ) ) )
 				scale_alpha( frame, iwidth, iheight, owidth, oheight );
 		}

--- a/src/modules/core/filter_resize.c
+++ b/src/modules/core/filter_resize.c
@@ -136,15 +136,14 @@ static uint8_t *frame_resize_image( mlt_frame frame, int owidth, int oheight, ml
 	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
 
 	// Get the input image, width and height
-	uint8_t *input = mlt_properties_get_data( properties, "image", NULL );
-	uint8_t *alpha = mlt_frame_get_alpha( frame );
-	int alpha_size = 0;
-	mlt_properties_get_data( properties, "alpha", &alpha_size );
+	uint8_t *input = frame->image.data;
+	uint8_t *alpha = frame->image.planes[3];
+	int alpha_size = frame->image.strides[3] * frame->image.height;
 	int bpp = 0;
 	mlt_image_format_size( format, owidth, oheight, &bpp );
 
-	int iwidth = mlt_properties_get_int( properties, "width" );
-	int iheight = mlt_properties_get_int( properties, "height" );
+	int iwidth = frame->image.width;
+	int iheight = frame->image.height;
 
 	// If width and height are correct, don't do anything
 	if ( iwidth < owidth || iheight < oheight )
@@ -230,9 +229,9 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 		int real_width = mlt_properties_get_int( properties, "meta.media.width" );
 		int real_height = mlt_properties_get_int( properties, "meta.media.height" );
 		if ( real_width == 0 )
-			real_width = mlt_properties_get_int( properties, "width" );
+			real_width = frame->image.width;
 		if ( real_height == 0 )
-			real_height = mlt_properties_get_int( properties, "height" );
+			real_height = frame->image.height;
 		double input_ar = aspect_ratio * real_width / real_height;
 		double output_ar = consumer_aspect * owidth / oheight;
 		
@@ -267,9 +266,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 	// If there will be padding, then we need packed image format.
 	if ( *format == mlt_image_yuv420p )
 	{
-		int iwidth = mlt_properties_get_int( properties, "width" );
-		int iheight = mlt_properties_get_int( properties, "height" );
-		if ( iwidth < owidth || iheight < oheight )
+		if ( frame->image.width < owidth || frame->image.height < oheight )
 			*format = mlt_image_yuv422;
 	}
 

--- a/src/modules/core/filter_watermark.c
+++ b/src/modules/core/filter_watermark.c
@@ -199,8 +199,8 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 				mlt_frame_set_image( frame, *image, *width * *height * 2, NULL );
 				if ( alpha )
 					mlt_frame_set_alpha( frame, alpha, *width * *height, NULL );
-				mlt_properties_set_int( a_props, "width", *width );
-				mlt_properties_set_int( a_props, "height", *height );
+				a_frame->image.width = *width;
+				a_frame->image.height = *height;
 				mlt_properties_set_int( a_props, "progressive", 1 );
 				mlt_properties_inc_ref( b_props );
 				strcpy( temp, "_b_frame" );

--- a/src/modules/core/link_timeremap.c
+++ b/src/modules/core/link_timeremap.c
@@ -244,10 +244,8 @@ static int link_get_image_blend( mlt_frame frame, uint8_t** image, mlt_image_for
 		*p = sum / image_count;
 		p++;
 	}
-	mlt_frame_set_image( frame, *image, size, mlt_pool_release );
-	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "format", *format );
-	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "width", *width );
-	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "height", *height );
+	mlt_image_set_values( &frame->image, *image, *format, *width, *height );
+	frame->image.release_data = mlt_pool_release;
 	mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "colorspace", colorspace );
 
 	return 0;
@@ -276,10 +274,8 @@ static int link_get_image_nearest( mlt_frame frame, uint8_t** image, mlt_image_f
 			int size = mlt_image_format_size( *format, *width, *height, NULL );
 			*image = mlt_pool_alloc( size );
 			memcpy( *image, in_image, size );
-			mlt_frame_set_image( frame, *image, size, mlt_pool_release );
-			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "format", *format );
-			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "width", *width );
-			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "height", *height );
+			mlt_image_set_values( &frame->image, *image, *format, *width, *height );
+			frame->image.release_data = mlt_pool_release;
 			mlt_properties_set_int( MLT_FRAME_PROPERTIES(frame), "colorspace", mlt_properties_get_int( MLT_FRAME_PROPERTIES(src_frame), "colorspace" ));
 
 			uint8_t* in_alpha = mlt_frame_get_alpha( src_frame );

--- a/src/modules/core/producer_consumer.c
+++ b/src/modules/core/producer_consumer.c
@@ -60,7 +60,8 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 	*image = new_image;
 	
 	// Copy the alpha channel
-	uint8_t *alpha = mlt_properties_get_data( MLT_FRAME_PROPERTIES( nested_frame ), "alpha", &size );
+	uint8_t *alpha = nested_frame->image.planes[3];
+	size = nested_frame->image.width * nested_frame->image.height;
 	if ( alpha && size > 0 )
 	{
 		new_image = mlt_pool_alloc( size );
@@ -216,8 +217,8 @@ static int get_frame( mlt_producer self, mlt_frame_ptr frame, int index )
 
 		// Inform the normalizers about our video properties
 		mlt_properties_set_double( frame_props, "aspect_ratio", mlt_profile_sar( cx->profile ) );
-		mlt_properties_set_int( frame_props, "width", cx->profile->width );
-		mlt_properties_set_int( frame_props, "height", cx->profile->height );
+		(*frame)->image.width = cx->profile->width;
+		(*frame)->image.height = cx->profile->height;
 		mlt_properties_set_int( frame_props, "meta.media.width", cx->profile->width );
 		mlt_properties_set_int( frame_props, "meta.media.height", cx->profile->height );
 		mlt_properties_set_int( frame_props, "progressive", cx->profile->progressive );

--- a/src/modules/core/producer_hold.c
+++ b/src/modules/core/producer_hold.c
@@ -85,10 +85,9 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	mlt_frame real_frame = mlt_frame_pop_service( frame );
 
 	// Get the image from the real frame
-	int size = 0;
-	*buffer = mlt_properties_get_data( MLT_FRAME_PROPERTIES( real_frame ), "image", &size );
-	*width = mlt_properties_get_int( MLT_FRAME_PROPERTIES( real_frame ), "width" );
-	*height = mlt_properties_get_int( MLT_FRAME_PROPERTIES( real_frame ), "height" );
+	*buffer = real_frame->image.data;
+	*width = real_frame->image.width;
+	*height = real_frame->image.height;
 
 	// If this is the first time, get it from the producer
 	if ( *buffer == NULL )
@@ -105,11 +104,11 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 		mlt_frame_get_image( real_frame, buffer, format, width, height, writable );
 	
 		// Make sure we get the size
-		*buffer = mlt_properties_get_data( MLT_FRAME_PROPERTIES( real_frame ), "image", &size );
+		*buffer = real_frame->image.data;
 	}
 
 	mlt_properties_pass( properties, MLT_FRAME_PROPERTIES( real_frame ), "" );
-
+	int size = mlt_image_format_size( *format, *width, *height, NULL );
 	// Set the values obtained on the frame
 	if ( *buffer != NULL )
 	{
@@ -167,8 +166,7 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		else
 		{
 			// Temporary fix - ensure that we aren't seen as a test frame
-			uint8_t *image = mlt_properties_get_data( MLT_FRAME_PROPERTIES( real_frame ), "image", NULL );
-			mlt_frame_set_image( *frame, image, 0, NULL );
+			mlt_frame_set_image( *frame, real_frame->image.data, 0, NULL );
 			mlt_properties_set_int( MLT_FRAME_PROPERTIES( *frame ), "test_image", 0 );
 		}
 

--- a/src/modules/core/transition_composite.c
+++ b/src/modules/core/transition_composite.c
@@ -632,13 +632,17 @@ static int get_b_frame_image( mlt_transition self, mlt_frame b_frame, uint8_t **
 	mlt_properties properties = MLT_TRANSITION_PROPERTIES( self );
 	uint8_t resize_alpha = mlt_properties_get_int( b_props, "resize_alpha" );
 	double output_ar = mlt_profile_sar( mlt_service_profile( MLT_TRANSITION_SERVICE(self) ) );
+	int real_width = mlt_properties_get_int( b_props, "meta.media.width" );
+	if (!real_width)
+		real_width = b_frame->image.width;
+	int real_height = mlt_properties_get_int( b_props, "meta.media.height" );
+	if (!real_height)
+		real_height = b_frame->image.height;
 
 	// Do not scale if we are cropping - the compositing rectangle can crop the b image
 	// TODO: Use the animatable w and h of the crop geometry to scale independently of crop rectangle
 	if ( mlt_properties_get( properties, "crop" ) )
 	{
-		int real_width = get_value( b_props, "meta.media.width", "width" );
-		int real_height = get_value( b_props, "meta.media.height", "height" );
 		double input_ar = mlt_properties_get_double( b_props, "aspect_ratio" );
 		int scaled_width = rint( ( input_ar == 0.0 ? output_ar : input_ar ) / output_ar * real_width );
 		int scaled_height = real_height;
@@ -647,8 +651,6 @@ static int get_b_frame_image( mlt_transition self, mlt_frame b_frame, uint8_t **
 	}
 	else if ( mlt_properties_get_int( properties, "crop_to_fill" ) )
 	{
-		int real_width = get_value( b_props, "meta.media.width", "width" );
-		int real_height = get_value( b_props, "meta.media.height", "height" );
 		double input_ar = mlt_properties_get_double( b_props, "aspect_ratio" );
 		int scaled_width = rint( ( input_ar == 0.0 ? output_ar : input_ar ) / output_ar * real_width );
 		int scaled_height = real_height;
@@ -677,8 +679,6 @@ static int get_b_frame_image( mlt_transition self, mlt_frame b_frame, uint8_t **
 		// Adjust b_frame pixel aspect
 		int normalised_width = geometry->item.w;
 		int normalised_height = geometry->item.h;
-		int real_width = get_value( b_props, "meta.media.width", "width" );
-		int real_height = get_value( b_props, "meta.media.height", "height" );
 		double input_ar = mlt_properties_get_double( b_props, "aspect_ratio" );
 		int scaled_width = rint( ( input_ar == 0.0 ? output_ar : input_ar ) / output_ar * real_width );
 		int scaled_height = real_height;

--- a/src/modules/core/transition_luma.c
+++ b/src/modules/core/transition_luma.c
@@ -547,9 +547,9 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 	}
 
 	// Extract the a_frame image info
-	*width = mlt_properties_get_int( !invert ? a_props : b_props, "width" );
-	*height = mlt_properties_get_int( !invert ? a_props : b_props, "height" );
-	*image = mlt_properties_get_data( !invert ? a_props : b_props, "image", NULL );
+	*width = !invert ? a_frame->image.width : b_frame->image.width;
+	*height = !invert ? a_frame->image.width : b_frame->image.width;
+	*image = !invert ? (uint8_t*)a_frame->image.data : (uint8_t*)b_frame->image.data;
 
 	return 0;
 }

--- a/src/modules/core/transition_matte.c
+++ b/src/modules/core/transition_matte.c
@@ -161,16 +161,10 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 
 	mlt_frame_get_image( a_frame, image, format, width, height, 1 );
 
-	// Get the properties of the a frame
-	mlt_properties a_props = MLT_FRAME_PROPERTIES( a_frame );
-
-	// Get the properties of the b frame
-	mlt_properties b_props = MLT_FRAME_PROPERTIES( b_frame );
-
 	int
-		width_a = mlt_properties_get_int( a_props, "width" ),
+		width_a = a_frame->image.width,
 		width_b = width_a,
-		height_a = mlt_properties_get_int( a_props, "height" ),
+		height_a = a_frame->image.height,
 		height_b = height_a;
 	
 	uint8_t *alpha_a, *image_b;
@@ -198,9 +192,9 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 	);
 
 	// Extract the a_frame image info
-	*width = mlt_properties_get_int( a_props, "width" );
-	*height = mlt_properties_get_int( a_props, "height" );
-	*image = mlt_properties_get_data( a_props, "image", NULL );
+	*width = a_frame->image.width;
+	*height = a_frame->image.height;
+	*image = a_frame->image.data;
 
 	return 0;
 }

--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -407,9 +407,9 @@ public:
 			mlt_properties_set_int( properties, "meta.media.sample_aspect_den", profile->sample_aspect_den );
 			mlt_properties_set_int( properties, "meta.media.frame_rate_num", profile->frame_rate_num );
 			mlt_properties_set_int( properties, "meta.media.frame_rate_den", profile->frame_rate_den );
-			mlt_properties_set_int( properties, "width", profile->width );
+			frame->image.width = profile->width;
 			mlt_properties_set_int( properties, "meta.media.width", profile->width );
-			mlt_properties_set_int( properties, "height", profile->height );
+			frame->image.height = profile->height;
 			mlt_properties_set_int( properties, "meta.media.height", profile->height );
 			mlt_properties_set_int( properties, "format", ( m_pixel_format == bmdFormat8BitYUV ) ? mlt_image_yuv422 : mlt_image_yuv422p16 );
 			mlt_properties_set_int( properties, "colorspace", m_colorspace );

--- a/src/modules/frei0r/transition_frei0r.c
+++ b/src/modules/frei0r/transition_frei0r.c
@@ -100,9 +100,9 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 
 		process_frei0r_item( MLT_TRANSITION_SERVICE(transition), position, time, length, !invert ? a_frame : b_frame, images, width, height );
 
-		*width = mlt_properties_get_int( !invert ? a_props : b_props, "width" );
-		*height = mlt_properties_get_int( !invert ? a_props : b_props, "height" );
-		*image = mlt_properties_get_data( !invert ? a_props : b_props , "image", NULL );
+		*width = !invert ? a_frame->image.width : b_frame->image.width;
+		*height = !invert ? a_frame->image.width : b_frame->image.width;
+		*image = !invert ? (uint8_t*)a_frame->image.data : (uint8_t*)b_frame->image.width;
 	}
 	return error;
 }

--- a/src/modules/gdk/producer_pango.c
+++ b/src/modules/gdk/producer_pango.c
@@ -568,8 +568,8 @@ static void refresh_image( producer_pango self, mlt_frame frame, int width, int 
 	}
 
 	// Set width/height
-	mlt_properties_set_int( properties, "width", self->width );
-	mlt_properties_set_int( properties, "height", self->height );
+	frame->image.width = self->width;
+	frame->image.height = self->height;
 }
 
 static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_format *format, int *width, int *height, int writable )

--- a/src/modules/gdk/producer_pixbuf.c
+++ b/src/modules/gdk/producer_pixbuf.c
@@ -555,8 +555,8 @@ static int refresh_pixbuf( producer_pixbuf self, mlt_frame frame )
 	}
 
 	// Set width/height of frame
-	mlt_properties_set_int( properties, "width", self->width );
-	mlt_properties_set_int( properties, "height", self->height );
+	frame->image.width = self->width;
+	frame->image.height = self->height;
 
 	return current_idx;
 }
@@ -636,11 +636,8 @@ static void refresh_image( producer_pixbuf self, mlt_frame frame, mlt_image_form
 			uint8_t *buffer = self->image;
 			if ( buffer )
 			{
-				mlt_frame_set_image( frame, self->image, image_size, mlt_pool_release );
-				mlt_properties_set_int( properties, "width", self->width );
-				mlt_properties_set_int( properties, "height", self->height );
-				mlt_properties_set_int( properties, "format", self->format );
-
+				mlt_image_set_values( &frame->image, self->image, self->format, self->width, self->height );
+				frame->image.release_data = mlt_pool_release;
 				if ( !frame->convert_image( frame, &self->image, &self->format, format ) )
 				{
 					buffer = self->image;
@@ -674,8 +671,8 @@ static void refresh_image( producer_pixbuf self, mlt_frame frame, mlt_image_form
 	}
 
 	// Set width/height of frame
-	mlt_properties_set_int( properties, "width", self->width );
-	mlt_properties_set_int( properties, "height", self->height );
+	frame->image.width = self->width;
+	frame->image.height = self->height;
 }
 
 static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_format *format, int *width, int *height, int writable )

--- a/src/modules/kdenlive/producer_framebuffer.c
+++ b/src/modules/kdenlive/producer_framebuffer.c
@@ -90,8 +90,8 @@ static int framebuffer_get_image( mlt_frame frame, uint8_t **image, mlt_image_fo
 		*format = (mlt_image_format) mlt_properties_get_int( properties, "_original_format" );
 	}
 	// Determine output buffer size
-	*width = mlt_properties_get_int( frame_properties, "width" );
-	*height = mlt_properties_get_int( frame_properties, "height" );
+	*width = frame->image.width;
+	*height = frame->image.height;
 	int size = mlt_image_format_size( *format, *width, *height, NULL );
 
 	// Get output buffer
@@ -154,8 +154,8 @@ static int framebuffer_get_image( mlt_frame frame, uint8_t **image, mlt_image_fo
 
 
 	// Which frames are buffered?
-	uint8_t *first_image = mlt_properties_get_data( first_frame_properties, "image", NULL );
-	uint8_t *first_alpha = mlt_properties_get_data( first_frame_properties, "alpha", NULL );
+	uint8_t *first_image = first_frame->image.data;
+	uint8_t *first_alpha = first_frame->image.planes[3];
 	if ( !first_image )
 	{
 		mlt_properties_set( first_frame_properties, "rescale.interp", mlt_properties_get( frame_properties, "rescale.interp" ) );
@@ -265,9 +265,10 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		// Give the returned frame temporal identity
 		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
 
-		mlt_properties_set_int( frame_properties, "meta.media.width", mlt_properties_get_int( properties, "width" ) );
-		mlt_properties_set_int( frame_properties, "meta.media.height", mlt_properties_get_int( properties, "height" ) );
-		mlt_properties_pass_list( frame_properties, properties, "width, height" );
+		mlt_properties_set_int( frame_properties, "meta.media.width", (*frame)->image.width );
+		mlt_properties_set_int( frame_properties, "meta.media.height", (*frame)->image.height );
+		mlt_properties_set_int( properties, "width", (*frame)->image.width );
+		mlt_properties_set_int( properties, "height", (*frame)->image.height );
 	}
 
 	return 0;

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -544,8 +544,8 @@ static int convert_image( mlt_frame frame, uint8_t **image, mlt_image_format *fo
 		return convert_on_cpu( frame, image, format, output_format );
 
 	int error = 0;
-	int width = mlt_properties_get_int( properties, "width" );
-	int height = mlt_properties_get_int( properties, "height" );
+	int width = frame->image.width;
+	int height = frame->image.height;
 
 	if (width < 1 || height < 1) {
 		mlt_log_error( NULL, "Invalid frame size for convert_image %dx%d.\n", width, height );
@@ -673,7 +673,7 @@ static int convert_image( mlt_frame frame, uint8_t **image, mlt_image_format *fo
 
 	GlslManager::get_instance()->unlock_service( frame );
 
-	mlt_properties_set_int( properties, "format", output_format );
+	frame->image.format = output_format;
 	*format = output_format;
 
 	return error;

--- a/src/modules/movit/filter_movit_resize.cpp
+++ b/src/modules/movit/filter_movit_resize.cpp
@@ -118,9 +118,9 @@ static int get_image( mlt_frame frame, uint8_t **image, mlt_image_format *format
 		int real_width = mlt_properties_get_int( properties, "meta.media.width" );
 		int real_height = mlt_properties_get_int( properties, "meta.media.height" );
 		if ( real_width == 0 )
-			real_width = mlt_properties_get_int( properties, "width" );
+			real_width = frame->image.width;
 		if ( real_height == 0 )
-			real_height = mlt_properties_get_int( properties, "height" );
+			real_height = frame->image.height;
 		double input_ar = aspect_ratio * real_width / real_height;
 		double output_ar = consumer_aspect * owidth / oheight;
 		

--- a/src/modules/oldfilm/filter_dust.c
+++ b/src/modules/oldfilm/filter_dust.c
@@ -132,7 +132,7 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 				{
 					mlt_image_format luma_format = mlt_image_yuv422;
 					luma_width = dx;
-					luma_height = luma_width * mlt_properties_get_int( MLT_FRAME_PROPERTIES ( luma_frame ) , "height" ) / mlt_properties_get_int( MLT_FRAME_PROPERTIES ( luma_frame ) , "width" );
+					luma_height = luma_width * luma_frame->image.height / luma_frame->image.width;
 
 					mlt_properties_set( MLT_FRAME_PROPERTIES( luma_frame ), "rescale.interp", "best" );// none/nearest/tiles/hyper
 					

--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -694,9 +694,6 @@ void drawKdenliveTitle( producer_ktitle self, mlt_frame frame, mlt_image_format 
 	mlt_profile profile = mlt_service_profile ( MLT_PRODUCER_SERVICE( producer ) ) ;
 	mlt_properties producer_props = MLT_PRODUCER_PROPERTIES( producer );
 
-	// Obtain properties of frame
-	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
-
 	pthread_mutex_lock( &self->mutex );
 
 	// Check if user wants us to reload the image or if we need animation
@@ -734,7 +731,7 @@ void drawKdenliveTitle( producer_ktitle self, mlt_frame frame, mlt_image_format 
 				qRegisterMetaType<QTextCursor>( "QTextCursor" );
 			scene = new QGraphicsScene();
 			scene->setItemIndexMethod( QGraphicsScene::NoIndex );
-			scene->setSceneRect(0, 0, mlt_properties_get_int( properties, "width" ), mlt_properties_get_int( properties, "height" ));
+			scene->setSceneRect(0, 0, frame->image.width, frame->image.height);
 			if ( mlt_properties_get( producer_props, "resource" ) && mlt_properties_get( producer_props, "resource" )[0] != '\0' )
 			{
 				// The title has a resource property, so we read all properties from the resource.
@@ -877,8 +874,8 @@ void drawKdenliveTitle( producer_ktitle self, mlt_frame frame, mlt_image_format 
 	}
 
 	pthread_mutex_unlock( &self->mutex );
-	mlt_properties_set_int( properties, "width", self->current_width );
-	mlt_properties_set_int( properties, "height", self->current_height );
+	frame->image.width = self->current_width;
+	frame->image.height = self->current_height;
 }
 
 

--- a/src/modules/qt/producer_kdenlivetitle.c
+++ b/src/modules/qt/producer_kdenlivetitle.c
@@ -89,8 +89,8 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 		drawKdenliveTitle( self, frame, *format, *width, *height, mlt_frame_original_position( frame ), 0 );
 	}
 	// Get width and height (may have changed during the refresh)
-	*width = mlt_properties_get_int( properties, "width" );
-	*height = mlt_properties_get_int( properties, "height" );
+	*width = frame->image.width;
+	*height = frame->image.height;
 	*format = self->format;
 
 	if ( self->current_image )

--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -250,8 +250,8 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	refresh_image( self, frame, *format, *width, *height, enable_caching );
 
 	// Get width and height (may have changed during the refresh)
-	*width = mlt_properties_get_int( properties, "width" );
-	*height = mlt_properties_get_int( properties, "height" );
+	*width = frame->image.width;
+	*height = frame->image.height;
 	*format = self->format;
 
 	// NB: Cloning is necessary with this producer (due to processing of images ahead of use)

--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -348,10 +348,9 @@ static int producer_get_image( mlt_frame frame, uint8_t** buffer, mlt_image_form
 	copy_image_to_alpha( *buffer, alpha, *width, *height );
 
 	// Update the frame
-	mlt_frame_set_image( frame, *buffer, img_size, mlt_pool_release );
+	mlt_image_set_values( &frame->image, *buffer, *format, *width, *height );
+	frame->image.release_data = mlt_pool_release;
 	mlt_frame_set_alpha( frame, alpha, alpha_size, mlt_pool_release );
-	mlt_properties_set_int( frame_properties, "width", *width );
-	mlt_properties_set_int( frame_properties, "height", *height );
 
 	return 0;
 }

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -143,7 +143,6 @@ static QImage* reorient_with_exif( producer_qimage self, int image_idx, QImage *
 int refresh_qimage( producer_qimage self, mlt_frame frame, int enable_caching )
 {
 	// Obtain properties of frame and producer
-	mlt_properties properties = MLT_FRAME_PROPERTIES( frame );
 	mlt_producer producer = &self->parent;
 	mlt_properties producer_props = MLT_PRODUCER_PROPERTIES( producer );
 
@@ -223,8 +222,8 @@ int refresh_qimage( producer_qimage self, mlt_frame frame, int enable_caching )
 	}
 
 	// Set width/height of frame
-	mlt_properties_set_int( properties, "width", self->current_width );
-	mlt_properties_set_int( properties, "height", self->current_height );
+	frame->image.width = self->current_width;
+	frame->image.height = self->current_height;
 
 	return image_idx;
 }
@@ -355,10 +354,12 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 				self->current_image = (uint8_t*) mlt_pool_alloc( image_size );
 				memcpy( self->current_image, buffer, image_size );
 			}
-			if ( ( buffer = (uint8_t*) mlt_properties_get_data( properties, "alpha", &self->alpha_size ) ) )
+			buffer = frame->image.planes[3];
+			self->alpha_size = frame->image.width * frame->image.height;
+			if ( buffer )
 			{
-                if ( !self->alpha_size )
-                    self->alpha_size = self->current_width * self->current_height;
+				if ( !self->alpha_size )
+					self->alpha_size = self->current_width * self->current_height;
 				self->current_alpha = (uint8_t*) mlt_pool_alloc( self->alpha_size );
 				memcpy( self->current_alpha, buffer, self->alpha_size );
 			}
@@ -382,8 +383,8 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 	}
 
 	// Set width/height of frame
-	mlt_properties_set_int( properties, "width", self->current_width );
-	mlt_properties_set_int( properties, "height", self->current_height );
+	frame->image.width = self->current_width;
+	frame->image.height = self->current_height;
 }
 
 extern void make_tempfile( producer_qimage self, const char *xml )

--- a/src/modules/qt/transition_vqm.cpp
+++ b/src/modules/qt/transition_vqm.cpp
@@ -183,9 +183,9 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 
 	// finish Qt drawing
 	painter.end();
-	window_size = mlt_image_format_size( *format, *width, *height, NULL );
-	uint8_t *dst = (uint8_t *) mlt_pool_alloc( window_size );
-	mlt_properties_set_data( MLT_FRAME_PROPERTIES(a_frame), "image", dst, window_size, mlt_pool_release, NULL );
+	mlt_image_set_values( &a_frame->image, NULL, *format, *width, *height );
+	mlt_image_alloc_data( &a_frame->image );
+	uint8_t* dst = (uint8_t*)a_frame->image.data;
 	*image = dst;
 
 	// convert qimage to mlt

--- a/src/modules/sdl/consumer_sdl_still.c
+++ b/src/modules/sdl/consumer_sdl_still.c
@@ -569,7 +569,6 @@ static void *consumer_thread( void *arg )
 					vfmt = preview_format;
 			
 				mlt_frame_get_image( frame, &image, &vfmt, &width, &height, 0 );
-				mlt_properties_set_int( MLT_FRAME_PROPERTIES( frame ), "format", vfmt );
 				mlt_events_fire( properties, "consumer-frame-show", mlt_event_data_from_frame(frame) );
 			}
 			mlt_frame_close( frame );


### PR DESCRIPTION
For discussion: not ready for commit.

This change is a proof of concept. It would be a necessary step if eventually we want mlt_frame_get_image() to use mlt_image (same for audio).

Some questions for this review:
* Are we interested in this approach overall?
* Is MLT7 good timing for a change this large (perhaps the window has closed). I would like to change mlt_frame_get_*() to use mlt_image and mlt_audio for MLT7. 

Notice that this concept provides a backwards compatible form of mlt_frame_get_image() so that every single service does not have to be changed (just the ones that modify properties directly).