### PR TITLE
Fix crash when changing video mode with count producer

### DIFF
--- a/src/modules/plus/producer_count.c
+++ b/src/modules/plus/producer_count.c
@@ -36,7 +36,6 @@
 #define OUTER_RING_RATIO 90
 #define INNER_RING_RATIO 80
 #define TEXT_SIZE_RATIO 70
-#define FACTORY_PRODUCER "_factory_producer"
 
 typedef struct
 {
@@ -193,8 +192,7 @@ static mlt_frame get_background_frame(mlt_producer producer)
 
     if (!color_producer) {
         mlt_profile profile = mlt_service_profile(MLT_PRODUCER_SERVICE(producer));
-        const char *factory_producer = mlt_properties_get(producer_properties, FACTORY_PRODUCER);
-        color_producer = mlt_factory_producer(profile, factory_producer, "colour");
+        color_producer = mlt_factory_producer(profile, "loader-nogl", "colour");
         mlt_properties_set_data(producer_properties,
                                 "_color_producer",
                                 color_producer,
@@ -224,12 +222,11 @@ static mlt_frame get_text_frame(mlt_producer producer, time_info *info)
     mlt_frame text_frame = NULL;
 
     if (!text_producer) {
-        const char *factory_producer = mlt_properties_get(producer_properties, FACTORY_PRODUCER);
-        text_producer = mlt_factory_producer(profile, factory_producer, "qtext");
+        text_producer = mlt_factory_producer(profile, "loader-nogl", "qtext");
 
         // Use pango if qtext is not available.
         if (!text_producer)
-            text_producer = mlt_factory_producer(profile, factory_producer, "pango");
+            text_producer = mlt_factory_producer(profile, "loader-nogl", "pango");
 
         if (!text_producer)
             mlt_log_warning(MLT_PRODUCER_SERVICE(producer),
@@ -646,9 +643,6 @@ mlt_producer producer_count_init(mlt_profile profile,
         mlt_properties_set(properties, "background", "clock");
         mlt_properties_set(properties, "drop", "0");
         mlt_properties_clear(properties, "resource");
-        // Let the arg specify the producer to use with the factory, e.g. loader-nogl
-        if (arg && strcmp(arg, ""))
-            mlt_properties_set(properties, FACTORY_PRODUCER, arg);
 
         // Callback registration
         producer->get_frame = producer_get_frame;

--- a/src/modules/plus/producer_count.yml
+++ b/src/modules/plus/producer_count.yml
@@ -13,17 +13,6 @@ description: >
   Generate frames with a counter and synchronized tone. 
   The counter can go up or down.
 parameters:
-  - identifier: argument
-    argument: yes
-    title: Factory Producer Name
-    description: >
-      This is not a saved property with a name. This optional argument tells
-      the count producer which loader producer to use, if any, when it creates
-      its child producers. For example, you can use loader-nogl to prevent it
-      from using movit filters in a thread not initialized with OpenGL and
-      Movit.
-    type: string
-    mutable: no
   - identifier: direction
     title: Count Direction
     description: Whether to count up or down.


### PR DESCRIPTION
As reported here:
https://forum.shotcut.org/t/release-candidate-version-23-04-20/38515/22

My proposal for the short term is that we should not ever use movit for the encapsulated services in the count producer.

The count producer was written before the generic text filter. Now it should be refactored to use the text filter instead of two producers and a transition. This would make it more efficient and it would not have any use for movit conversions. But this larger change should wait until after a release.