### PR TITLE
Wrap some structs in anonymous namespace

### DIFF
--- a/src/modules/qt/filter_audiolevelgraph.cpp
+++ b/src/modules/qt/filter_audiolevelgraph.cpp
@@ -27,12 +27,14 @@
 #include <QPainter>
 #include <QVector>
 
+namespace {
 // Private Types
 typedef struct
 {
     mlt_filter levels_filter;
     int preprocess_warned;
 } private_data;
+} // namespace
 
 static int filter_get_audio(mlt_frame frame,
                             void **buffer,

--- a/src/modules/qt/filter_audiowaveform.cpp
+++ b/src/modules/qt/filter_audiowaveform.cpp
@@ -27,6 +27,7 @@
 
 static const qreal MAX_S16_AMPLITUDE = 32768.0;
 
+namespace {
 // Private Types
 typedef struct
 {
@@ -44,6 +45,8 @@ typedef struct
     int samples;
     int channels;
 } save_buffer;
+
+} // namespace
 
 static save_buffer *create_save_buffer(int samples, int channels, int16_t *buffer)
 {

--- a/src/modules/qt/filter_gpsgraphic.h
+++ b/src/modules/qt/filter_gpsgraphic.h
@@ -29,6 +29,8 @@ struct s_gps_data_bounds
     }
 };
 
+namespace {
+
 typedef struct
 {
     gps_point_raw *gps_points_r;  //raw gps data from file
@@ -52,6 +54,8 @@ typedef struct
     QRectF bg_img_matched_rect;
     int swap_180;
 } private_data;
+
+} // namespace
 
 typedef enum {
     gspg_location_src = 0,

--- a/src/modules/qt/filter_gpstext.cpp
+++ b/src/modules/qt/filter_gpstext.cpp
@@ -24,6 +24,8 @@ static QMutex f_mutex;
 
 #define MAX_TEXT_LEN 1024
 
+namespace {
+
 typedef struct
 {
     gps_point_raw *gps_points_r;  //raw gps data from file
@@ -41,6 +43,8 @@ typedef struct
     char interpolated;
     int swap_180;
 } private_data;
+
+} // namespace
 
 // Sets the private data to default values and frees gps points array
 static void default_priv_data(private_data *pdata)

--- a/src/modules/qt/filter_lightshow.cpp
+++ b/src/modules/qt/filter_lightshow.cpp
@@ -27,6 +27,8 @@
 // Private Constants
 static const double PI = 3.14159265358979323846;
 
+namespace {
+
 // Private Types
 typedef struct
 {
@@ -35,6 +37,8 @@ typedef struct
     int rel_pos;
     int preprocess_warned;
 } private_data;
+
+} // namespace
 
 static int filter_get_audio(mlt_frame frame,
                             void **buffer,


### PR DESCRIPTION
This is to fix errors like:
error: type ‘struct private_data’ violates the C++ One Definition Rule [- Werror=odr]

Fixes #905 