### PR TITLE
profile description and colorspace corrupted with consumer prod

### DIFF
--- a/src/modules/core/producer_loader.c
+++ b/src/modules/core/producer_loader.c
@@ -145,6 +145,7 @@ static mlt_producer create_producer( mlt_profile profile, char *file )
 			profile->sample_aspect_num = backup_profile->sample_aspect_num;
 			profile->width = backup_profile->width;
 			profile->colorspace = backup_profile->colorspace;
+			free( profile->description );
 			profile->description = strdup( backup_profile->description );
 
 			// Use the 'consumer' producer.

--- a/src/modules/core/producer_loader.c
+++ b/src/modules/core/producer_loader.c
@@ -144,6 +144,8 @@ static mlt_producer create_producer( mlt_profile profile, char *file )
 			profile->sample_aspect_den = backup_profile->sample_aspect_den;
 			profile->sample_aspect_num = backup_profile->sample_aspect_num;
 			profile->width = backup_profile->width;
+			profile->colorspace = backup_profile->colorspace;
+			profile->description = strdup( backup_profile->description );
 
 			// Use the 'consumer' producer.
 			mlt_producer_close( result );


### PR DESCRIPTION
Project profile's description and colorspace were overwritten by the profile from the consumer.
Reproducible with:
melt -profile dv_pal explicit=1 color:red -track hd-playlist.mlt -consumer xml

The output xml's profile would now use the description of the profile embedded in hd-playlist.mlt