### PR TITLE
Fix rgb names missed in rename

### DIFF
--- a/presets/consumer/avformat/alpha/Quicktime Animation
+++ b/presets/consumer/avformat/alpha/Quicktime Animation
@@ -3,7 +3,7 @@ vcodec=qtrle
 g=1
 bf=0
 progressive=1
-mlt_image_format=rgb24a
+mlt_image_format=rgba
 pix_fmt=argb
 
 meta.preset.extension=mov

--- a/presets/consumer/avformat/alpha/Ut Video
+++ b/presets/consumer/avformat/alpha/Ut Video
@@ -1,6 +1,6 @@
 f=avi
 vcodec=utvideo
-mlt_image_format=rgb24a
+mlt_image_format=rgba
 pix_fmt=gbrap
 g=1
 bf=0

--- a/presets/consumer/avformat/alpha/vp8
+++ b/presets/consumer/avformat/alpha/vp8
@@ -19,7 +19,7 @@ arnr_max_frames=7
 arnr_strength=5
 arnr_type=3
 auto-alt-ref=0
-mlt_image_format=rgb24a
+mlt_image_format=rgba
 pix_fmt=yuva420p
 
 meta.preset.name=alpha/WebM VP8 with alpha channel

--- a/presets/consumer/avformat/alpha/vp9
+++ b/presets/consumer/avformat/alpha/vp9
@@ -21,7 +21,7 @@ frame-parallel=1
 lag-in-frames=25
 row-mt=1
 auto-alt-ref=0
-mlt_image_format=rgb24a
+mlt_image_format=rgba
 pix_fmt=yuva420p
 
 meta.preset.name=alpha/WebM VP9 with alpha channel

--- a/src/modules/core/filter_mask_apply.yml
+++ b/src/modules/core/filter_mask_apply.yml
@@ -34,8 +34,8 @@ parameters:
     description: Set to the same image format that the transition needs.
     values:
     mutable: yes
-    default: rgb24a
+    default: rgba
     values:
       - yuv422
-      - rgb24
-      - rgb24a
+      - rgb
+      - rgba

--- a/src/modules/core/filter_rescale.c
+++ b/src/modules/core/filter_rescale.c
@@ -31,10 +31,10 @@
  *
  * image scaler implementations are expected to support the following in and out formats:
  * yuv422 -> yuv422
- * rgb24 -> rgb24
- * rgb24a -> rgb24a
- * rgb24 -> yuv422
- * rgb24a -> yuv422
+ * rgb -> rgb
+ * rgba -> rgba
+ * rgb -> yuv422
+ * rgba -> yuv422
  */
 
 typedef int ( *image_scaler )( mlt_frame frame, uint8_t **image, mlt_image_format *format, int iwidth, int iheight, int owidth, int oheight );

--- a/src/modules/core/producer_colour.yml
+++ b/src/modules/core/producer_colour.yml
@@ -34,5 +34,5 @@ parameters:
     values:
       - yuv420p
       - yuv422
-      - rgb24
-      - rgb24a
+      - rgb
+      - rgba

--- a/src/modules/core/transition_matte.yml
+++ b/src/modules/core/transition_matte.yml
@@ -31,7 +31,7 @@ notes: |
 
   melt sg_gm_2013_clip_title.avi -attach frei0r.alpha0ps 0=0.21 -consumer \
     avformat:sg_gm_2013_clip_title.matte_full.mp4 crf=10 preset=placebo an=1 \
-    mlt_image_format=rgb24a pix_fmt=yuvj422p
+    mlt_image_format=rgba pix_fmt=yuvj422p
 
   ffmpeg -i sg_gm_2013_clip_title.avi -vf "alphaextract" -pix_fmt \
     yuvj422p -preset placebo -crf 10 -y sg_gm_2013_clip_title.matte_full.mp4

--- a/src/swig/python/getimage.py
+++ b/src/swig/python/getimage.py
@@ -25,6 +25,6 @@ frame.set("consumer_deinterlace", 1)
 
 # Now we are ready to get the image and save it.
 size = (profile.width(), profile.height())
-rgb = frame.get_image(mlt.mlt_image_rgb24, *size)
+rgb = frame.get_image(mlt.mlt_image_rgb, *size)
 img = Image.fromstring('RGB', size, rgb)
 img.save(sys.argv[1] + '.png')

--- a/src/tests/test_image/test_image.cpp
+++ b/src/tests/test_image/test_image.cpp
@@ -54,7 +54,7 @@ private Q_SLOTS:
 		QVERIFY(i.plane(0) != nullptr);
 	}
 
-	void PlaneAndStrideRgb24()
+	void PlaneAndStrideRgb()
 	{
 		Image i(1920, 1080, mlt_image_rgb );
 		QVERIFY(i.plane(0) != nullptr);
@@ -67,7 +67,7 @@ private Q_SLOTS:
 		QCOMPARE(i.stride(3), 0);
 	}
 
-	void PlaneAndStrideRgb24a()
+	void PlaneAndStrideRgba()
 	{
 		Image i(1920, 1080, mlt_image_rgba );
 		QVERIFY(i.plane(0) != nullptr);


### PR DESCRIPTION
rgb24 and rgb24a were renamed to rbg and rgba respectively in MLT7.
Some instances were missed in the rename.

Also fixes #1107