### PR TITLE
Use image based producers for jfif images

### DIFF
--- a/src/modules/core/loader.dict
+++ b/src/modules/core/loader.dict
@@ -22,6 +22,7 @@ plain:https://*=webvfx:plain:
 *.ico=qimage,avformat
 *.jfx=xml
 *.jef=xml
+*.jfif=qimage,pixbuf
 *.jpg=qimage,pixbuf
 *.jpeg=qimage,pixbuf
 *.kdenlivetitle=kdenlivetitle


### PR DESCRIPTION
Currently, jfif images are loaded using the avformat producer by default. For MLT based apps, it would be better to load it with the usual image producers