### PR TITLE
Threaded avformat producer

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -1045,6 +1045,24 @@ static int producer_open(producer_avformat self, mlt_profile profile, const char
 				}
 #endif
 			}
+
+			// set up discard
+			if (self->video_format) {
+				for (unsigned x = 0; x < self->video_format->nb_streams; x++) {
+					self->video_format->streams[x]->discard = AVDISCARD_ALL;
+				}
+				self->video_format->streams[self->video_index]->discard = AVDISCARD_DEFAULT;
+			}
+
+			if (self->audio_format) {
+				// don't overwrite the discard we just set if audio_format == video_format
+				if (self->audio_format != self->video_format) {
+					for (unsigned x = 0; x < self->audio_format->nb_streams; x++) {
+						self->audio_format->streams[x]->discard = AVDISCARD_ALL;
+					}
+				}
+				self->audio_format->streams[self->audio_index]->discard = AVDISCARD_DEFAULT;
+			}
 		}
 	}
 	av_dict_free( &params );


### PR DESCRIPTION
This brings melt quite a bit closer to ffmpeg in terms of wall time for decoding 4k ProRes on an AWS c5d.18xlarge with network attached storage (EBS). From 90 to 77 seconds for a 100s sample, where ffmpeg takes 67 seconds.

This could maybe be improved to do similar threading for audio, with the AVDISCARD_ALL branch this is unlikely to improve things with seekable sources.