### PR TITLE
Allow outputing frame audio peak in dB

### DIFF
--- a/src/modules/normalize/filter_audiolevel.c
+++ b/src/modules/normalize/filter_audiolevel.c
@@ -61,7 +61,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	mlt_properties filter_props = MLT_FILTER_PROPERTIES( filter );
 
 	int iec_scale = mlt_properties_get_int( filter_props, "iec_scale" );
-	int peak = mlt_properties_get_int( filter_props, "peak" );
+	int peak = mlt_properties_get_int( filter_props, "dbpeak" );
 	*format = mlt_audio_s16;
 	int error = mlt_frame_get_audio( frame, buffer, format, frequency, channels, samples );
 	if ( error || !buffer ) return error;
@@ -93,7 +93,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 			}
 			else
 			{
-				level = 20 * log10( (double)peakVal / (double)INT16_MAX );
+				level = AMPTODBFS( (double)peakVal / (double)INT16_MAX );
 			}
 		}
 		else

--- a/src/modules/normalize/filter_audiolevel.c
+++ b/src/modules/normalize/filter_audiolevel.c
@@ -61,7 +61,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	mlt_properties filter_props = MLT_FILTER_PROPERTIES( filter );
 
 	int iec_scale = mlt_properties_get_int( filter_props, "iec_scale" );
-	int peak = mlt_properties_get_int( filter_props, "dbpeak" );
+	int dbPeak = mlt_properties_get_int( filter_props, "dbpeak" );
 	*format = mlt_audio_s16;
 	int error = mlt_frame_get_audio( frame, buffer, format, frequency, channels, samples );
 	if ( error || !buffer ) return error;
@@ -76,25 +76,22 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	for ( c = 0; c < *channels; c++ )
 	{
 		double level = 0.0;
-		if ( peak )
+		if ( dbPeak )
 		{
 			int16_t peakVal = 0;
 			for ( s = 0; s < num_samples; s++ )
 			{
 				int16_t sample = abs( pcm[c + s * num_channels] );
 				if ( sample > peakVal )
-				{
 					peakVal = sample;
-				}
 			}
 			if ( peakVal == 0 )
-			{
 				level = -100;
-			}
 			else
-			{
 				level = AMPTODBFS( (double)peakVal / (double)INT16_MAX );
-			}
+
+			if ( iec_scale )
+				level = IEC_Scale( level );
 		}
 		else
 		{

--- a/src/modules/normalize/filter_audiolevel.c
+++ b/src/modules/normalize/filter_audiolevel.c
@@ -61,6 +61,7 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 	mlt_properties filter_props = MLT_FILTER_PROPERTIES( filter );
 
 	int iec_scale = mlt_properties_get_int( filter_props, "iec_scale" );
+	int peak = mlt_properties_get_int( filter_props, "peak" );
 	*format = mlt_audio_s16;
 	int error = mlt_frame_get_audio( frame, buffer, format, frequency, channels, samples );
 	if ( error || !buffer ) return error;
@@ -74,32 +75,54 @@ static int filter_get_audio( mlt_frame frame, void **buffer, mlt_audio_format *f
 
 	for ( c = 0; c < *channels; c++ )
 	{
-		double val = 0;
 		double level = 0.0;
-
-		for ( s = 0; s < num_samples; s++ )
+		if ( peak )
 		{
-			double sample = fabs( pcm[c + s * num_channels] / 128.0 );
-			val += sample;
-			if ( sample == 128 )
-				num_oversample++;
-			else
-				num_oversample = 0;
-			// 10 samples @max => show max signal
-			if ( num_oversample > 10 )
+			int16_t peakVal = 0;
+			for ( s = 0; s < num_samples; s++ )
 			{
-				level = 1.0;
-				break;
+				int16_t sample = abs( pcm[c + s * num_channels] );
+				if ( sample > peakVal )
+				{
+					peakVal = sample;
+				}
 			}
-			// if 3 samples over max => 1 peak over 0 db (0 dB = 40.0)
-			if ( num_oversample > 3 )
-				level = 41.0/42.0;
+			if ( peakVal == 0 )
+			{
+				level = -100;
+			}
+			else
+			{
+				level = 20 * log10( (double)peakVal / (double)INT16_MAX );
+			}
 		}
-		// max amplitude = 40/42, 3to10  oversamples=41, more then 10 oversamples=42
-		if ( level == 0.0 && num_samples > 0 )
-			level = val / num_samples * 40.0/42.0 / 127.0;
-		if ( iec_scale )
-			level = IEC_Scale( AMPTODBFS( level ) );
+		else
+		{
+			double val = 0;
+			for ( s = 0; s < num_samples; s++ )
+			{
+				double sample = fabs( pcm[c + s * num_channels] / 128.0 );
+				val += sample;
+				if ( sample == 128 )
+					num_oversample++;
+				else
+					num_oversample = 0;
+				// 10 samples @max => show max signal
+				if ( num_oversample > 10 )
+				{
+					level = 1.0;
+					break;
+				}
+				// if 3 samples over max => 1 peak over 0 db (0 dB = 40.0)
+				if ( num_oversample > 3 )
+					level = 41.0/42.0;
+			}
+			// max amplitude = 40/42, 3to10  oversamples=41, more then 10 oversamples=42
+			if ( level == 0.0 && num_samples > 0 )
+				level = val / num_samples * 40.0/42.0 / 127.0;
+			if ( iec_scale )
+				level = IEC_Scale( AMPTODBFS( level ) );
+		}
 		sprintf( key, "meta.media.audio_level.%d", c );
 		mlt_properties_set_double( MLT_FRAME_PROPERTIES( frame ), key, level );
 		sprintf( key, "_audio_level.%d", c );

--- a/src/modules/normalize/filter_audiolevel.yml
+++ b/src/modules/normalize/filter_audiolevel.yml
@@ -22,13 +22,13 @@ tags:
 parameters:
   - identifier: iec_scale
     title: Use IEC 60268-18 Scale
-    type: bool
+    type: boolean
     default: 1
     widget: checkbox
 
   - identifier: dbpeak
     title: output true peak value in dB instead of a percentage in _audio_level.<N>
-    type: bool
+    type: boolean
     default: 0
     widget: checkbox
 

--- a/src/modules/normalize/filter_audiolevel.yml
+++ b/src/modules/normalize/filter_audiolevel.yml
@@ -1,4 +1,4 @@
-schema_version: 0.1
+schema_version: 7.0
 type: filter
 identifier: audiolevel
 title: Audio Levels
@@ -22,17 +22,13 @@ tags:
 parameters:
   - identifier: iec_scale
     title: Use IEC 60268-18 Scale
-    type: integer
-    minimum: 0
-    maximum: 1
+    type: bool
     default: 1
     widget: checkbox
 
-  - identifier: peak
-    title: output samples peak value in dB instead of percentage in _audio_level.<N>
-    type: integer
-    minimum: 0
-    maximum: 1
+  - identifier: dbpeak
+    title: output true peak value in dB instead of a percentage in _audio_level.<N>
+    type: bool
     default: 0
     widget: checkbox
 

--- a/src/modules/normalize/filter_audiolevel.yml
+++ b/src/modules/normalize/filter_audiolevel.yml
@@ -2,7 +2,7 @@ schema_version: 0.1
 type: filter
 identifier: audiolevel
 title: Audio Levels
-version: 1
+version: 2
 copyright: Dan Dennedy, Marco Gittler, and Steve Harris
 creator: Dan Dennedy
 contributor:
@@ -26,6 +26,14 @@ parameters:
     minimum: 0
     maximum: 1
     default: 1
+    widget: checkbox
+
+  - identifier: peak
+    title: output samples peak value in dB instead of percentage in _audio_level.<N>
+    type: integer
+    minimum: 0
+    maximum: 1
+    default: 0
     widget: checkbox
 
   - identifier: _audio_level.<N>


### PR DESCRIPTION
in Kdenlive we use the "audiolevel" filter to get the peak audio level for each track, using the _audio_level.<N> property.
With this change, the filter can now optionally output the peak audio level in dB instead of a percentage, making it easier to use in vu-meter. No changes were done on the existing functionnalities