### PR TITLE
Fix loading image sequence in Windows

### DIFF
--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -181,28 +181,6 @@ static int load_sequence_querystring( producer_qimage self, mlt_properties prope
 	return result;
 }
 
-static int load_folder( producer_qimage self, mlt_properties properties, const char *filename )
-{
-	int result = 0;
-
-	// Obtain filenames within folder
-	if ( strstr( filename, "/.all." ) != NULL )
-	{
-		char wildcard[ 1024 ];
-		char *dir_name = strdup( filename );
-		char *extension = strrchr( dir_name, '.' );
-
-		*( strstr( dir_name, "/.all." ) + 1 ) = '\0';
-		sprintf( wildcard, "*%s", extension );
-
-		mlt_properties_dir_list( self->filenames, dir_name, wildcard, 1 );
-
-		free( dir_name );
-		result = 1;
-	}
-	return result;
-}
-
 static void load_filenames( producer_qimage self, mlt_properties properties )
 {
 	char *filename = mlt_properties_get( properties, "resource" );
@@ -212,7 +190,7 @@ static void load_filenames( producer_qimage self, mlt_properties properties )
 		!load_sequence_querystring( self, properties, filename ) &&
 		!load_sequence_sprintf( self, properties, filename ) &&
 		!load_sequence_deprecated( self, properties, filename ) &&
-		!load_folder( self, properties, filename ) )
+		!load_folder( self, filename ) )
 	{
 		mlt_properties_set( self->filenames, "0", filename );
 	}

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -26,6 +26,8 @@
 
 #include <QImage>
 #include <QSysInfo>
+#include <QFileInfo>
+#include <QDir>
 #include <QMutex>
 #include <QtEndian>
 #include <QTemporaryFile>
@@ -455,6 +457,28 @@ int load_sequence_sprintf(producer_qimage self, mlt_properties properties, const
 			result = 1;
 		}
 	}
+	return result;
+}
+
+int load_folder( producer_qimage self, const char *filename )
+{
+	int result = 0;
+
+	// Obtain filenames within folder
+	if ( strstr( filename, "/.all." ) != NULL )
+	{
+		mlt_properties filename_property = self->filenames;
+		QFileInfo info( filename );
+		QDir dir = info.absoluteDir();
+		QStringList filters = {QString( "*.%1" ).arg( info.suffix() )};
+		QStringList files = dir.entryList( filters, QDir::Files, QDir::Name );
+		int key;
+		for ( auto &f : files ) {
+			key = mlt_properties_count( filename_property );
+			mlt_properties_set_string( filename_property, QString::number( key ).toLatin1(), dir.absoluteFilePath( f ).toUtf8().constData() );
+		}
+		result = 1;
+    }
 	return result;
 }
 

--- a/src/modules/qt/qimage_wrapper.h
+++ b/src/modules/qt/qimage_wrapper.h
@@ -54,6 +54,7 @@ extern void refresh_image( producer_qimage, mlt_frame, mlt_image_format, int wid
 extern void make_tempfile( producer_qimage, const char *xml );
 extern int init_qimage(mlt_producer producer, const char *filename);
 extern int load_sequence_sprintf( producer_qimage self, mlt_properties properties, const char *filename );
+extern int load_folder( producer_qimage self, const char *filename );
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Currently, loading a wildcard image sequence with UTF-8 characters in the path fails on Windows, see:
https://bugs.kde.org/show_bug.cgi?id=448124

This is probably caused by mlt_properties_dir_list using C opendir and readdir that are not using UTF-8.
Reproducible with this command:

`melt.exe E:\Camera Roll\AÑO 2020\/.all.jpg`

My patch fixes it by using Qt functions to load the file names, as was done for pattern loading in :
https://github.com/mltframework/mlt/commit/40a17dd6864b8beeac9b8ade66b1576a674fe129#diff-353bdc0e1f99662238006ba036b75e1a5228d10acfe832014e5828b60e784964
