### PR TITLE
Deliver the true average value for the audio level

### DIFF
--- a/src/modules/normalize/filter_audiolevel.c
+++ b/src/modules/normalize/filter_audiolevel.c
@@ -79,7 +79,8 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 
 		for ( s = 0; s < num_samples; s++ )
 		{
-			double sample = fabs( pcm[c + s * num_channels] / 128.0 );
+			double sample = fabs( (double)pcm[c + s * num_channels] / 32768.0 );
+
 			val += sample;
 			if ( sample == 128 )
 				num_oversample++;
@@ -97,7 +98,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 		}
 		// max amplitude = 40/42, 3to10  oversamples=41, more then 10 oversamples=42
 		if ( level == 0.0 && num_samples > 0 )
-			level = val / num_samples * 40.0/42.0 / 127.0;
+			level = val / num_samples;
 		if ( iec_scale )
 			level = IEC_Scale( AMPTODBFS( level ) );
 		sprintf( key, "meta.media.audio_level.%d", c );


### PR DESCRIPTION
Posting this here for discussion (not a real change proposal)
Motivated by this report:
https://forum.shotcut.org/t/audio-peak-meter-shows-different-values/32254/6

What is the "Audio Peak Meter" in Shotcut supposed to represent?
I thought that it would represent the peak sample value for each frame.

But when I investigate the code in the audio level filter, I see that it is averaging the sample values. However, it is some kind of scaled average because of two reasons:
1) The s16 value is divided by 128 and then by 127 later. So it is divided by 16,256 total. However, to scale to 0-1.0, it should be scaled by 2^11 (32,768)
2) It is also scaled to 40/42 = leaving 41 and 42 as "overshoot" values

So the value returned by the filter can not be easily converted to a true dB value unless the two scaling factors are undone. And then it is only an "average" value, not a peak value.

The Shotcut meter is taking the value returned from the filter and converting to dB. The result is that when a -9dB sine wave is presented, the meter shows values between -7.1dB and -7.2dB (higher than the actual peak in the audio!)

The edits in this code review demonstrate the changes that would need to be made to return "average" audio level.

What to do?
* Leave as is (maybe hide the actual values)
* Modify the audio level filter to return a true average value (scaled to 0-1.0) - this patch. Then, rename the Shotcut meter to "audio level" or something similar.
* Make a new peak filter that actually returns the peak value - use that in Shotcut instead?

