### PR TITLE
Fall back to r_frame_rate when avg_frame_rate is 0/0

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -403,7 +403,8 @@ static mlt_properties find_default_streams( producer_avformat self )
 				}
 				mlt_properties_set( meta_media, key, "video" );
 				snprintf( key, sizeof(key), "meta.media.%u.stream.frame_rate", i );
-				double ffmpeg_fps = av_q2d( context->streams[ i ]->avg_frame_rate );
+				double avg_frame_rate = av_q2d( context->streams[ i ]->avg_frame_rate );
+				double ffmpeg_fps = isfinite( avg_frame_rate ) ? avg_frame_rate : av_q2d( context->streams[ i ]->r_frame_rate );
 				mlt_properties_set_double( meta_media, key, ffmpeg_fps );
 
 				const char *projection = get_projection(context->streams[i]);


### PR DESCRIPTION
`avg_frame_rate` is sometimes `0/0` in some video streams, particularly in mxf files. Not sure why.

This change will grab the frame rate from `r_frame_rate` when `avg_frame_rate` is not a finite number.
It is theoretically possible that `r_frame_rate` will also be `0/0` for some file, but with this change the likelihood of obtaining a correct value increases, and with every file I've seen so far `r_frame_rate` has had the correct value when `avg_frame_rate` was `0/0`.