### PR TITLE
Fix building frei0r module in KDE Craft

### DIFF
--- a/src/modules/frei0r/CMakeLists.txt
+++ b/src/modules/frei0r/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(mltfrei0r MODULE
 )
 
 target_compile_options(mltfrei0r PRIVATE ${MLT_COMPILE_OPTIONS})
+target_include_directories(mltfrei0r PRIVATE ${FREI0R_INCLUDE_DIRS})
 if(APPLE AND RELOCATABLE)
   target_compile_definitions(mltfrei0r PRIVATE RELOCATABLE)
 endif()


### PR DESCRIPTION
when all dependencies are prepared in a bundle folder, cmake build was not finding frei0r.h