### PR TITLE
Define image format in producer's get_frame method so we can possibly...

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -646,4 +646,5 @@ MLT_7.10.0 {
   global:
     mlt_image_fill_checkerboard;
     mlt_image_fill_white;
+    mlt_image_rgba_opaque;
 } MLT_7.8.0;

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -581,3 +581,20 @@ void mlt_image_format_planes( mlt_image_format format, int width, int height, vo
 		strides[3] = 0;
 	};
 }
+
+
+
+/** Check if the alpha channel of an rgba image is opaque
+ *
+ * \public \memberof mlt_image_s
+ * \param image the image buffer
+ * \param width width of the image in pixels
+ * \param height height of the image in pixels
+ */
+int mlt_image_rgba_opaque(uint8_t *image, int width, int height)
+{
+	for (int i = 0; i < width * height; ++i) {
+		if (image[4 * i + 3] != 0xff) return 0;
+	}
+	return 1;
+}

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -59,6 +59,7 @@ extern void mlt_image_fill_white( mlt_image self, int full_range );
 extern void mlt_image_fill_opaque( mlt_image self );
 extern const char * mlt_image_format_name( mlt_image_format format );
 extern mlt_image_format mlt_image_format_id( const char * name );
+extern int mlt_image_rgba_opaque(uint8_t *image, int width, int height);
 
 // Deprecated functions
 extern int mlt_image_format_size( mlt_image_format format, int width, int height, int *bpp );

--- a/src/framework/mlt_tractor.c
+++ b/src/framework/mlt_tractor.c
@@ -562,6 +562,7 @@ static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int tra
 				mlt_frame_push_service( *frame, producer_get_image );
 				mlt_properties_set_int( frame_properties, "width", mlt_properties_get_int( video_properties, "width" ) );
 				mlt_properties_set_int( frame_properties, "height", mlt_properties_get_int( video_properties, "height" ) );
+				mlt_properties_set_int( frame_properties, "format", mlt_properties_get_int( video_properties, "format" ) );
 				mlt_properties_pass_list( frame_properties, video_properties, "meta.media.width, meta.media.height" );
 				mlt_properties_set_int( frame_properties, "progressive", mlt_properties_get_int( video_properties, "progressive" ) );
 				mlt_properties_set_double( frame_properties, "aspect_ratio", mlt_properties_get_double( video_properties, "aspect_ratio" ) );

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -78,13 +78,6 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 	mlt_image_format current_format = mlt_properties_get_int( producer_props, "_format" );
 
 	// Parse the colour
-	if ( now && strchr( now, '/' ) )
-	{
-		now = strdup( strrchr( now, '/' ) + 1 );
-		mlt_properties_set( producer_props, "resource", now );
-		free( now );
-		now = mlt_properties_get( producer_props, "resource" );
-	}
 	mlt_color color = mlt_properties_get_color( producer_props, "resource" );
 
 	if ( mlt_properties_get( producer_props, "mlt_image_format") )

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -252,6 +252,17 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		if ( mlt_properties_get( producer_props, "colour" ) != NULL )
 			mlt_properties_set( producer_props, "resource", mlt_properties_get( producer_props, "colour" ) );
 		
+		char *colorstring = mlt_properties_get( producer_props, "resource" );
+		if ( colorstring && strchr( colorstring, '/' ) )
+		{
+			colorstring = strdup( strrchr( colorstring, '/' ) + 1 );
+			mlt_properties_set( producer_props, "resource", colorstring );
+			free( colorstring );
+		}
+		mlt_color color = mlt_properties_get_color( producer_props, "resource" );
+		// Inform framework of the default frame format for this producer
+		mlt_properties_set_int( properties, "format", color.a < 255 ? mlt_image_rgba : mlt_image_yuv422 );
+
 		// Push the get_image method
 		mlt_frame_push_service( *frame, producer );
 		mlt_frame_push_get_image( *frame, producer_get_image );

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -251,7 +251,7 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		// colour is an alias for resource
 		if ( mlt_properties_get( producer_props, "colour" ) != NULL )
 			mlt_properties_set( producer_props, "resource", mlt_properties_get( producer_props, "colour" ) );
-		
+
 		char *colorstring = mlt_properties_get( producer_props, "resource" );
 		if ( colorstring && strchr( colorstring, '/' ) )
 		{
@@ -259,9 +259,17 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 			mlt_properties_set( producer_props, "resource", colorstring );
 			free( colorstring );
 		}
-		mlt_color color = mlt_properties_get_color( producer_props, "resource" );
-		// Inform framework of the default frame format for this producer
-		mlt_properties_set_int( properties, "format", color.a < 255 ? mlt_image_rgba : mlt_image_yuv422 );
+
+		// Check if we have a predefined image format
+		if ( mlt_properties_exists( producer_props, "mlt_image_format") )
+		{
+			int image_format = mlt_image_format_id( mlt_properties_get( producer_props, "mlt_image_format") );
+			mlt_properties_set_int( properties, "format", image_format );
+		} else {
+			mlt_color color = mlt_properties_get_color( producer_props, "resource" );
+			// Inform framework of the default frame format for this producer
+			mlt_properties_set_int( properties, "format", color.a < 255 ? mlt_image_rgba : mlt_image_yuv422 );
+		}
 
 		// Push the get_image method
 		mlt_frame_push_service( *frame, producer );

--- a/src/modules/core/producer_noise.c
+++ b/src/modules/core/producer_noise.c
@@ -170,6 +170,9 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", 1 );
 
+		// Inform framework that this producer creates yuv frames by default
+		mlt_properties_set_int( properties, "format", mlt_image_yuv422 );
+
 		// Update timecode on the frame we're creating
 		mlt_frame_set_position( *frame, mlt_producer_position( producer ) );
 

--- a/src/modules/frei0r/producer_frei0r.c
+++ b/src/modules/frei0r/producer_frei0r.c
@@ -76,6 +76,8 @@ int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int index )
 		mlt_properties_set_double( properties, "aspect_ratio", mlt_profile_sar( profile ) );
 		mlt_properties_set_int( properties, "meta.media.width", profile->width );
 		mlt_properties_set_int( properties, "meta.media.height", profile->height );
+		// Inform framework that this producer creates rgba frames by default
+		mlt_properties_set_int( properties, "format", mlt_image_rgba );
 
 		// Push the get_image method
 		mlt_frame_push_service( *frame, producer );

--- a/src/modules/frei0r/transition_frei0r.c
+++ b/src/modules/frei0r/transition_frei0r.c
@@ -22,16 +22,6 @@
 #include "frei0r_helper.h"
 #include <string.h>
 
-static int is_opaque( uint8_t *image, int width, int height )
-{
-	int pixels = width * height + 1;
-	while ( --pixels ) {
-		if ( image[3] != 0xff ) return 0;
-		image += 4;
-	}
-	return 1;
-}
-
 static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable ){
 	
 	mlt_frame b_frame = mlt_frame_pop_frame( a_frame );
@@ -68,7 +58,7 @@ static int transition_get_image( mlt_frame a_frame, uint8_t **image, mlt_image_f
 	    && ( !mlt_properties_get( properties, "1" ) || !strcmp( "normal", mlt_properties_get( properties, "1" ) ) )
 	    && ( !blend_mode || !strcmp("normal", blend_mode) )
 	    // Check if the alpha channel is entirely opaque.
-	    && is_opaque( images[1], *width, *height ) )
+	    && mlt_image_rgba_opaque( images[1], *width, *height ) )
 	{
 		if (invert)
 			error = mlt_frame_get_image( a_frame, image, format, width, height, 0 );

--- a/src/modules/gdk/producer_pango.c
+++ b/src/modules/gdk/producer_pango.c
@@ -565,6 +565,8 @@ static void refresh_image( producer_pango self, mlt_frame frame, int width, int 
 		// Store width and height
 		self->width = width;
 		self->height = height;
+		int has_alpha = gdk_pixbuf_get_has_alpha( self->pixbuf );
+		mlt_properties_set_int( properties, "format", has_alpha ? mlt_image_rgba : mlt_image_rgb );
 	}
 
 	// Set width/height

--- a/src/modules/gdk/producer_pixbuf.c
+++ b/src/modules/gdk/producer_pixbuf.c
@@ -548,6 +548,8 @@ static int refresh_pixbuf( producer_pixbuf self, mlt_frame frame )
 			mlt_properties_set_int( producer_props, "meta.media.width", self->width );
 			mlt_properties_set_int( producer_props, "meta.media.height", self->height );
 			mlt_properties_set_int( producer_props, "_disable_exif", disable_exif );
+			int has_alpha = gdk_pixbuf_get_has_alpha( self->pixbuf );
+			mlt_properties_set_int( properties, "format", has_alpha ? mlt_image_rgba : mlt_image_rgb );
 			mlt_events_unblock( producer_props, NULL );
 
 		}

--- a/src/modules/glaxnimate/producer_glaxnimate.cpp
+++ b/src/modules/glaxnimate/producer_glaxnimate.cpp
@@ -171,6 +171,8 @@ static int get_frame(mlt_producer producer, mlt_frame_ptr frame, int index)
 
 	// Set frame properties
 	mlt_properties_set_int(frame_properties, "progressive", 1);
+	// Inform framework that this producer creates rgba frames by default
+	mlt_properties_set_int( frame_properties, "format", mlt_image_rgba );
 	double force_ratio = mlt_properties_get_double(MLT_PRODUCER_PROPERTIES(producer), "force_aspect_ratio");
 	if (force_ratio > 0.0)
 		mlt_properties_set_double(frame_properties, "aspect_ratio", force_ratio);

--- a/src/modules/kdenlive/producer_framebuffer.c
+++ b/src/modules/kdenlive/producer_framebuffer.c
@@ -251,8 +251,10 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 			int error = mlt_frame_get_image( first_frame, &image, &format, &width, &height, 0 );
 			if ( !error )
 			{
-			// cache the original producer's pixel format
-			mlt_properties_set_int( properties, "_original_format", (int) format );
+				// cache the original producer's pixel format
+				mlt_properties_set_int( properties, "_original_format", (int) format );
+				// Inform framework of the default frame format for this producer
+				mlt_properties_set_int( frame_properties, "format", format );
 			}
 		}
 

--- a/src/modules/plus/producer_count.c
+++ b/src/modules/plus/producer_count.c
@@ -595,6 +595,9 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		mlt_properties_set_int( frame_properties, "meta.media.width", profile->width );
 		mlt_properties_set_int( frame_properties, "meta.media.height", profile->height );
 
+		// Inform framework that this producer creates rgba frames by default
+		mlt_properties_set_int( frame_properties, "format", mlt_image_rgba );
+
 		// Configure callbacks
 		mlt_frame_push_service( *frame, producer );
 		mlt_frame_push_get_image( *frame, producer_get_image );

--- a/src/modules/plus/producer_pgm.c
+++ b/src/modules/plus/producer_pgm.c
@@ -209,6 +209,8 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 	mlt_properties_set_int( properties, "has_image", 1 );
 	mlt_properties_set_int( properties, "progressive", 1 );
 	mlt_properties_set_double( properties, "aspect_ratio", 1 );
+	// Inform framework that this producer creates yuv frames by default
+	mlt_properties_set_int( properties, "format", mlt_image_yuv422 );
 
 	// Push the image callback
 	mlt_frame_push_service( *frame, producer );

--- a/src/modules/qt/producer_kdenlivetitle.c
+++ b/src/modules/qt/producer_kdenlivetitle.c
@@ -148,6 +148,11 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( producer_props, "progressive" ) );
+
+		// Inform framework that this producer creates rgba frames by default
+		// TODO: read the producer's xml on opening so we know if we have RGB or RGBA data
+		mlt_properties_set_int( properties, "format", mlt_image_rgba );
+
 		double force_ratio = mlt_properties_get_double( producer_props, "force_aspect_ratio" );
 		if ( force_ratio > 0.0 )
 			mlt_properties_set_double( properties, "aspect_ratio", force_ratio );

--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -336,6 +336,7 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 
 		// Set producer-specific frame properties
 		mlt_properties_set_int( properties, "progressive", mlt_properties_get_int( producer_properties, "progressive" ) );
+		mlt_properties_set_int( properties, "format", mlt_properties_get_int( producer_properties, "format" ) );
 		double force_ratio = mlt_properties_get_double( producer_properties, "force_aspect_ratio" );
 		if ( force_ratio > 0.0 )
 			mlt_properties_set_double( properties, "aspect_ratio", force_ratio );

--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -402,6 +402,9 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 		mlt_properties_set( frame_properties, "_outline", mlt_properties_get( producer_properties, "outline" ) );
 		mlt_properties_set_data( frame_properties, "_producer_qtext", static_cast<void*>( producer ), 0, NULL, NULL );
 
+		// Inform framework that this producer creates rgba frames by default
+		mlt_properties_set_int( frame_properties, "format", mlt_image_rgba );
+
 		// Set frame properties
 		mlt_properties_set_int( frame_properties, "progressive", 1 );
 		double force_ratio = mlt_properties_get_double( producer_properties, "force_aspect_ratio" );

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -245,6 +245,7 @@ int refresh_qimage( producer_qimage self, mlt_frame frame, int enable_caching )
 			self->current_height = qimage->height( );
 
 			mlt_events_block( producer_props, NULL );
+			mlt_properties_set_int( producer_props, "format", qimage->hasAlphaChannel() ? mlt_image_rgba : mlt_image_rgb);
 			mlt_properties_set_int( producer_props, "meta.media.width", self->current_width );
 			mlt_properties_set_int( producer_props, "meta.media.height", self->current_height );
 			mlt_properties_set_int( producer_props, "_disable_exif", disable_exif );

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -194,7 +194,7 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 		{
 			hasAlpha = true;
 		}
-		hasAlpha = hasAlpha && mlt_image_rgba_opaque( b_image, b_width, b_height );
+		hasAlpha = hasAlpha && !mlt_image_rgba_opaque( b_image, b_width, b_height );
 	}
 	if ( !hasAlpha )
 	{
@@ -213,7 +213,6 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 			*height = b_height;
 		}
 		*image = b_image;
-		// mlt_frame_replace_image( a_frame, b_image, *format, *width, *height );
 		free( interps );
 		return 0;
 	}

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -25,16 +25,6 @@
 #include <QPainter>
 #include <QTransform>
 
-static int is_opaque( uint8_t *image, int width, int height )
-{
-	int pixels = width * height + 1;
-	while ( --pixels ) {
-		if ( image[3] != 0xff ) return 0;
-		image += 4;
-	}
-	return 1;
-}
-
 static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *format, int *width, int *height, int writable )
 {
 	int error = 0;
@@ -65,7 +55,7 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 	int b_height = mlt_properties_get_int( b_properties, "meta.media.height" );
 	bool distort = mlt_properties_get_int( transition_properties, "distort" );
 
-	// Potention optimization if the producers do set their native format before fetching image
+	// Check the producer's native format before fetching image
 	if (mlt_properties_get_int( b_properties, "format" ) == mlt_image_rgba) {
 		hasAlpha = true;
 		*format = mlt_image_rgba;
@@ -204,7 +194,7 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 		{
 			hasAlpha = true;
 		}
-		if (hasAlpha && is_opaque( b_image, b_width, b_height ) )
+		if ( hasAlpha && mlt_image_rgba_opaque( b_image, b_width, b_height ) )
 		{
 			hasAlpha = false;
 		}

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -190,14 +190,11 @@ static int get_image( mlt_frame a_frame, uint8_t **image, mlt_image_format *form
 		// fetch image
 		error = mlt_frame_get_image( b_frame, &b_image, format, &b_width, &b_height, 0 );
 		bool imageFetched = true;
-		if (!hasAlpha && *format == mlt_image_rgba || mlt_frame_get_alpha( b_frame ) )
+		if ( !hasAlpha && ( *format == mlt_image_rgba || mlt_frame_get_alpha( b_frame ) ) )
 		{
 			hasAlpha = true;
 		}
-		if ( hasAlpha && mlt_image_rgba_opaque( b_image, b_width, b_height ) )
-		{
-			hasAlpha = false;
-		}
+		hasAlpha = hasAlpha && mlt_image_rgba_opaque( b_image, b_width, b_height );
 	}
 	if ( !hasAlpha )
 	{


### PR DESCRIPTION
Here is my proposal as discussed to define the image format in each producer's get_frame method, before attempting to fetch an image. This allows possible optimizations like I do in qtblend (requesting the best suited image format by default.

I tried to add the change in all possible producers. Some points to be discussed/reviewed:
**avformat** producer:
I included a minor refactoring to avoid code duplication
**color** producer:
There is some code duplication between get_frame and get_image. Also I set the default format to yuv422 when the color has an opaque alpha component and rgba otherwise, maybe that is not the best.
**blipflash and noise** producers
Handle both yuv/rgba cases themselves in get_image so I didn't set the format
**hold and consumer** producers
Does not seem possible / useful for these 2 as we don't necessarily know the format at that stage

Let me know ŵhat you think, in any case this leads to some nice performance improvement in qtblend transition.


