### PR TITLE
Fix #945 MLT::Chain leaking memory

### DIFF
--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -394,6 +394,8 @@ void mlt_chain_close(mlt_chain self)
         for (i = 0; i < base->link_count; i++)
             mlt_link_close(base->links[i]);
         free(base->links);
+        mlt_producer_close(base->source);
+        mlt_properties_close(base->source_parameters);
         mlt_profile_close(base->source_profile);
         free(base);
         self->parent.close = NULL;

--- a/src/modules/core/producer_melt.c
+++ b/src/modules/core/producer_melt.c
@@ -439,6 +439,7 @@ mlt_producer producer_melt_init(mlt_profile profile,
                 }
                 if (producer != NULL && chain != NULL) {
                     mlt_chain_set_source(chain, producer);
+                    mlt_producer_close(producer);
                     mlt_chain_attach_normalizers(chain);
                     producer = MLT_CHAIN_PRODUCER(chain);
                 } else if (producer != NULL) {

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -665,6 +665,7 @@ static void on_end_chain(deserialise_context context, const xmlChar *name)
         mlt_properties_inherit(MLT_PRODUCER_PROPERTIES(source), properties);
         // Add the source producer to the chain
         mlt_chain_set_source(chain, source);
+        mlt_producer_close(source);
         mlt_chain_attach_normalizers(chain);
 
         // See if the chain should be added to a playlist or multitrack


### PR DESCRIPTION
Ensure the source producer is closed. Memory can lean if it is never closed.