### PR TITLE
Silence false library errors from LADSPA plugin manager

### DIFF
--- a/src/modules/jackrack/plugin_mgr.c
+++ b/src/modules/jackrack/plugin_mgr.c
@@ -201,7 +201,13 @@ plugin_mgr_get_dir_plugins (plugin_mgr_t * plugin_mgr, const char * dir)
       if (S_ISDIR (info.st_mode))
         plugin_mgr_get_dir_plugins (plugin_mgr, file_name);
       else
-        plugin_mgr_get_object_file_plugins (plugin_mgr, file_name);
+        {
+          char * ext = strrchr(file_name, '.');
+          if (ext && (strcmp(ext, ".so") == 0 || strcmp(ext, ".dll") == 0))
+          {
+            plugin_mgr_get_object_file_plugins (plugin_mgr, file_name);
+          }
+        }
       
       g_free (file_name);
     }


### PR DESCRIPTION
These errors seem to cause a lot of noise and confusing on the forum:

```
[Info   ] <MLT> plugin_mgr_get_object_file_plugins: error opening shared object file 'C:\Users\Owner\Downloads\shotcut-win64-211017\Shotcut\lib\ladspa/AUTHORS': "C:\Users\Owner\Downloads\shotcut-win64-211017\Shotcut\lib\ladspa\AUTHORS": The specified module could not be found.
[Info   ] <MLT> plugin_mgr_get_object_file_plugins: error opening shared object file 'C:\Users\Owner\Downloads\shotcut-win64-211017\Shotcut\lib\ladspa/COPYING': "C:\Users\Owner\Downloads\shotcut-win64-211017\Shotcut\lib\ladspa\COPYING": The specified module could not be found.
[Info   ] <MLT> plugin_mgr_get_object_file_plugins: error opening shared object file 'C:\Users\Owner\Downloads\shotcut-win64-211017\Shotcut\lib\ladspa/readme.txt': "C:\Users\Owner\Downloads\shotcut-win64-211017\Shotcut\lib\ladspa\readme.txt": %1 is not a valid Win32 application.
```

Maybe this would be a way to reduce some noise/distraction.

Any thoughts on other extensions to allow? Maybe ".dylib" - but I notice the plugins are ".so" in our Mac build.