### PR TITLE
Fix audio "echo" with wma file.

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -2651,10 +2651,17 @@ static int decode_audio( producer_avformat self, int *ignore, const AVPacket *pk
 
 		if ( self->seekable || int_position > 0 )
 		{
+			int64_t ahead_threshold = 2;
+			if ( codec_context->codec_id == AV_CODEC_ID_WMAPRO )
+			{
+				// WMAPro needs more tolerance for sync detection
+				ahead_threshold = 4;
+			}
+
 			if ( req_pts > pts ) {
 				// We are behind, so skip some
 				*ignore = lrint( timebase * (req_pts - pts) * codec_context->sample_rate );
-			} else if ( self->audio_index != INT_MAX && int_position > req_position + 2 && !self->is_audio_synchronizing ) {
+			} else if ( self->audio_index != INT_MAX && int_position > req_position + ahead_threshold && !self->is_audio_synchronizing ) {
 				// We are ahead, so seek backwards some more.
 				// Supply -1 as the position to defeat the checks needed by for the other
 				// call to seek_audio() at the beginning of producer_get_audio(). Otherwise,


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/re-audio-echoes-when-opening-in-shotcut-but-not-when-using-other-players/37125

With test file:
https://www.yellowsubroutine.com/content/private2015code/tallship-medium.wmv

This is a proposed fix for the provided test file.

I notice that for this clip, the actual vs requested position can be as high as 4. For most other streams, the maximum is 1 or 2. I wonder if this has to do with the fact that wma allows multiple frames per packet.