### PR TITLE
Fix artifacts in composite transition

### DIFF
--- a/src/modules/core/transition_composite.c
+++ b/src/modules/core/transition_composite.c
@@ -144,6 +144,7 @@ void composite_line_yuv( uint8_t *dest, uint8_t *src, int width, uint8_t *alpha_
 			alpha_a += j;
 		if ( alpha_b )
 			alpha_b += j;
+		return;
 	}
 #endif
 


### PR DESCRIPTION
When no luma file was specified, the compositing was performed twice, leading to some artifacts
https://invent.kde.org/multimedia/kdenlive/-/issues/670