### PR TITLE
Fix implicite delaration of isspace()

### DIFF
--- a/src/modules/xml/gps_parser.h
+++ b/src/modules/xml/gps_parser.h
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include <ctype.h>
 
 #include <libxml/tree.h>
 #include <libxml/parser.h>


### PR DESCRIPTION
In `gps_parser.c` the compiler throws a implicit declaration warning for `isspace`. Depending on your compiler settings this can lead to an error. Including [`ctype.h`](https://www.cplusplus.com/reference/cctype/) fixes it.