### PR TITLE
Fix mask start/apply corruption by intermediate filters

### DIFF
--- a/src/modules/core/filter_mask_apply.c
+++ b/src/modules/core/filter_mask_apply.c
@@ -25,21 +25,6 @@
 
 #include <string.h>
 
-static int dummy_get_image(mlt_frame frame,
-                           uint8_t **image,
-                           mlt_image_format *format,
-                           int *width,
-                           int *height,
-                           int writable)
-{
-    mlt_properties properties = MLT_FRAME_PROPERTIES(frame);
-    *image = mlt_properties_get_data(properties, "image", NULL);
-    *format = mlt_properties_get_int(properties, "format");
-    *width = mlt_properties_get_int(properties, "width");
-    *height = mlt_properties_get_int(properties, "height");
-    return 0;
-}
-
 static int get_image(mlt_frame frame,
                      uint8_t **image,
                      mlt_image_format *format,
@@ -54,15 +39,10 @@ static int get_image(mlt_frame frame,
         mlt_properties properties = MLT_FRAME_PROPERTIES(frame);
         mlt_frame clone = mlt_properties_get_data(properties, "mask frame", NULL);
         if (clone) {
-            mlt_frame_push_get_image(frame, dummy_get_image);
             mlt_service_lock(MLT_TRANSITION_SERVICE(transition));
-            mlt_transition_process(transition, clone, frame);
+            mlt_transition_process(transition, frame, clone);
             mlt_service_unlock(MLT_TRANSITION_SERVICE(transition));
-            error = mlt_frame_get_image(clone, image, format, width, height, writable);
-            if (!error) {
-                int size = mlt_image_format_size(*format, *width, *height, NULL);
-                mlt_frame_set_image(frame, *image, size, NULL);
-            }
+            error = mlt_frame_get_image(frame, image, format, width, height, writable);
         }
     }
     return error;


### PR DESCRIPTION
When using mask_start and mask_apply, filters between them can corrupt the mask. This patch stores the mask on the clone frame so that intermediate filters can not corrupt it. The cloned frame mask is inverted and the composite is reversed to achieve the same effect.

Originally reported here:
https://forum.shotcut.org/t/beta-version-23-04-now-available-to-test/38269/125

Blur: Gaussian and Blur: Box do not work with Mask: Start and Mask: Apply because they apply the blur operation to the alpha mask that was generated by Mask: Start. Blur: Low Pass and Blur Exponential work just fine because they do not operate on the alpha mask. I did not take an inventory of what other filters are able to corrupt the alpha mask.

This patch is one idea I had to solve this problem for all filters. Maybe there are potential side effects I am not thinking of. Another idea I had is to add an option to Blur: Gaussian and Blur: Box to let the user tell the filter to not operate on the alpha channel. This option would have to be added to any filter that operates on alpha.