### PR TITLE
fix unguarded null ptr

### DIFF
--- a/src/framework/mlt_profile.c
+++ b/src/framework/mlt_profile.c
@@ -363,9 +363,17 @@ mlt_properties mlt_profile_list( )
 	if ( prefix == NULL )
 	{
 		prefix = mlt_environment( "MLT_DATA" );
-		filename = calloc( 1, strlen( prefix ) + strlen( PROFILES_DIR ) + 1 );
-		strcpy( filename, prefix );
-		strcat( filename, PROFILES_DIR );
+		if (prefix)
+		{
+			filename = calloc( 1, strlen( prefix ) + strlen( PROFILES_DIR ) + 1 );
+			strcpy( filename, prefix );
+			strcat( filename, PROFILES_DIR );
+		}
+		else
+		{			
+			filename = calloc( 1, strlen( PROFILES_DIR ) + 1 );
+			strcpy( filename, PROFILES_DIR );
+		}		
 		prefix = filename;
 	}
 


### PR DESCRIPTION
Hi Dan,
Here is one unguarded nullptr fix because mlt_environment can return NULL
Could be that this situation is rare, and happens with accesses when mlt is not properly initialized (yet)
I ran into this issue while implementing a new feature and refactoring kdenlive. Due to my refactoring modifications I needed to do the initialialisation of the mlt factory a bit sooner and in the meantime this bug surfaced.

cheers,
Ondrej