### PR TITLE
Honor DESTDIR when creating the melt symlink

### DIFF
--- a/src/melt/CMakeLists.txt
+++ b/src/melt/CMakeLists.txt
@@ -23,6 +23,6 @@ if(WIN32 OR APPLE)
 else()
   install(PROGRAMS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/melt" DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME melt-${MLT_VERSION_MAJOR})
   install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink melt-${MLT_VERSION_MAJOR} melt \
-                                WORKING_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR})"
+                                WORKING_DIRECTORY \$ENV\{DESTDIR\}${CMAKE_INSTALL_FULL_BINDIR})"
   )
 endif()


### PR DESCRIPTION
Otherwise it will try to create it on the host build system