### PR TITLE
Remove unused pkgconfig files. Modify moduledir.

### DIFF
--- a/src/framework/mlt-framework.pc.in
+++ b/src/framework/mlt-framework.pc.in
@@ -4,8 +4,8 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 datadir=@CMAKE_INSTALL_FULL_DATADIR@
 
-moduledir=${libdir}/mlt
-mltdatadir=${datadir}/mlt-@MLT_VERSION_MAJOR@
+moduledir=${prefix}/@MLT_INSTALL_MODULE_DIR@
+mltdatadir=${prefix}/@MLT_INSTALL_DATA_DIR@
 
 Name: mlt-framework
 Description: MLT multimedia framework

--- a/src/framework/mlt-framework.pc.in
+++ b/src/framework/mlt-framework.pc.in
@@ -4,7 +4,7 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 datadir=@CMAKE_INSTALL_FULL_DATADIR@
 
-moduledir=${libdir}/mlt-@MLT_VERSION_MAJOR@
+moduledir=${libdir}/mlt
 mltdatadir=${datadir}/mlt-@MLT_VERSION_MAJOR@
 
 Name: mlt-framework


### PR DESCRIPTION
melt looks for plugins in `.../lib/mlt` see https://github.com/mltframework/mlt/blob/master/src/framework/mlt_factory.c#L43 , but the pkgconfig `moduledir` specifies `mlt-7`. So this changes it to use `.../lib/mlt`. Also the toplevel pkgconfig `.pc.in` files seem to be unused, they were moved into subdirectories.