### PR TITLE
On Chain init, don't unnecessarily fetch source frame

### DIFF
--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -128,8 +128,10 @@ void mlt_chain_set_source(mlt_chain self, mlt_producer source)
         // Save the native source producer frame rate
         base->source_profile = mlt_profile_clone(mlt_service_profile(MLT_CHAIN_SERVICE(self)));
         mlt_frame frame = NULL;
-        mlt_service_get_frame(MLT_PRODUCER_SERVICE(source), &frame, 0);
-        mlt_frame_close(frame);
+        if (!mlt_properties_exists(source_properties, "meta.media.frame_rate_num") || !mlt_properties_exists(source_properties, "meta.media.frame_rate_den")) {
+            mlt_service_get_frame(MLT_PRODUCER_SERVICE(source), &frame, 0);
+            mlt_frame_close(frame);
+        }
         if (mlt_properties_get_int(source_properties, "meta.media.frame_rate_num") > 0
             && mlt_properties_get_int(source_properties, "meta.media.frame_rate_den") > 0) {
             base->source_profile->frame_rate_num


### PR DESCRIPTION
Currently, on Chain initialization, MLT always fetches a frame from the source producer. While this is ok when creating a new Chain, it is problematic for us on project load.

When attempting to load a project file from xml, like:
std::unique_ptr<Mlt::Producer> xmlProd(new Mlt::Producer(profile, "xml-string", playlist_string);

(where playlist_string is the .mlt project xml data)
Simply attempting to create this producer will try to fetch a frame for each avformat producer that is included in a chain, taking a long time and eating a lot of memory in the process.

My proposal would be to avoid fetching a frame when the meta properties have already been set (as is the case in Kdenlive project files). This makes projects open a lot faster.
