### PR TITLE
Add filtergraph support for avformat producer

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -875,10 +875,6 @@ static int setup_filters(producer_avformat self)
 				inputs->next = NULL;
 
 				if (!error) error = (avfilter_graph_parse(self->vfilter_graph, self->filtergraph, inputs, outputs, NULL) < 0);
-				if (error) {
-					avfilter_inout_free(&outputs);
-					avfilter_inout_free(&inputs);
-				}
 		}
 		if (self->vfilter_graph) {
 			if (!error && !self->filtergraph) error = ( avfilter_link(self->vfilter_in, 0, last_filter, 0) < 0 );

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -132,6 +132,7 @@ struct producer_avformat_s
 	int autorotate;
 	int is_audio_synchronizing;
 	int video_send_result;
+	char* filtergraph;
 #if USE_HWACCEL
 	struct {
 		int pix_fmt;
@@ -830,32 +831,57 @@ static int insert_filter(AVFilterGraph *graph, AVFilterContext **last_filter, co
 	return result;
 }
 
-static int setup_autorotate_filters(producer_avformat self)
+static int setup_filters(producer_avformat self)
 {
 	int error = 0;
 
-	if (!self->vfilter_graph && self->autorotate && self->video_index != -1) {
-		mlt_properties properties = MLT_PRODUCER_PROPERTIES(self->parent);
-		double theta  = get_rotation(properties, self->video_format->streams[self->video_index]);
+	if (!self->vfilter_graph && (self->autorotate || self->filtergraph) && self->video_index != -1) {
+		AVFilterContext *last_filter = NULL;
+		if (self->autorotate) {
+				mlt_properties properties = MLT_PRODUCER_PROPERTIES(self->parent);
+				double theta  = get_rotation(properties, self->video_format->streams[self->video_index]);
 
-		if (fabs(theta - 90) < 1.0) {
-			error = ( setup_video_filters(self) < 0 );
-			AVFilterContext *last_filter = self->vfilter_out;
-			if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "transpose", "clock") < 0 );
-			if (!error) error = ( avfilter_link(self->vfilter_in, 0, last_filter, 0) < 0 );
-			if (!error) error = ( avfilter_graph_config(self->vfilter_graph, NULL) < 0 );
-		} else if (fabs(theta - 180) < 1.0) {
-			error = ( setup_video_filters(self) < 0 );
-			AVFilterContext *last_filter = self->vfilter_out;
-			if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "hflip", NULL) < 0 );
-			if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "vflip", NULL) < 0 );
-			if (!error) error = ( avfilter_link(self->vfilter_in, 0, last_filter, 0) < 0 );
-			if (!error) error = ( avfilter_graph_config(self->vfilter_graph, NULL) < 0 );
-		} else if (fabs(theta - 270) < 1.0) {
-			error = ( setup_video_filters(self) < 0 );
-			AVFilterContext *last_filter = self->vfilter_out;
-			if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "transpose", "cclock") < 0 );
-			if (!error) error = ( avfilter_link(self->vfilter_in, 0, last_filter, 0) < 0 );
+				if (fabs(theta - 90) < 1.0) {
+					error = ( setup_video_filters(self) < 0 );
+					last_filter = self->vfilter_out;
+					if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "transpose", "clock") < 0 );
+				} else if (fabs(theta - 180) < 1.0) 	{
+					error = ( setup_video_filters(self) < 0 );
+					last_filter = self->vfilter_out;
+					if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "hflip", NULL) < 0 );
+					if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "vflip", NULL) < 0 );
+				} else if (fabs(theta - 270) < 1.0) {
+					error = ( setup_video_filters(self) < 0 );
+					last_filter = self->vfilter_out;
+					if (!error) error = ( insert_filter(self->vfilter_graph, &last_filter, "transpose", "cclock") < 0 );
+				}
+		}
+		if (self->filtergraph && !error) {
+				if (!self->vfilter_graph) {
+					error = ( setup_video_filters(self) < 0 );
+					last_filter = self->vfilter_out;
+				}
+				AVFilterInOut *outputs = avfilter_inout_alloc();
+				AVFilterInOut *inputs  = avfilter_inout_alloc();
+
+				outputs->name = av_strdup("in");
+				outputs->filter_ctx = self->vfilter_in;
+				outputs->pad_idx = 0;
+				outputs->next = NULL;
+
+				inputs->name = av_strdup("out");
+				inputs->filter_ctx = last_filter;
+				inputs->pad_idx = 0;
+				inputs->next = NULL;
+
+				if (!error) error = (avfilter_graph_parse(self->vfilter_graph, self->filtergraph, inputs, outputs, NULL) < 0);
+				if (error) {
+					avfilter_inout_free(&outputs);
+					avfilter_inout_free(&inputs);
+				}
+		}
+		if (self->vfilter_graph) {
+			if (!error && !self->filtergraph) error = ( avfilter_link(self->vfilter_in, 0, last_filter, 0) < 0 );
 			if (!error) error = ( avfilter_graph_config(self->vfilter_graph, NULL) < 0 );
 		}
 	}
@@ -1019,7 +1045,8 @@ static int producer_open(producer_avformat self, mlt_profile profile, const char
 #ifdef AVFILTER
 				if (!test_open) {
 					self->autorotate = !mlt_properties_get(properties, "autorotate") || mlt_properties_get_int(properties, "autorotate");
-					error = setup_autorotate_filters(self);
+					self->filtergraph = mlt_properties_get(properties, "filtergraph");
+					error = setup_filters(self);
 				}
 #endif
 			}
@@ -1956,7 +1983,7 @@ static int producer_get_image( mlt_frame frame, uint8_t **buffer, mlt_image_form
 			if ( got_picture )
 			{
 #ifdef AVFILTER
-				if (self->autorotate && !setup_autorotate_filters(self) && self->vfilter_graph) {
+				if ((self->autorotate  || self->filtergraph) && !setup_filters(self) && self->vfilter_graph) {
 					int ret = av_buffersrc_add_frame(self->vfilter_in, self->video_frame);
 					if (ret < 0) {
 						got_picture = 0;

--- a/src/modules/avformat/producer_avformat.yml
+++ b/src/modules/avformat/producer_avformat.yml
@@ -246,3 +246,8 @@ parameters:
       multiple of 90 degrees.
     type: integer
     unit: degrees
+
+  - identifier: filtergraph
+    title: Filtergraph
+    description: >
+      Filtergraph to apply to resource. Uses libavfilter syntax.

--- a/src/modules/avformat/producer_avformat.yml
+++ b/src/modules/avformat/producer_avformat.yml
@@ -249,5 +249,5 @@ parameters:
 
   - identifier: filtergraph
     title: Filtergraph
-    description: >
-      Filtergraph to apply to resource. Uses libavfilter syntax.
+    type: string
+    description: Filtergraph to apply to resource. Uses libavfilter syntax.


### PR DESCRIPTION
Currently I am working with footage in S-Log3 (10bit/yuv422p10le).

My workflow has been to apply any corrections that need or benefit from 10bit (e.g. exposure, color space transform, LUT) during transcoding with ffmpeg to 8bit and then to work with the resulting files in kdenlive.

To get rid of the overhead of transcoding all files before using them I implemented a new property 'filtergraph' on the avformat producer where you can input a libavfilter filter graph string as in ffmpeg's '-vf' parameter.