### PR TITLE
Fix Chains incorrectly applying deinterlace link on invalid producers

### DIFF
--- a/src/modules/gdk/producer_pango.c
+++ b/src/modules/gdk/producer_pango.c
@@ -226,6 +226,7 @@ mlt_producer producer_pango_init(const char *filename)
         mlt_properties_set_int(properties, "stretch", PANGO_STRETCH_NORMAL + 1);
         mlt_properties_set_int(properties, "rotate", 0);
         mlt_properties_set_int(properties, "seekable", 1);
+        mlt_properties_set_int(properties, "meta.media.progressive", 1);
 
         if (filename == NULL
             || (filename

--- a/src/modules/gdk/producer_pixbuf.c
+++ b/src/modules/gdk/producer_pixbuf.c
@@ -124,6 +124,7 @@ mlt_producer producer_pixbuf_init(char *filename)
         mlt_properties_set_int(properties, "progressive", 1);
         mlt_properties_set_int(properties, "seekable", 1);
         mlt_properties_set_int(properties, "loop", 1);
+        mlt_properties_set_int(properties, "meta.media.progressive", 1);
 
         // Validate the resource
         if (filename)

--- a/src/modules/qt/producer_kdenlivetitle.c
+++ b/src/modules/qt/producer_kdenlivetitle.c
@@ -159,9 +159,7 @@ static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int in
         mlt_frame_set_position(*frame, mlt_producer_position(producer));
 
         // Set producer-specific frame properties
-        mlt_properties_set_int(properties,
-                               "progressive",
-                               mlt_properties_get_int(producer_props, "progressive"));
+        mlt_properties_set_int(properties, "progressive", 1);
 
         // Inform framework that this producer creates rgba frames by default
         // TODO: read the producer's xml on opening so we know if we have RGB or RGBA data
@@ -210,7 +208,7 @@ mlt_producer producer_kdenlivetitle_init(mlt_profile profile,
         producer->get_frame = producer_get_frame;
         producer->close = (mlt_destructor) producer_close;
         mlt_properties_set(properties, "resource", filename);
-        mlt_properties_set_int(properties, "progressive", 1);
+        mlt_properties_set_int(properties, "meta.media.progressive", 1);
         mlt_properties_set_int(properties, "aspect_ratio", 1);
         mlt_properties_set_int(properties, "seekable", 1);
         if (!initTitleProducer(producer)) {

--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -80,7 +80,7 @@ mlt_producer producer_qimage_init(mlt_profile profile,
         mlt_properties_set(properties, "resource", filename);
         mlt_properties_set_int(properties, "ttl", self->count > 1 ? 1 : 25);
         mlt_properties_set_int(properties, "aspect_ratio", 1);
-        mlt_properties_set_int(properties, "progressive", 1);
+        mlt_properties_set_int(properties, "meta.media.progressive", 1);
         mlt_properties_set_int(properties, "seekable", 1);
 
         // Validate the resource
@@ -331,9 +331,7 @@ static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int in
         }
 
         // Set producer-specific frame properties
-        mlt_properties_set_int(properties,
-                               "progressive",
-                               mlt_properties_get_int(producer_properties, "progressive"));
+        mlt_properties_set_int(properties, "progressive", 1);
         mlt_properties_set_int(properties,
                                "format",
                                mlt_properties_get_int(producer_properties, "format"));

--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -498,7 +498,7 @@ mlt_producer producer_qtext_init(mlt_profile profile,
         mlt_properties_set(producer_properties, "style", "normal");
         mlt_properties_set(producer_properties, "weight", "400");
         mlt_properties_set(producer_properties, "encoding", "UTF-8");
-        mlt_properties_set_int(producer_properties, "progressive", 1);
+        mlt_properties_set_int(producer_properties, "meta.media.progressive", 1);
 
         // Parse the filename argument
         if (filename == NULL || !strcmp(filename, "") || strstr(filename, "<producer>")) {

--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -498,6 +498,7 @@ mlt_producer producer_qtext_init(mlt_profile profile,
         mlt_properties_set(producer_properties, "style", "normal");
         mlt_properties_set(producer_properties, "weight", "400");
         mlt_properties_set(producer_properties, "encoding", "UTF-8");
+        mlt_properties_set_int(producer_properties, "progressive", 1);
 
         // Parse the filename argument
         if (filename == NULL || !strcmp(filename, "") || strstr(filename, "<producer>")) {

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -653,8 +653,9 @@ static void on_end_chain(deserialise_context context, const xmlChar *name)
             mlt_log_error(NULL, "[producer_xml] failed to load chain \"%s\"\n", resource);
             source = mlt_factory_producer(context->profile, NULL, "+INVALID.txt");
             if (source) {
-                // Save the original mlt_service for the consumer to serialize it as original.
+                // QText producer produces progressive material, don't try to deinterlace.
                 mlt_properties_set_int(properties, "progressive", 1);
+                // Save the original mlt_service for the consumer to serialize it as original.
                 mlt_properties_set_string(properties,
                                           "_xml_mlt_service",
                                           mlt_properties_get(properties, "mlt_service"));

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -653,8 +653,6 @@ static void on_end_chain(deserialise_context context, const xmlChar *name)
             mlt_log_error(NULL, "[producer_xml] failed to load chain \"%s\"\n", resource);
             source = mlt_factory_producer(context->profile, NULL, "+INVALID.txt");
             if (source) {
-                // QText producer produces progressive material, don't try to deinterlace.
-                mlt_properties_set_int(properties, "progressive", 1);
                 // Save the original mlt_service for the consumer to serialize it as original.
                 mlt_properties_set_string(properties,
                                           "_xml_mlt_service",

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -650,10 +650,11 @@ static void on_end_chain(deserialise_context context, const xmlChar *name)
         if (!source && resource)
             source = mlt_factory_producer(context->profile, NULL, resource);
         if (!source) {
-            mlt_log_error(NULL, "[producer_xml] failed to load producer \"%s\"\n", resource);
+            mlt_log_error(NULL, "[producer_xml] failed to load chain \"%s\"\n", resource);
             source = mlt_factory_producer(context->profile, NULL, "+INVALID.txt");
             if (source) {
                 // Save the original mlt_service for the consumer to serialize it as original.
+                mlt_properties_set_int(properties, "progressive", 1);
                 mlt_properties_set_string(properties,
                                           "_xml_mlt_service",
                                           mlt_properties_get(properties, "mlt_service"));


### PR DESCRIPTION
link_deinterlace was incorrectly attached to INVALID xml producers (the producers with a missing source on load), resulting in corrupted frames and possible crashes.

This can be reproduced with this command:
`melt -chain qtext:+INVALID`

With my fix, it now produces a correct image