### PR TITLE
Fix consumer: resources incorrectly prefixed with root

### DIFF
--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -262,7 +262,8 @@ static inline int is_known_prefix(const char* resource)
 			"udplite",
 			"unix",
 			"color",
-			"colour"
+			"colour",
+			"consumer"
 		};
 		size_t i, n = prefix - resource;
 		for (i = 0; i < sizeof(whitelist) / sizeof(whitelist[0]); ++i) {


### PR DESCRIPTION
The `consumer` producer is currently not correctly recognized when loading xml through the producer_xml. This means that the document root is prepended if you have a resource like: `consumer:path_to_resource`, breaking the producer.

This can be reproduced with this command line (timewarping an mlt playlist) :
`melt timewarp:4:consumer:playlist.mlt -consumer xml:playlist-fast.mlt`

Trying to play the newly created file fails with:
`[producer_xml] failed to load producer "4:/$PATH_TO_SEQUENCE.MLT/consumer:playlist-fast.mlt"

This is because the `consumer` producer is not currently recognized by producer_xml, like `colour`.
`
