### PR TITLE
Fix compilation: type mismatch

### DIFF
--- a/src/modules/plus/factory.c
+++ b/src/modules/plus/factory.c
@@ -105,7 +105,10 @@ extern mlt_producer producer_blipflash_init(mlt_profile profile,
                                             mlt_service_type type,
                                             const char *id,
                                             char *arg);
-extern mlt_producer producer_count_init(const char *arg);
+extern mlt_producer producer_count_init(mlt_profile profile,
+                                        mlt_service_type type,
+                                        const char *id,
+                                        char *arg);
 extern mlt_producer producer_pgm_init(mlt_profile profile,
                                       mlt_service_type type,
                                       const char *id,


### PR DESCRIPTION
```
./src/modules/plus/factory.c:108:21: error: type of ‘producer_count_init’ does not match original declaration [-Werror=lto-type-mismatch]
./src/modules/plus/producer_count.c:632:14: note: type mismatch in parameter 2
./src/modules/plus/producer_count.c:632:14: note: type ‘mlt_service_type’ should match type ‘void’
./src/modules/plus/producer_count.c:632:14: note: ‘producer_count_init’ was previously declared here
lto1: all warnings being treated as errors
```
See https://launchpadlibrarian.net/659401639/buildlog_ubuntu-kinetic-amd64.mlt_7.15.0+git202304021819-2~ubuntu22.10.1_BUILDING.txt.gz