### PR TITLE
Restore simplified alpha transparency syntax

### DIFF
--- a/src/modules/core/filter_brightness.c
+++ b/src/modules/core/filter_brightness.c
@@ -129,6 +129,11 @@ static int filter_get_image( mlt_frame frame, uint8_t **image, mlt_image_format 
 	alpha_level = mlt_properties_get(properties, "alpha")? MIN(mlt_properties_anim_get_double(properties, "alpha", position, length), 1.0) : 1.0;
 	if (alpha_level < 0.0) {
 		alpha_level = level;
+		if ( mlt_properties_exists( properties, "end" ) )
+		{
+			// we use the simplified start / end syntax
+			level = 1.0;
+		}
 	}
 
 	// Only process if we have no error.


### PR DESCRIPTION
Prior to MLT 7, the brightness filter could be used to create fade from/to alpha using a simplified syntax, like :
melt color:red -track myclip.mp4 -attach brightness out=100 start=0 end=1 alpha=-1 -transition frei0r.cairoblend
This creates a simple fade from transparent to opaque for the effect duration, without needing to introduce animated parameters (alpha follows the opacity defined by start/end).
This patch re-introduces the feature. Would you be ok for it ? I know that I can also use the full syntax by setting alpha="0=0;100=1" but the simplified syntax was much easier to handle... Anyways I would understand if you don't want to reintroduce this, just let me know.