### PR TITLE
Include locale.h on any GNU libc platform

### DIFF
--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -30,7 +30,7 @@
 #include <sys/param.h>
 #endif
 
-#if (defined(__linux__) && !defined(__APPLE__))
+#if defined(__linux__) || defined(__GLIBC__)
 #include <locale.h>
 typedef locale_t mlt_locale_t;
 #elif defined(__APPLE__) || (defined(__FreeBSD_version) && __FreeBSD_version >= 900506)


### PR DESCRIPTION
`locale.h` & `locale_t` are implemented by GNU libc (at least), so any OS based on it has them; hence, extend the check to use `__GLIBC__` as alternative to `__linux__`.

Updates commit 7d82553a00e74af77e69cc74645e0a3ec6bb3aa1 by bringing `__GLIBC__` back in use.

Fixes commit 2a2ff9eeeca75b053dc7256de990562ecebd109d by dropping the check for macOS (`__APPLE__`) when GNU libc is available; there is no GNU libc on macOS, so that check is always false.