### PR TITLE
Ensure animation serialization includes last key value

### DIFF
--- a/src/framework/mlt_animation.c
+++ b/src/framework/mlt_animation.c
@@ -674,8 +674,11 @@ char *mlt_animation_serialize_cut_tf( mlt_animation self, int in, int out, mlt_t
 					break;
 
 				// Special case - crop at the out point
-				if ( item.frame > out )
+				if ( item.frame > out ) {
 					mlt_animation_get_item( self, &item, out );
+					// To ensure correct seeding
+					item.is_key = 1;
+				}
 			}
 			// We've handled the last keyframe
 			else


### PR DESCRIPTION
This is a proposed fix. I am open to suggestions about different ways to fix this. But I think it makes sense to force keyframe for the "out" value as is already done for the "in" value.
---------------------------------------------------------------------------

When serializing key frames, the last keyframe would not have a
value after the "=". Upon re-parsing the string, the last value
is interpred to be a "zero".

This fix forces the last key value to be included by marking it
as a key frame.

Fix for issue reported here:
https://forum.shotcut.org/t/keyframes-error-after-cut-of-parts/31180