### PR TITLE
Fix two data races and a potential deadlock

### DIFF
--- a/src/framework/mlt_events.c
+++ b/src/framework/mlt_events.c
@@ -22,6 +22,7 @@
 
 #include <limits.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -60,8 +61,8 @@ typedef struct mlt_events_struct *mlt_events;
 struct mlt_event_struct
 {
     mlt_events parent;
-    int ref_count;
-    int block_count;
+    atomic_int_fast32_t ref_count;
+    atomic_int_fast32_t block_count;
     mlt_listener listener;
     void *listener_data;
 };

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -1923,8 +1923,8 @@ static int producer_get_image(mlt_frame frame,
     int dst_full_range = dst_color_range
                          && (!strcmp("pc", dst_color_range) || !strcmp("jpeg", dst_color_range));
 
-    pthread_mutex_lock(&self->video_mutex);
     mlt_service_lock(MLT_PRODUCER_SERVICE(producer));
+    pthread_mutex_lock(&self->video_mutex);
     mlt_log_timings_begin();
 
 #ifdef AVFILTER


### PR DESCRIPTION
While testing melt-7 with shotcut for issue #899 (the idea was to check for thread leaks), the following two data races and one cycle in lock order issues were found:

* Lock order:
`producer_set_up_video()` versus `producer_get_frame()`
* Data race:
`consumer_worker_thread()` versus `first_unprocessed_frame()`
* Data race:
`mlt_events_fire()` versus `mlt_event_unblock()`

Details to the individual ThreadSanitizer reports are in the respective commit descriptions.