### PR TITLE
Use ascii file mode for vid.stab

### DIFF
--- a/src/modules/vid.stab/filter_vidstab.cpp
+++ b/src/modules/vid.stab/filter_vidstab.cpp
@@ -219,6 +219,9 @@ static void init_analyze_data( mlt_filter filter, mlt_frame frame, VSPixelFormat
 
 	// Initialize the saved VSMotionDetect
 	vsMotionDetectInit( &analyze_data->md, &conf, &fi );
+#ifdef ASCII_SERIALIZATION_MODE
+	analyze_data->md.serializationMode = ASCII_SERIALIZATION_MODE;
+#endif
 
 	// Initialize the file to save results to
 	char* filename = mlt_properties_get( properties, "filename" );


### PR DESCRIPTION
For accuracy value > 9, vid.stab creates a binary analysis file that
it can not read properly - causing memory exhaustion and crash.
Ascii file format does not have that problem.

Fixes:
https://forum.shotcut.org/t/please-test-the-version-21-06-release-candidate/28284/16