### PR TITLE
Fix building for musl

### DIFF
--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -30,7 +30,7 @@
 #include <sys/param.h>
 #endif
 
-#if (defined(__GLIBC__) && !defined(__APPLE__)) || defined(HAVE_LOCALE_H)
+#if (defined(__linux__) && !defined(__APPLE__))
 #  include <locale.h>
 #elif defined(__APPLE__) || (defined(__FreeBSD_version) && __FreeBSD_version >= 900506)
 #  include <xlocale.h>


### PR DESCRIPTION
reverts: https://github.com/mltframework/mlt/pull/298.
There is no gurantee that either HAVE_STRTOD_L or HAVE_LOCALE_H will be
defined at compile-time. Try for example building this project :)

The locale usage is now defined in POSIX and therefore we can now
assume it will be available on Linux, except for ancient systems.
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/locale.h.html

Another way of dealing with this would be to have a global mlt_config.h
where HAVE_LOCALE_H and HAVE_STRTOD_L are defined to values determined
when mlt is installed.