### PR TITLE
Improve synchronization when reversing clips

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -2630,7 +2630,7 @@ static int decode_audio( producer_avformat self, int *ignore, const AVPacket *pk
 
 		if ( self->seekable || int_position > 0 )
 		{
-			if ( req_position > int_position ) {
+			if ( req_pts > pts ) {
 				// We are behind, so skip some
 				*ignore = lrint( timebase * (req_pts - pts) * codec_context->sample_rate );
 			} else if ( self->audio_index != INT_MAX && int_position > req_position + 2 && !self->is_audio_synchronizing ) {


### PR DESCRIPTION
When performing synchronization, synchronize with PTS accuracy
instead of frame accuracy

As reported here:
https://forum.shotcut.org/t/reversing-a-clip-on-linux-causes-the-audio-to-crackle/31713

With my test clips, I get considerably better results when reversing a clip. I still see some distortion at the very beginning of the file. I suspect that is because the synchronization logic is not applied until after some audio has already been read and sent. I am not sure what regressions would result if I changed it to synchronize the first audio packet. But this change seems fairly low risk.