### PR TITLE
Fix: update `_mlt` references to `_mlt7` in SWIG configuration

### DIFF
--- a/src/swig/mlt.i
+++ b/src/swig/mlt.i
@@ -69,10 +69,10 @@ namespace Mlt {
 
 #if defined(SWIGPYTHON)
 %feature("shadow") Frame::get_waveform(int, int) %{
-    def get_waveform(*args): return _mlt.frame_get_waveform(*args)
+    def get_waveform(*args): return _mlt7.frame_get_waveform(*args)
 %}
 %feature("shadow") Frame::get_image(mlt_image_format&, int&, int&) %{
-    def get_image(*args): return _mlt.frame_get_image(*args)
+    def get_image(*args): return _mlt7.frame_get_image(*args)
 %}
 #endif
 


### PR DESCRIPTION
There are two specific references to `_mlt`  in the `mlt.i` file, which appear to need to be updated to say `_mlt7` (since the underlying C++ library is now referenced as `_mlt7`).

Flowblade's rotomask filter uses one of the affected interfaces, and throws an error that goes away with this patch.  (The rotomask filter then remains quite broken, but at least not because of `mlt`.)