### PR TITLE
Fix timer filter speed interaction with start delay

### DIFF
--- a/src/modules/plus/filter_timer.c
+++ b/src/modules/plus/filter_timer.c
@@ -38,7 +38,8 @@ double time_to_seconds( char* time )
 static void get_timer_str( mlt_filter filter, mlt_frame frame, char* text )
 {
 	mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
-	mlt_position current_frame = mlt_filter_get_position( filter, frame ) * mlt_properties_get_double( properties, "speed" );
+	double filter_speed = mlt_properties_get_double( properties, "speed" );
+	mlt_position current_frame = mlt_filter_get_position( filter, frame ) * filter_speed;
 	char* direction = mlt_properties_get( properties, "direction" );
 	double timer_start = time_to_seconds( mlt_properties_get( properties, "start" ) );
 	double timer_duration = time_to_seconds( mlt_properties_get( properties, "duration" ) );
@@ -50,17 +51,17 @@ static void get_timer_str( mlt_filter filter, mlt_frame frame, char* text )
 		// "duration" of zero means entire length of the filter.
 		mlt_position filter_length = mlt_filter_get_length2( filter, frame ) - 1;
 		double filter_duration = time_to_seconds( mlt_properties_frames_to_time( properties, filter_length, mlt_time_clock ) );
-		timer_duration = filter_duration - timer_start;
+		timer_duration = (filter_duration - timer_start) * filter_speed;
 	}
 
-	if ( value < timer_start )
+	if ( value < timer_start * filter_speed)
 	{
 		// Hold at 0 until start time.
 		value = 0.0;
 	}
 	else
 	{
-		value = value - timer_start;
+		value = value - timer_start * filter_speed;
 		if ( value > timer_duration )
 		{
 			// Hold at duration after the timer has elapsed.

--- a/src/modules/plus/filter_timer.yml
+++ b/src/modules/plus/filter_timer.yml
@@ -76,6 +76,12 @@ parameters:
     description: >
       Clock speed multiplier. For example, speed 10.0 makes the timer tick 10
       seconds for each second of playback.
+
+      Scales Duration but does not affect Start or Offset. For example: start
+      5s, duration 30s, offset 7s and speed 10.0 will have the timer start at
+      playback time 00:00:05.000 with value 00:00:07, count 10 seconds per
+      second of playback and stop at playback time 00:00:08.000 with value
+      00:00:37.
     default: 1.0
     readonly: no
     mutable: yes


### PR DESCRIPTION
See: https://forum.shotcut.org/t/please-test-the-version-21-06-release-candidate/28284/27

The speed parameter added in PR #706 did not interact well with the start parameter, nor with duration set to zero. This PR makes the parameters interact sensibly, although this choice is up for debate as it is somewhat arbitrary:

- Start parameter is in playback time and is not affected by speed.
- Duration is in timer time; playback duration _is_ scaled by speed but the max timer value is _not_ affected by speed.
- Offset is in timer time and is not affected by speed.

So, for example, with start 5s, duration 30s, offset 7s and speed 10.0:

- The timer will start frozen with value 00:00:07.
- At playback time 00:00:05.000, the timer starts counting 10 seconds per 1 second of playback.
- At playback time 00:00:08.000, the timer stops and remains frozen with value 00:00:37.

I've also confirmed that this behaviour also works for timer direction "down".