### PR TITLE
Fix clang LTO error

### DIFF
--- a/src/modules/decklink/common.cpp
+++ b/src/modules/decklink/common.cpp
@@ -99,8 +99,9 @@ void swab2( const void *from, void *to, int n )
 
 	__asm__ volatile
 	(
-		"loop_start:                            \n\t"
-
+		/* "loop_start:                            \n\t" */
+		"1:                                     \n\t"
+		
 		/* load */
 		"movdqa         0(%[from]), %%xmm0      \n\t"
 		"add            $0x10, %[from]          \n\t"
@@ -122,7 +123,8 @@ void swab2( const void *from, void *to, int n )
 		"add            $0x10, %[to]            \n\t"
 
 		"dec            %[cnt]                  \n\t"
-		"jnz            loop_start              \n\t"
+		"jnz            1b                      \n\t"
+		/* "jnz            loop_start              \n\t" */
 
 		: [from]"+r"(from), [to]"+r"(to), [cnt]"+r"(cnt)
 		:


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/14506151/invalid-symbol-redefinition-in-inline-asm-on-llvm and https://github.com/anrieff/libcpuid/issues/69.