### PR TITLE
Fix data race in time remapping

### DIFF
--- a/src/modules/core/link_timeremap.c
+++ b/src/modules/core/link_timeremap.c
@@ -268,7 +268,10 @@ static int link_get_image_blend( mlt_frame frame, uint8_t** image, mlt_image_for
 		{
 			break;
 		}
-		if ( mlt_frame_get_image( src_frame, &images[image_count], format, &requested_width, &requested_height, 0 ) != 0 )
+		mlt_service_lock( MLT_LINK_SERVICE(self) );
+		int result = mlt_frame_get_image( src_frame, &images[image_count], format, &requested_width, &requested_height, 0 );
+		mlt_service_unlock( MLT_LINK_SERVICE(self) );
+		if ( result != 0 )
 		{
 			mlt_log_error( MLT_LINK_SERVICE(self), "Failed to get image %s\n", key );
 			break;
@@ -333,7 +336,10 @@ static int link_get_image_nearest( mlt_frame frame, uint8_t** image, mlt_image_f
 	if ( src_frame )
 	{
 		uint8_t* in_image;
-		if ( !mlt_frame_get_image( src_frame, &in_image, format, width, height, 0 ) )
+		mlt_service_lock( MLT_LINK_SERVICE(self) );
+		int result = mlt_frame_get_image( src_frame, &in_image, format, width, height, 0 );
+		mlt_service_unlock( MLT_LINK_SERVICE(self) );
+		if ( !result )
 		{
 			int size = mlt_image_format_size( *format, *width, *height, NULL );
 			*image = mlt_pool_alloc( size );

--- a/src/modules/core/link_timeremap.c
+++ b/src/modules/core/link_timeremap.c
@@ -271,7 +271,7 @@ static int link_get_image_blend( mlt_frame frame, uint8_t** image, mlt_image_for
 		mlt_service_lock( MLT_LINK_SERVICE(self) );
 		int result = mlt_frame_get_image( src_frame, &images[image_count], format, &requested_width, &requested_height, 0 );
 		mlt_service_unlock( MLT_LINK_SERVICE(self) );
-		if ( result != 0 )
+		if ( !result )
 		{
 			mlt_log_error( MLT_LINK_SERVICE(self), "Failed to get image %s\n", key );
 			break;


### PR DESCRIPTION
~This is the hack referred to in #729 that got me around the frame corruption problem. Just for reference; not an actual fix :wink:.~

Fix an issue in `link_timeremap.c`, where multiple concurrent threads calling `mlt_frame_get_image` would cause the returned image data to be corrupted, or to be consumed incorrectly. As a result, the produced frames would be seemingly arbitrarily corrupted, more so in "blend" mode than in "nearest" mode, due to the increased number of frames fetched.

Add a `mlt_service_lock` and `mlt_service_unlock` call around the critical function calls to ensure data returned is intact.

Fixes #729.
