### PR TITLE
fix mlt_chain inits movit on wrong thread

### DIFF
--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -84,7 +84,7 @@ mlt_chain mlt_chain_init( mlt_profile profile )
 			// Generate local space
 			self->local = calloc( 1, sizeof( mlt_chain_base ) );
 			mlt_chain_base* base = self->local;
-			base->source_profile = mlt_profile_clone(profile);
+			base->source_profile = NULL;
 
 			// Listen to property changes to pass along to the source
 			mlt_events_listen( MLT_CHAIN_PROPERTIES(self), self, "property-changed", ( mlt_listener )chain_property_changed );
@@ -125,6 +125,7 @@ void mlt_chain_set_source( mlt_chain self, mlt_producer source )
 		mlt_properties_inc_ref( source_properties );
 
 		// Save the native source producer frame rate
+		base->source_profile = mlt_profile_clone(mlt_service_profile(MLT_CHAIN_SERVICE(self)));
 		mlt_frame frame = NULL;
 		mlt_service_get_frame(MLT_PRODUCER_SERVICE(source), &frame, 0);
 		mlt_frame_close(frame);

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -3,7 +3,7 @@
  * \brief interface for all frame classes
  * \see mlt_frame_s
  *
- * Copyright (C) 2003-2022 Meltytech, LLC
+ * Copyright (C) 2003-2023 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -914,6 +914,8 @@ mlt_frame mlt_frame_clone( mlt_frame self, int is_deep )
 		mlt_frame_get_original_producer( self ), 0, NULL, NULL );
 	mlt_properties_set_data( new_props, "movit.convert",
 		mlt_properties_get_data( properties, "movit.convert", NULL), 0, NULL, NULL );
+	mlt_properties_set_data( new_props, "_movit cpu_convert",
+	    mlt_properties_get_data( properties, "_movit cpu_convert", NULL), 0, NULL, NULL );
 
 	if ( is_deep )
 	{

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -728,12 +728,7 @@ mlt_filter filter_movit_convert_init( mlt_profile profile, mlt_service_type type
 	{
 		mlt_properties properties = MLT_FILTER_PROPERTIES( filter );
 		glsl->add_ref( properties );
-#ifdef _WIN32
-		// XXX avcolor_space is crashing on Windows in this context!
-		mlt_filter cpu_csc = NULL;
-#else
 		mlt_filter cpu_csc = create_filter( profile, "avcolor_space" );
-#endif
 		if ( !cpu_csc )
 			cpu_csc = create_filter( profile, "imageconvert" );
 		if ( cpu_csc )


### PR DESCRIPTION
OpenGL has thread affinity, and mlt_chain is initializing Movit on the wrong thread because it calls `mlt_profile_from_producer`, which calls `mlt_frame_get_image`, which invokes the Movit OpenGL. Rather, the mlt_consumer read ahead (render) thread must be the only thread to call `mlt_frame_get_image`. This is documented [here](https://www.mltframework.org/docs/opengl/).   `mlt_profile_from_producer` calls `mlt_frame_get_image` because only certain information such as interlace/progressive is reliable after decoding a frame. However, mlt_chain only seems to be concerned about frame rate, and that is obtained with avformat simply by getting a frame.
"meta.media.frame_rate_num" and "meta.media.frame_rate_den" are conventions supported by producers that have frame rates - decklink and avformat currently.
What are the consequences of the `mlt_chain_base.source_profile` resolution and aspect ratio based on the composition profile rather than source?
 