### PR TITLE
Avoid to load both qt modules

### DIFF
--- a/src/framework/mlt_factory.h
+++ b/src/framework/mlt_factory.h
@@ -36,6 +36,7 @@
  * MLT_REPOSITORY is ignored on Windows and OS X relocatable builds.
  * \envvar \em MLT_PRESETS_PATH overrides the default full path to the properties preset files, defaults to \p MLT_DATA/presets
  * \envvar \em MLT_REPOSITORY_DENY colon seperated list of modules to skip. Example: libmltplus:libmltavformat:libmltfrei0r
+ * In case both qt5 and qt6 modules are found and none of both is blocked by MLT_REPOSITORY_DENY, qt6 will be blocked
  * \event \em producer-create-request fired when mlt_factory_producer is called;
  *   the event data is a pointer to mlt_factory_event_data
  * \event \em producer-create-done fired when a producer registers itself;


### PR DESCRIPTION
In case there is the intention to load both qt modules, qt6 will be
blocked. Use MLT_REPOSITORY_DENY to block qt5 (mltqt) instead