### PR TITLE
Add speed parameter to timer filter

### DIFF
--- a/src/modules/plus/filter_timer.c
+++ b/src/modules/plus/filter_timer.c
@@ -38,7 +38,7 @@ double time_to_seconds( char* time )
 static void get_timer_str( mlt_filter filter, mlt_frame frame, char* text )
 {
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
-	mlt_position current_frame = mlt_filter_get_position( filter, frame );
+	mlt_position current_frame = mlt_filter_get_position( filter, frame ) * mlt_properties_get_double( properties, "speed" );
 	char* direction = mlt_properties_get( properties, "direction" );
 	double timer_start = time_to_seconds( mlt_properties_get( properties, "start" ) );
 	double timer_duration = time_to_seconds( mlt_properties_get( properties, "duration" ) );
@@ -160,6 +160,7 @@ mlt_filter filter_timer_init( mlt_profile profile, mlt_service_type type, const 
 		mlt_properties_set( my_properties, "start", "00:00:00.000" );
 		mlt_properties_set( my_properties, "duration", "00:10:00.000" );
 		mlt_properties_set( my_properties, "offset", "00:00:00.000" );
+		mlt_properties_set_double( my_properties, "speed", 1.0 );
 		mlt_properties_set( my_properties, "direction", "up" );
 		mlt_properties_set( my_properties, "geometry", "0%/0%:100%x100%:100%" );
 		mlt_properties_set( my_properties, "family", "Sans" );

--- a/src/modules/plus/filter_timer.yml
+++ b/src/modules/plus/filter_timer.yml
@@ -71,6 +71,16 @@ parameters:
     mutable: yes
     widget: text
 
+  - identifier: speed
+    title: Speed
+    type: float
+    description: >
+      Clock speed multiplier. For example, speed 10.0 makes the timer tick 10
+      seconds for each second of playback.
+    default: 1.0
+    readonly: no
+    mutable: yes
+
   - identifier: direction
     title: Direction
     type: string


### PR DESCRIPTION
Hi! I'm currently using Shotcut to edit a timelapse video and wanted the ability to add a sped-up "real-time" timer to the timelapse. I traced that back to here and was able to successfully plumb this through the Shotcut UI and implement the feature. Do you want it?

This is my first contact with this library, so please let me know if there's something more I should do for this (like add tests, or translation keys?).