### PR TITLE
Remove code that was only used with Qt4

### DIFF
--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -55,7 +55,7 @@ bool createQApplicationIfNeeded(mlt_service service)
 
 void convert_qimage_to_mlt_rgba( QImage* qImg, uint8_t* mImg, int width, int height )
 {
-#if QT_VERSION >= 0x050200
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 	// QImage::Format_RGBA8888 was added in Qt5.2
 	// Nothing to do in this case  because the image was modified directly.
 	// Destination pointer must be the same pointer that was provided to
@@ -81,7 +81,7 @@ void convert_qimage_to_mlt_rgba( QImage* qImg, uint8_t* mImg, int width, int hei
 
 void convert_mlt_to_qimage_rgba( uint8_t* mImg, QImage* qImg, int width, int height )
 {
-#if QT_VERSION >= 0x050200
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 	// QImage::Format_RGBA8888 was added in Qt5.2
 	// Initialize the QImage with the MLT image because the data formats match.
 	*qImg = QImage( mImg, width, height, QImage::Format_RGBA8888 );

--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -43,7 +43,7 @@
 #include <QWidget>
 #include <framework/mlt_log.h>
 
-#if QT_VERSION >= 0x040600
+#if QT_VERSION >= QT_VERSION_CHECK(4, 6, 0)
 #include <QGraphicsEffect>
 #include <QGraphicsBlurEffect>
 #include <QGraphicsDropShadowEffect>
@@ -634,7 +634,7 @@ void loadFromXml( producer_ktitle self, QGraphicsScene *scene, const char *templ
 			int zValue = nodeAttributes.namedItem( "z-index" ).nodeValue().toInt();
 			gitem->setZValue( zValue );
 
-#if QT_VERSION >= 0x040600
+#if QT_VERSION >= QT_VERSION_CHECK(4, 6, 0)
 			// effects
 			QDomNode eff = items.item(i).namedItem("effect");
 			if (!eff.isNull()) {
@@ -772,7 +772,7 @@ void drawKdenliveTitle( producer_ktitle self, mlt_frame frame, mlt_image_format 
 
 		//must be extracted from kdenlive title
 		self->rgba_image = (uint8_t *) mlt_pool_alloc( image_size );
-#if QT_VERSION >= 0x050200
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 		// QImage::Format_RGBA8888 was added in Qt5.2
 		// Initialize the QImage with the MLT image because the data formats match.
 		QImage img( self->rgba_image, width, height, QImage::Format_RGBA8888 );

--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -43,11 +43,9 @@
 #include <QWidget>
 #include <framework/mlt_log.h>
 
-#if QT_VERSION >= QT_VERSION_CHECK(4, 6, 0)
 #include <QGraphicsEffect>
 #include <QGraphicsBlurEffect>
 #include <QGraphicsDropShadowEffect>
-#endif
 
 #include <memory>
 
@@ -165,7 +163,7 @@ public:
 	}
 
 	void updateText(QString text) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
 		m_path.clear();
 #else
 		m_path = QPainterPath();
@@ -634,7 +632,6 @@ void loadFromXml( producer_ktitle self, QGraphicsScene *scene, const char *templ
 			int zValue = nodeAttributes.namedItem( "z-index" ).nodeValue().toInt();
 			gitem->setZValue( zValue );
 
-#if QT_VERSION >= QT_VERSION_CHECK(4, 6, 0)
 			// effects
 			QDomNode eff = items.item(i).namedItem("effect");
 			if (!eff.isNull()) {
@@ -651,7 +648,6 @@ void loadFromXml( producer_ktitle self, QGraphicsScene *scene, const char *templ
 					gitem->setGraphicsEffect(shadow);
 				}
 			}
-#endif
 		}
 	}
 

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -279,7 +279,7 @@ void refresh_image( producer_qimage self, mlt_frame frame, mlt_image_format form
 
 		// Copy the image
 		int image_size;
-#if QT_VERSION >= 0x050200
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 		if ( has_alpha )
 		{
 			self->format = mlt_image_rgba;


### PR DESCRIPTION
As far as I can see in the CMake files building against Qt4 is not supported anymore hence we don't need code and version checks for Qt < 5 anymore. Correct me if I am wrong!

This PR also adds QT_VERSION_CHECK everywhere for consistency

**Question:** It seems the `"consumer-cleanup"` event was only used in code used with Qt4. Should the `"consumer-cleanup"` be removed?