### PR TITLE
Fix audio index broken for audio only files

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -252,7 +252,7 @@ mlt_producer producer_avformat_init(mlt_profile profile, const char *service, ch
                 } else if (self->seekable) {
                     mlt_properties_set_int(properties,
                                            "astream",
-                                           relative_stream_index(self->video_format,
+                                           relative_stream_index(self->audio_format,
                                                                  AVMEDIA_TYPE_AUDIO,
                                                                  self->audio_index));
                     mlt_properties_set_int(properties,


### PR DESCRIPTION
The recent introduction of aStream/vStream broke playback of audio only files.
This patch seems to make it work as usual.