### PR TITLE
Playlist seam

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -676,3 +676,8 @@ MLT_7.16.0 {
     mlt_frame_clone_audio;
     mlt_frame_clone_image;
 } MLT_7.14.0;
+
+MLT_7.18.0 {
+  global:
+    mlt_audio_free_data;
+} MLT_7.16.0;

--- a/src/framework/mlt_audio.c
+++ b/src/framework/mlt_audio.c
@@ -127,13 +127,35 @@ void mlt_audio_alloc_data(mlt_audio self)
     if (!self)
         return;
 
-    if (self->release_data) {
-        self->release_data(self->data);
-    }
+    mlt_audio_free_data(self);
 
     int size = mlt_audio_calculate_size(self);
     self->data = mlt_pool_alloc(size);
     self->release_data = mlt_pool_release;
+}
+
+/** Free the data field using the destructor function.
+ *
+ * If the constructor function does not exist, the value will be set to NULL
+ * without being released.
+ *
+ * After this function call, the data and release_data fields will be NULL.
+ *
+ * \public \memberof mlt_audio_s
+ * \param self the Audio object
+ */
+
+void mlt_audio_free_data(mlt_audio self)
+{
+    if (!self)
+        return;
+
+    if (self->release_data) {
+        self->release_data(self->data);
+    }
+
+    self->data = NULL;
+    self->release_data = NULL;
 }
 
 /** Calculate the number of bytes needed for the Audio data.

--- a/src/framework/mlt_audio.h
+++ b/src/framework/mlt_audio.h
@@ -53,6 +53,7 @@ extern void mlt_audio_get_values(mlt_audio self,
                                  int *samples,
                                  int *channels);
 extern void mlt_audio_alloc_data(mlt_audio self);
+extern void mlt_audio_free_data(mlt_audio self);
 extern int mlt_audio_calculate_size(mlt_audio self);
 extern int mlt_audio_plane_count(mlt_audio self);
 extern int mlt_audio_plane_size(mlt_audio self);

--- a/src/modules/core/CMakeLists.txt
+++ b/src/modules/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(mltcore MODULE
   filter_audiomap.c
   filter_audioseam.c
   filter_audiowave.c
+  filter_autofade.c
   filter_box_blur.c
   filter_brightness.c
   filter_channelcopy.c
@@ -77,6 +78,7 @@ install(FILES
   consumer_multi.yml
   filter_audiomap.yml
   filter_audiowave.yml
+  filter_autofade.yml
   filter_box_blur.yml
   filter_brightness.yml
   filter_channelcopy.yml

--- a/src/modules/core/CMakeLists.txt
+++ b/src/modules/core/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(mltcore MODULE
   filter_audiochannels.c
   filter_audioconvert.c
   filter_audiomap.c
+  filter_audioseam.c
   filter_audiowave.c
   filter_box_blur.c
   filter_brightness.c

--- a/src/modules/core/factory.c
+++ b/src/modules/core/factory.c
@@ -45,6 +45,10 @@ extern mlt_filter filter_audiowave_init(mlt_profile profile,
                                         mlt_service_type type,
                                         const char *id,
                                         char *arg);
+extern mlt_filter filter_autofade_init(mlt_profile profile,
+                                       mlt_service_type type,
+                                       const char *id,
+                                       char *arg);
 extern mlt_filter filter_box_blur_init(mlt_profile profile,
                                        mlt_service_type type,
                                        const char *id,
@@ -203,6 +207,7 @@ MLT_REPOSITORY
     MLT_REGISTER(mlt_service_filter_type, "audiomap", filter_audiomap_init);
     MLT_REGISTER(mlt_service_filter_type, "audioseam", filter_audioseam_init);
     MLT_REGISTER(mlt_service_filter_type, "audiowave", filter_audiowave_init);
+    MLT_REGISTER(mlt_service_filter_type, "autofade", filter_autofade_init);
     MLT_REGISTER(mlt_service_filter_type, "box_blur", filter_box_blur_init);
     MLT_REGISTER(mlt_service_filter_type, "brightness", filter_brightness_init);
     MLT_REGISTER(mlt_service_filter_type, "channelcopy", filter_channelcopy_init);
@@ -264,6 +269,7 @@ MLT_REPOSITORY
     MLT_REGISTER_METADATA(mlt_service_filter_type, "audiomap", metadata, "filter_audiomap.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "audioseam", metadata, "filter_audioseam.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "audiowave", metadata, "filter_audiowave.yml");
+    MLT_REGISTER_METADATA(mlt_service_filter_type, "autofade", metadata, "filter_autofade.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "box_blur", metadata, "filter_box_blur.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "brightness", metadata, "filter_brightness.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type,

--- a/src/modules/core/factory.c
+++ b/src/modules/core/factory.c
@@ -65,6 +65,10 @@ extern mlt_filter filter_crop_init(mlt_profile profile,
                                    mlt_service_type type,
                                    const char *id,
                                    char *arg);
+extern mlt_filter filter_audioseam_init(mlt_profile profile,
+                                        mlt_service_type type,
+                                        const char *id,
+                                        char *arg);
 extern mlt_filter filter_fieldorder_init(mlt_profile profile,
                                          mlt_service_type type,
                                          const char *id,
@@ -197,6 +201,7 @@ MLT_REPOSITORY
     MLT_REGISTER(mlt_service_filter_type, "audiochannels", filter_audiochannels_init);
     MLT_REGISTER(mlt_service_filter_type, "audioconvert", filter_audioconvert_init);
     MLT_REGISTER(mlt_service_filter_type, "audiomap", filter_audiomap_init);
+    MLT_REGISTER(mlt_service_filter_type, "audioseam", filter_audioseam_init);
     MLT_REGISTER(mlt_service_filter_type, "audiowave", filter_audiowave_init);
     MLT_REGISTER(mlt_service_filter_type, "box_blur", filter_box_blur_init);
     MLT_REGISTER(mlt_service_filter_type, "brightness", filter_brightness_init);
@@ -257,6 +262,7 @@ MLT_REPOSITORY
                           metadata,
                           "filter_audioconvert.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "audiomap", metadata, "filter_audiomap.yml");
+    MLT_REGISTER_METADATA(mlt_service_filter_type, "audioseam", metadata, "filter_audioseam.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "audiowave", metadata, "filter_audiowave.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "box_blur", metadata, "filter_box_blur.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "brightness", metadata, "filter_brightness.yml");

--- a/src/modules/core/filter_audioseam.c
+++ b/src/modules/core/filter_audioseam.c
@@ -1,0 +1,181 @@
+/*
+ * filter_audioseam.c -- smooth seams between clips in a playlist
+ * Copyright (C) 2023 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+typedef struct
+{
+    struct mlt_audio_s prev_audio;
+} private_data;
+
+static float db_delta(float a, float b)
+{
+    float dba = 0;
+    float dbb = 0;
+    const float essentially_zero = 0.001;
+    // Calculate db from zero
+    if (fabs(a) > essentially_zero) {
+        dba = log10(fabs(a)) * 20;
+    }
+    if (fabs(b) > essentially_zero) {
+        dbb = log10(fabs(b)) * 20;
+    }
+    // Apply sign
+    if (a < 0) {
+        dba *= -1.0;
+    }
+    if (b < 0) {
+        dba *= -1;
+    }
+    return dba - dbb;
+}
+
+static int filter_get_audio(mlt_frame frame,
+                            void **buffer,
+                            mlt_audio_format *format,
+                            int *frequency,
+                            int *channels,
+                            int *samples)
+{
+    mlt_filter filter = mlt_frame_pop_audio(frame);
+    mlt_properties filter_properties = MLT_FILTER_PROPERTIES(filter);
+    private_data *pdata = (private_data *) filter->child;
+    int clip_position = mlt_properties_get_int(MLT_FRAME_PROPERTIES(frame),
+                                               "meta.playlist.clip_position");
+    int clip_length = mlt_properties_get_int(MLT_FRAME_PROPERTIES(frame),
+                                             "meta.playlist.clip_length");
+
+    if (clip_length == 0 || (clip_position != 0 && clip_position != (clip_length - 1))) {
+        // Only operate on the first and last frame of every clip
+        return mlt_frame_get_audio(frame, buffer, format, frequency, channels, samples);
+    }
+
+    *format = mlt_audio_f32le;
+    int ret = mlt_frame_get_audio(frame, buffer, format, frequency, channels, samples);
+    if (ret != 0) {
+        return ret;
+    }
+
+    struct mlt_audio_s curr_audio;
+    mlt_audio_set_values(&curr_audio, *buffer, *frequency, *format, *samples, *channels);
+
+    if (clip_position == 0) {
+        if (!pdata->prev_audio.data) {
+            mlt_log_debug(MLT_FILTER_SERVICE(filter), "Missing previous audio\n");
+        } else {
+            float *prev_data = pdata->prev_audio.data;
+            float *curr_data = curr_audio.data;
+            float level_delta = db_delta(prev_data[pdata->prev_audio.samples - 1], curr_data[0]);
+            double discontinuity_threshold = mlt_properties_get_double(filter_properties,
+                                                                       "discontinuity_threshold");
+            if (fabs(level_delta) > discontinuity_threshold) {
+                // We have decided to create a transition with the previous frame.
+                // Reverse the prevous frame and use the reversed samples as faux
+                // data that is continuous from the prevous frame.
+                // Mix/fade the reversed previous samples with the new samples to create a transition.
+                mlt_audio_reverse(&pdata->prev_audio);
+                int fade_samples = 1000;
+                if (fade_samples > curr_audio.samples) {
+                    fade_samples = curr_audio.samples;
+                }
+                if (fade_samples > pdata->prev_audio.samples) {
+                    fade_samples = pdata->prev_audio.samples;
+                }
+                for (int c = 0; c < curr_audio.channels; c++) {
+                    curr_data = (float *) curr_audio.data + c;
+                    prev_data = (float *) pdata->prev_audio.data + c;
+                    for (int i = 0; i < fade_samples; i++) {
+                        float mix = (1.0 / fade_samples) * (float) (fade_samples - i);
+                        *curr_data = (*prev_data * mix) + (*curr_data * (1.0 - mix));
+                        curr_data += curr_audio.channels;
+                        prev_data += curr_audio.channels;
+                    }
+                }
+                // If this flag is set, it must be cleared so that other services will know it can't be ignored.
+                mlt_properties_clear(MLT_FRAME_PROPERTIES(frame), "test_audio");
+                // Increment the counter
+                mlt_properties_set_int(filter_properties,
+                                       "seam_count",
+                                       mlt_properties_get_int(filter_properties, "seam_count") + 1);
+            }
+        }
+        mlt_audio_free_data(&pdata->prev_audio);
+    } else if (clip_position == (clip_length - 1)) {
+        // Save the samples of the last frame to be used to mix with the first frame of the next clip.
+        mlt_audio_set_values(&pdata->prev_audio, NULL, *frequency, *format, *samples, *channels);
+        mlt_audio_alloc_data(&pdata->prev_audio);
+        mlt_audio_copy(&pdata->prev_audio, &curr_audio, *samples, 0, 0);
+    }
+
+    return 0;
+}
+
+static mlt_frame filter_process(mlt_filter filter, mlt_frame frame)
+{
+    mlt_properties frame_properties = MLT_FRAME_PROPERTIES(frame);
+    int clip_position = mlt_properties_get_int(frame_properties, "meta.playlist.clip_position");
+    int clip_length = mlt_properties_get_int(frame_properties, "meta.playlist.clip_length");
+
+    // Only operate on the first and last frame of every clip
+    if (clip_length > 0 && (clip_position == 0 || clip_position == (clip_length - 1))) {
+        // Be sure to process blanks in a playlist
+        mlt_properties_clear(frame_properties, "test_audio");
+        mlt_frame_push_audio(frame, filter);
+        mlt_frame_push_audio(frame, filter_get_audio);
+    }
+    return frame;
+}
+
+static void filter_close(mlt_filter filter)
+{
+    private_data *pdata = (private_data *) filter->child;
+
+    if (pdata) {
+        mlt_audio_free_data(&pdata->prev_audio);
+    }
+    free(pdata);
+    filter->child = NULL;
+    filter->close = NULL;
+    filter->parent.close = NULL;
+    mlt_service_close(&filter->parent);
+}
+
+mlt_filter filter_audioseam_init(mlt_profile profile,
+                                 mlt_service_type type,
+                                 const char *id,
+                                 char *arg)
+{
+    mlt_filter filter = mlt_filter_new();
+    private_data *pdata = (private_data *) calloc(1, sizeof(private_data));
+
+    if (filter && pdata) {
+        filter->close = filter_close;
+        filter->process = filter_process;
+        filter->child = pdata;
+    } else {
+        mlt_filter_close(filter);
+        filter = NULL;
+        free(pdata);
+    }
+
+    return filter;
+}

--- a/src/modules/core/filter_audioseam.yml
+++ b/src/modules/core/filter_audioseam.yml
@@ -1,0 +1,36 @@
+schema_version: 0.3
+type: filter
+identifier: audioseam
+title: Audio Seam
+version: 1
+copyright: Meltytech, LLC
+license: LGPLv2.1
+language: en
+tags:
+  - Audio
+description: >
+  Seam audio splices between clips in a playlist.
+  Only to be used as a filter on playlist producers.
+  Uses the "meta.playlist.clip_position" and "meta.playlist.clip_length"
+  properties that are added by the playlist producer to determine where
+  the seams between clips occur.
+
+  - identifier: discontinuity_threshold
+    title: Discontinuity Threshold
+    type: float
+    description: >
+      The delta between the last sample of one clip and the first sample of the following clip that
+      are spliced. If the delta is above the discontinuity threshold, then smoothing will be applied.
+    readonly: no
+    mutable: yes
+    default: 2
+    minimum: 0
+    maximum: 30
+    unit: dB
+
+  - identifier: seam_count
+    title: Seam Count
+    type: integer
+    description: >
+      The number of splices that have exceeded the discontinuity threshold and have been seamed.
+    readonly: yes

--- a/src/modules/core/filter_autofade.c
+++ b/src/modules/core/filter_autofade.c
@@ -1,0 +1,135 @@
+/*
+ * filter_autofade.c -- Automatically fade audio between clips in a playlist.
+ * Copyright (C) 2023 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+static float decay_factor(int position, int count)
+{
+    float factor = (float) position / (float) (count - 1);
+    if (factor < 0) {
+        factor = 0;
+    } else if (factor > 1.0) {
+        factor = 1.0;
+    }
+    return factor;
+}
+
+static int filter_get_audio(mlt_frame frame,
+                            void **buffer,
+                            mlt_audio_format *format,
+                            int *frequency,
+                            int *channels,
+                            int *samples)
+{
+    mlt_filter filter = mlt_frame_pop_audio(frame);
+    *format = mlt_audio_f32le;
+    int ret = mlt_frame_get_audio(frame, buffer, format, frequency, channels, samples);
+    if (ret != 0) {
+        return ret;
+    }
+
+    mlt_properties filter_properties = MLT_FILTER_PROPERTIES(filter);
+    int clip_position = mlt_properties_get_int(MLT_FRAME_PROPERTIES(frame),
+                                               "meta.playlist.clip_position");
+    int clip_length = mlt_properties_get_int(MLT_FRAME_PROPERTIES(frame),
+                                             "meta.playlist.clip_length");
+    int fade_duration = mlt_properties_get_int(filter_properties, "fade_duration");
+    int fade_samples = fade_duration * *frequency / 1000;
+    double fps = mlt_profile_fps(mlt_service_profile(MLT_FILTER_SERVICE(filter)));
+    int64_t samples_to_frame_begin = mlt_audio_calculate_samples_to_position(fps,
+                                                                             *frequency,
+                                                                             clip_position);
+    int64_t samples_in_clip = mlt_audio_calculate_samples_to_position(fps,
+                                                                      *frequency,
+                                                                      clip_length + 1);
+    int64_t samples_to_clip_end = samples_in_clip - samples_to_frame_begin - *samples;
+    struct mlt_audio_s audio;
+    mlt_audio_set_values(&audio, *buffer, *frequency, *format, *samples, *channels);
+    float *data = (float *) audio.data;
+    if (samples_to_frame_begin <= fade_samples) {
+        // Fade in
+        for (int i = 0; i < audio.samples; i++) {
+            float factor = decay_factor(samples_to_frame_begin + i, fade_samples);
+            for (int c = 0; c < audio.channels; c++) {
+                *data = *data * factor;
+                data++;
+            }
+        }
+        mlt_properties_set_int(filter_properties,
+                               "fade_in_count",
+                               mlt_properties_get_int(filter_properties, "fade_in_count") + 1);
+    } else if ((samples_to_clip_end - *samples) <= fade_samples) {
+        // Fade out
+        for (int i = 0; i < audio.samples; i++) {
+            float factor = decay_factor(samples_to_clip_end - i, fade_samples);
+            for (int c = 0; c < audio.channels; c++) {
+                *data = *data * factor;
+                data++;
+            }
+        }
+        mlt_properties_set_int(filter_properties,
+                               "fade_out_count",
+                               mlt_properties_get_int(filter_properties, "fade_out_count") + 1);
+    }
+
+    return 0;
+}
+
+static mlt_frame filter_process(mlt_filter filter, mlt_frame frame)
+{
+    int clip_position = mlt_properties_get_int(MLT_FRAME_PROPERTIES(frame),
+                                               "meta.playlist.clip_position");
+    int clip_length = mlt_properties_get_int(MLT_FRAME_PROPERTIES(frame),
+                                             "meta.playlist.clip_length");
+    int fade_duration = mlt_properties_get_int(MLT_FILTER_PROPERTIES(filter), "fade_duration");
+    double fps = mlt_profile_fps(mlt_service_profile(MLT_FILTER_SERVICE(filter)));
+    int ms_from_begining = (double) clip_position * 1000.0 / fps;
+    int ms_from_end = (double) (clip_length - clip_position - 1) * 1000.0 / fps;
+    if (ms_from_begining <= fade_duration || ms_from_end <= fade_duration) {
+        mlt_frame_push_audio(frame, filter);
+        mlt_frame_push_audio(frame, filter_get_audio);
+    }
+    return frame;
+}
+
+static void filter_close(mlt_filter filter)
+{
+    filter->child = NULL;
+    filter->close = NULL;
+    filter->parent.close = NULL;
+    mlt_service_close(&filter->parent);
+}
+
+mlt_filter filter_autofade_init(mlt_profile profile,
+                                mlt_service_type type,
+                                const char *id,
+                                char *arg)
+{
+    mlt_filter filter = mlt_filter_new();
+
+    if (filter) {
+        filter->close = filter_close;
+        filter->process = filter_process;
+    }
+
+    return filter;
+}

--- a/src/modules/core/filter_autofade.yml
+++ b/src/modules/core/filter_autofade.yml
@@ -1,0 +1,44 @@
+schema_version: 0.3
+type: filter
+identifier: autofade
+title: Auto Fade
+version: 1
+copyright: Meltytech, LLC
+license: LGPLv2.1
+language: en
+tags:
+  - Audio
+description: >
+  Automatically fade audio between clips in a playlist.
+  This filter will fade the audio out at the end of a clip and fade the
+  audio in at the  begining of a clip.
+  Only to be used as a filter on playlist producers.
+  Uses the "meta.playlist.clip_position" and "meta.playlist.clip_length"
+  properties that are added by the playlist producer to determine where
+  the splices between clips occur.
+
+  - identifier: fade_duration
+    title: Fade Duration
+    type: integer
+    description: >
+      The duration of each fade in and fade out.
+    readonly: no
+    mutable: yes
+    default: 20
+    minimum: 1
+    maximum: 1000
+    unit: ms
+
+  - identifier: fade_in_count
+    title: Fade In Count
+    type: integer
+    description: >
+      The number of time fade in has been applied.
+    readonly: yes
+
+  - identifier: fade_out_count
+    title: Fade Out Count
+    type: integer
+    description: >
+      The number of time fade out has been applied.
+    readonly: yes


### PR DESCRIPTION
Add two "track only" filters to attempt to smooth discontinuities between clips in a playlist.

Before:
![image](https://github.com/mltframework/mlt/assets/821968/853b0069-4322-4fae-8ff7-6d6e1591f00c)

Auto Fade applied:
![image](https://github.com/mltframework/mlt/assets/821968/9893bf04-de56-470b-a08c-ef52b20ed839)

Seam applied:
![image](https://github.com/mltframework/mlt/assets/821968/e0586214-64e7-46b6-b3ef-ffd4ba9f1620)

The seam can produce perceptibly seamless splices in content with many frequencies. But it can cause destructive noise in calculated content like a sine wave.