### PR TITLE
Fix compilation: parameter type mismatch

### DIFF
--- a/src/modules/avformat/factory.c
+++ b/src/modules/avformat/factory.c
@@ -32,7 +32,7 @@ extern mlt_filter filter_swscale_init(mlt_profile profile, char *arg);
 extern mlt_producer producer_avformat_init(mlt_profile profile, const char *service, char *file);
 extern mlt_filter filter_avfilter_init(mlt_profile, mlt_service_type, const char *, char *);
 extern mlt_link link_avdeinterlace_init(mlt_profile, mlt_service_type, const char *, char *);
-extern mlt_link link_swresample_init(mlt_profile profile, char *arg);
+extern mlt_link link_swresample_init(mlt_profile profile, mlt_service_type, const char *, char *);
 
 // ffmpeg Header files
 #include <libavcodec/avcodec.h>
@@ -95,7 +95,7 @@ static void *create_service(mlt_profile profile, mlt_service_type type, const ch
         if (type == mlt_service_filter_type)
             return filter_swresample_init(profile, arg);
         else if (type == mlt_service_link_type)
-            return link_swresample_init(profile, arg);
+            return link_swresample_init(profile, type, id, arg);
     }
 #endif
     return NULL;

--- a/src/win32/win32.c
+++ b/src/win32/win32.c
@@ -70,7 +70,7 @@ int setenv(const char *name, const char *value, int overwrite)
 
 static int iconv_from_utf8( mlt_properties properties, const char *prop_name, const char *prop_name_out, const char* encoding )
 {
-	char *text = mlt_properties_get( properties, prop_name );
+	const char *text = mlt_properties_get( properties, prop_name );
 	int result = 0;
 
 	if ( text ) {
@@ -99,7 +99,7 @@ static int iconv_from_utf8( mlt_properties properties, const char *prop_name, co
 
 static int iconv_to_utf8( mlt_properties properties, const char *prop_name, const char *prop_name_out, const char* encoding )
 {
-	char *text = mlt_properties_get( properties, prop_name );
+	const char *text = mlt_properties_get( properties, prop_name );
 	int result = 0;
 
 	if ( text ) {


### PR DESCRIPTION
Fix our PPA compilation:
./src/modules/avformat/factory.c:35:17: error: type of ‘link_swresample_init’ does not match original declaration [-Werror=lto-type-mismatch]
./src/modules/avformat/link_swresample.c:340:10: note: type mismatch in parameter 2
./src/modules/avformat/link_swresample.c:340:10: note: ‘link_swresample_init’ was previously declared here