### PR TITLE
Add mlt_producer_probe()

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -661,5 +661,6 @@ MLT_7.12.0 {
 
 MLT_7.14.0 {
   global:
+    mlt_producer_probe;
     mlt_chain_attach_normalizers;
 } MLT_7.12.0;

--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -77,9 +77,10 @@ mlt_chain mlt_chain_init( mlt_profile profile )
 			mlt_properties_clear( properties, "length");
 
 			producer->get_frame = producer_get_frame;
-			producer->probe = producer_probe;
 			producer->close = ( mlt_destructor )mlt_chain_close;
 			producer->close_object = self;
+
+			mlt_properties_set_data( properties, "_probe", producer_probe, 0, NULL, NULL );
 
 			mlt_service_set_profile( MLT_CHAIN_SERVICE( self ), profile );
 

--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -48,6 +48,7 @@ mlt_chain_base;
 */
 
 static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int index );
+static int producer_probe( mlt_producer parent );
 static void relink_chain( mlt_chain self );
 static void chain_property_changed( mlt_service owner, mlt_chain self, char *name );
 static void source_property_changed( mlt_service owner, mlt_chain self, char *name );
@@ -76,6 +77,7 @@ mlt_chain mlt_chain_init( mlt_profile profile )
 			mlt_properties_clear( properties, "length");
 
 			producer->get_frame = producer_get_frame;
+			producer->probe = producer_probe;
 			producer->close = ( mlt_destructor )mlt_chain_close;
 			producer->close_object = self;
 
@@ -471,6 +473,20 @@ static int producer_get_frame( mlt_producer parent, mlt_frame_ptr frame, int ind
 		}
 	}
 	return result;
+}
+
+static int producer_probe( mlt_producer parent )
+{
+	if ( parent && parent->child )
+	{
+		mlt_chain self = parent->child;
+		mlt_chain_base *base = self->local;
+		if ( base && base->source )
+		{
+			return mlt_producer_probe( base->source );
+		}
+	}
+	return 1;
 }
 
 static void relink_chain( mlt_chain self )

--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -80,7 +80,7 @@ mlt_chain mlt_chain_init( mlt_profile profile )
 			producer->close = ( mlt_destructor )mlt_chain_close;
 			producer->close_object = self;
 
-			mlt_properties_set_data( properties, "_probe", producer_probe, 0, NULL, NULL );
+			mlt_properties_set_data( properties, "mlt_producer_probe", producer_probe, 0, NULL, NULL );
 
 			mlt_service_set_profile( MLT_CHAIN_SERVICE( self ), profile );
 

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -1291,8 +1291,11 @@ void mlt_producer_set_creation_time( mlt_producer self, int64_t creation_time )
 
 int mlt_producer_probe( mlt_producer self )
 {
-	if ( self && self->probe )
+	if ( self )
 	{
-		return self->probe( self );
+		int ( *probe )( mlt_producer ) = mlt_properties_get_data( MLT_PRODUCER_PROPERTIES(self), "_probe", NULL );
+		if ( probe )
+			return probe( self );
 	}
+	return 0;
 }

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -1279,3 +1279,20 @@ void mlt_producer_set_creation_time( mlt_producer self, int64_t creation_time )
 	mlt_properties_set( MLT_PRODUCER_PROPERTIES( parent ), "creation_time", datestr);
 	free( datestr );
 }
+
+/** Probe the producer to publish metadata properties.
+ *
+ * After this call the producer will publish meta.media properties
+ *
+ * \public \memberof mlt_producer_s
+ * \param self a producer
+  * \return true on error
+ */
+
+int mlt_producer_probe( mlt_producer self )
+{
+	if ( self && self->probe )
+	{
+		return self->probe( self );
+	}
+}

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -1293,7 +1293,7 @@ int mlt_producer_probe( mlt_producer self )
 {
 	if ( self )
 	{
-		int ( *probe )( mlt_producer ) = mlt_properties_get_data( MLT_PRODUCER_PROPERTIES(self), "_probe", NULL );
+		int ( *probe )( mlt_producer ) = mlt_properties_get_data( MLT_PRODUCER_PROPERTIES(self), "mlt_producer_probe", NULL );
 		if ( probe )
 			return probe( self );
 	}

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -97,13 +97,6 @@ struct mlt_producer_s
 	 */
 	int ( *set_in_and_out )( mlt_producer, mlt_position, mlt_position );
 
-	/** Probe for metadata.
-	 *
-	 * \param mlt_producer a producer
-	 * \return true if there was an error
-	 */
-	int ( *probe )( mlt_producer );
-
 	/** the destructor virtual function */
 	mlt_destructor close;
 	void *close_object; /**< the object supplied to the close virtual function */

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -97,6 +97,12 @@ struct mlt_producer_s
 	 */
 	int ( *set_in_and_out )( mlt_producer, mlt_position, mlt_position );
 
+	/** Probe for metadata.
+	 *
+	 * \param mlt_producer a producer
+	 * \return true if there was an error
+	 */
+	int ( *probe )( mlt_producer );
 
 	/** the destructor virtual function */
 	mlt_destructor close;
@@ -145,5 +151,6 @@ extern int mlt_producer_optimise( mlt_producer self );
 extern void mlt_producer_close( mlt_producer self );
 int64_t mlt_producer_get_creation_time( mlt_producer self );
 void mlt_producer_set_creation_time( mlt_producer self, int64_t creation_time );
+extern int  mlt_producer_probe( mlt_producer self );
 
 #endif

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -264,3 +264,8 @@ void Producer::set_creation_time( int64_t creation_time )
 {
 	mlt_producer_set_creation_time( get_producer( ), creation_time );
 }
+
+bool Producer::probe( )
+{
+	mlt_producer_probe( get_producer( ) );
+}

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -267,5 +267,5 @@ void Producer::set_creation_time( int64_t creation_time )
 
 bool Producer::probe( )
 {
-	mlt_producer_probe( get_producer( ) );
+	return mlt_producer_probe( get_producer( ) );
 }

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -77,6 +77,7 @@ namespace Mlt
 			int clear( );
 			int64_t get_creation_time( );
 			void set_creation_time( int64_t creation_time );
+			bool probe( );
 	};
 }
 

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -729,6 +729,7 @@ MLT_7.12.0 {
 MLT_7.14.0 {
   global:
     extern "C++" {
+      "Mlt::Producer::probe()";
       "Mlt::Chain::attach_normalizers()";
     };
 } MLT_7.12.0;

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -95,6 +95,7 @@ struct producer_avformat_s
 	int video_index;
 	int64_t first_pts;
 	atomic_int_fast64_t last_position;
+	int probe_complete;
 	int video_seekable;
 	int seekable; /// This one is used for both audio and file level seekability.
 	atomic_int_fast64_t current_position;
@@ -153,6 +154,7 @@ typedef struct producer_avformat_s *producer_avformat;
 static int list_components( char* file );
 static int producer_open( producer_avformat self, mlt_profile profile, const char *URL, int take_lock, int test_open );
 static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int index );
+static int producer_probe( mlt_producer producer );
 static void producer_avformat_close( producer_avformat );
 static void producer_close( mlt_producer parent );
 static void producer_set_up_video( producer_avformat self, mlt_frame frame );
@@ -196,6 +198,9 @@ mlt_producer producer_avformat_init( mlt_profile profile, const char *service, c
 
 			// Register our get_frame implementation
 			producer->get_frame = producer_get_frame;
+
+			// Register our probe implementation
+			producer->probe = producer_probe;
 
 			// Force the duration to be computed unless explicitly provided.
 			mlt_properties_set_position( properties, "length", 0 );
@@ -2199,6 +2204,7 @@ exit_get_image:
 	// Set immutable properties of the selected track's (or overridden) source attributes.
 	mlt_properties_set_int( properties, "meta.media.top_field_first", self->top_field_first );
 	mlt_properties_set_int( properties, "meta.media.progressive", mlt_properties_get_int( frame_properties, "progressive" ) );
+	self->probe_complete = 1;
 	mlt_service_unlock( MLT_PRODUCER_SERVICE( producer ) );
 
 	mlt_log_timings_end( NULL, __FUNCTION__ );
@@ -2539,6 +2545,7 @@ static void producer_set_up_video( producer_avformat self, mlt_frame frame )
 	{
 		// Reset the video properties if the index changed
 		self->video_index = index;
+		self->probe_complete = 0;
 		pthread_mutex_lock( &self->open_mutex );
 		if ( self->video_codec )
 			avcodec_close( self->video_codec );
@@ -3160,6 +3167,7 @@ static void producer_set_up_audio( producer_avformat self, mlt_frame frame )
 		producer_open( self, mlt_service_profile( MLT_PRODUCER_SERVICE(producer) ),
 			mlt_properties_get( properties, "resource" ), 1, 0 );
 		context = self->audio_format;
+		self->probe_complete = 0;
 	}
 
 	// Exception handling for audio_index
@@ -3272,10 +3280,77 @@ static int producer_get_frame( mlt_producer producer, mlt_frame_ptr frame, int i
 	mlt_position position = mlt_producer_frame( producer );
 	mlt_properties_set_position( frame_properties, "original_position", position );
 
+	if ( !self->probe_complete && self->video_index < 0 )
+	{
+		// If video index is valid, get_image() must be called before the probe is complete
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.width" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.height" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.color_range" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.aspect_ratio" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.progressive" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.sample_aspect_num" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.sample_aspect_den" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.top_field_first" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.progressive" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.variable_frame_rate" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.colorspace" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.color_trc" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "meta.media.has_b_frames" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "aspect_ratio" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "width" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "height" );
+		mlt_properties_clear( MLT_PRODUCER_PROPERTIES(producer), "format" );
+		self->probe_complete = 1;
+	}
+
 	// Calculate the next timecode
 	mlt_producer_prepare_next( producer );
 
 	return 0;
+}
+
+static int producer_probe( mlt_producer producer )
+{
+	producer_avformat self = producer->child;
+	int error = 0;
+
+	pthread_mutex_lock( &self->video_mutex );
+	// Update the video properties if the index changed
+	int video_index = mlt_properties_get_int( MLT_PRODUCER_PROPERTIES(producer), "video_index" );
+	if ( self->video_format && video_index > -1 && video_index != self->video_index )
+		self->probe_complete = 0;
+	pthread_mutex_unlock( &self->video_mutex );
+
+	pthread_mutex_lock( &self->audio_mutex );
+	// Update the audio properties if the index changed
+	int audio_index = mlt_properties_get_int( MLT_PRODUCER_PROPERTIES(producer), "audio_index" );
+	if ( self->audio_format && audio_index > -1 && audio_index != self->audio_index )
+		self->probe_complete = 0;
+	pthread_mutex_unlock( &self->audio_mutex );
+
+	if ( self->probe_complete )
+	{
+		return error;
+	}
+
+	mlt_frame fr = NULL;
+	mlt_position save_position = mlt_producer_position( producer );
+
+	// Call producer_get_frame() directly so that the underlying service will not attach any normalizers
+	error = producer_get_frame( producer, &fr, 0 );
+	if ( !error && fr && self->video_index > -1 )
+	{
+		// Some video metadata is not exposed until after the first get_image call.
+		uint8_t *buffer = NULL;
+		mlt_image_format fmt = mlt_image_none;
+		int w = 0;
+		int h = 0;
+		error = mlt_frame_get_image( fr, &buffer, &fmt, &w, &h, 0 );
+	}
+	mlt_frame_close( fr );
+	mlt_producer_seek( producer, save_position );
+
+	return error;
 }
 
 static void producer_avformat_close( producer_avformat self )

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -200,7 +200,7 @@ mlt_producer producer_avformat_init( mlt_profile profile, const char *service, c
 			producer->get_frame = producer_get_frame;
 
 			// Register our probe implementation
-			producer->probe = producer_probe;
+			mlt_properties_set_data( properties, "_probe", producer_probe, 0, NULL, NULL );
 
 			// Force the duration to be computed unless explicitly provided.
 			mlt_properties_set_position( properties, "length", 0 );

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -200,7 +200,7 @@ mlt_producer producer_avformat_init( mlt_profile profile, const char *service, c
 			producer->get_frame = producer_get_frame;
 
 			// Register our probe implementation
-			mlt_properties_set_data( properties, "_probe", producer_probe, 0, NULL, NULL );
+			mlt_properties_set_data( properties, "mlt_producer_probe", producer_probe, 0, NULL, NULL );
 
 			// Force the duration to be computed unless explicitly provided.
 			mlt_properties_set_position( properties, "length", 0 );


### PR DESCRIPTION
I need a way for links to be able to query the source producer before they have received a frame. This idea adds a function that will cause the producer to probe itself if necessary. Subsequent calls can skip the probe if the data is current. This implementation skips the entire mlt frame stack so that normalizing filters are skipped.

I have a concept patch here that uses the probe function to simplify the avformat producer widget. I think this might avoid the problem with the GPU thread. But I have not  tested yet.
https://github.com/bmatherly/shotcut/commit/00be4019aeb7ca3a9471676cba8bca07d8182b88

Do you think this is promising/interesting? If so, I will do more testing.