### PR TITLE
Fix vidstab metadata path

### DIFF
--- a/src/modules/vid.stab/CMakeLists.txt
+++ b/src/modules/vid.stab/CMakeLists.txt
@@ -13,4 +13,4 @@ set_target_properties(mltvidstab PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${MLT_MODU
 
 install(TARGETS mltvidstab LIBRARY DESTINATION ${MLT_INSTALL_MODULE_DIR})
 
-install(FILES filter_deshake.yml filter_vidstab.yml DESTINATION ${MLT_INSTALL_DATA_DIR}/vidstab)
+install(FILES filter_deshake.yml filter_vidstab.yml DESTINATION ${MLT_INSTALL_DATA_DIR}/vid.stab)


### PR DESCRIPTION
When switching from autotools to cmake build system, the metadata path was switched from "vid.stab" to "vidstab". The metadada is registered in factory.c as "vid.stab", so it is not found anymore with the cmake build.