### PR TITLE
Avoid cusp and overshoot in keyframe_type_smooth

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -681,3 +681,10 @@ MLT_7.18.0 {
   global:
     mlt_audio_free_data;
 } MLT_7.16.0;
+
+MLT_7.20.0 {
+  global:
+    mlt_property_is_color;
+    mlt_property_is_numeric;
+    mlt_property_is_rect;
+} MLT_7.18.0;

--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -3,7 +3,7 @@
  * \brief Property class declaration
  * \see mlt_property_s
  *
- * Copyright (C) 2003-2021 Meltytech, LLC
+ * Copyright (C) 2003-2023 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -126,5 +126,8 @@ extern mlt_rect mlt_property_anim_get_rect(
 
 extern int mlt_property_set_properties(mlt_property self, mlt_properties properties);
 extern mlt_properties mlt_property_get_properties(mlt_property self);
+extern int mlt_property_is_color(mlt_property self);
+extern int mlt_property_is_numeric(mlt_property self, mlt_locale_t locale);
+extern int mlt_property_is_rect(mlt_property self);
 
 #endif

--- a/src/tests/test_animation/test_animation.cpp
+++ b/src/tests/test_animation/test_animation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Dan Dennedy <dan@dennedy.org>
+ * Copyright (C) 2015-2023 Dan Dennedy <dan@dennedy.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -461,6 +461,281 @@ private Q_SLOTS:
         ret = a.previous_key(101, key);
         QCOMPARE(ret, false);
         QCOMPARE(key, 100);
+    }
+
+    void LinearInterpolationOneKey()
+    {
+        Properties p;
+        p.set("foo", "50=10");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 10
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 10);
+        }
+    }
+
+    void SmoothInterpolationOneKey()
+    {
+        Properties p;
+        p.set("foo", "50~=10");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 10
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 10);
+        }
+    }
+
+    void LinearInterpolationTwoKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10=50; 20=100");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should step by 5
+        prev = 50 - 5;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, prev + 5);
+            prev = current;
+        }
+        // Values after 20 should all be 100
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 100);
+        }
+    }
+
+    void SmoothInterpolationTwoKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10~=50; 20~=100");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should increase but not exceed 100
+        prev = 49;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current <= 100);
+            prev = current;
+        }
+        // Values after 20 should all be 100
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 100);
+        }
+    }
+
+    void LinearInterpolationThreeKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10=50; 20=100; 30=50");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should step up by 5
+        prev = 50 - 5;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, prev + 5);
+            prev = current;
+        }
+        // Values from 20 to 30 should step down by 5
+        prev = 100 + 5;
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, prev - 5);
+            prev = current;
+        }
+        // Values after 30 should all be 50
+        for (int i = 30; i <= 40; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+    }
+
+    void SmoothInterpolationThreeKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10~=50; 20~=100; 30~=50");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should increase but not exceed 100
+        prev = 49;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current <= 100);
+            prev = current;
+        }
+        // Values from 20 to 30 should decrease but not exceed 50
+        prev = 101;
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current < prev);
+            QVERIFY(current >= 50);
+            prev = current;
+        }
+        // Values after 30 should all be 50
+        for (int i = 30; i <= 40; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+    }
+
+    void LinearDoesNotReverse()
+    {
+        Properties p;
+        double prev;
+        // This sequence of keyframes has abrupt changes. For some interpolation algorithms, this
+        // can result in values changing direction along the interpolation path (cusp or
+        // overshoot).
+        // The purpose of this test is to ensure that values do not reverse direction (exept as
+        // expected at keyframes if the user specified a direction change).
+        p.set("foo",
+              "50=0; 60=100; 100=110; 150=200; 200=110; 240=100; 260=50; 300=200; 301=10; 350=11");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 50 should all be 0
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 0);
+        }
+        // Values from 50 to 150 should only go up
+        prev = 0;
+        for (int i = 50; i <= 150; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current >= prev);
+            prev = current;
+        }
+        // Values from 150 to 260 should only go down
+        prev = 201;
+        for (int i = 150; i <= 260; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current < prev);
+            prev = current;
+        }
+        // Values from 260 to 300 should only go up
+        prev = 49;
+        for (int i = 260; i <= 300; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 200.01);
+            prev = current;
+        }
+        // Values above 301 to 350 should go up from 10 to 11
+        prev = 9.99;
+        for (int i = 301; i <= 350; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 11.01);
+            prev = current;
+        }
+        // Values above 350 should be 11
+        for (int i = 350; i <= 360; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 11);
+        }
+    }
+
+    void SmoothDoesNotReverse()
+    {
+        Properties p;
+        double prev;
+        // This sequence of keyframes has abrupt changes. For some interpolation algorithms, this
+        // can result in values changing direction along the interpolation path (cusp or
+        // overshoot).
+        // The purpose of this test is to ensure that values do not reverse direction (exept as
+        // expected at keyframes if the user specified a direction change).
+        p.set("foo",
+              "50~=0; 60~=100; 100~=110; 150~=200; 200~=110; 240~=100; 260~=50; 300~=200; 301~=10; "
+              "350~=11");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 50 should all be 0
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 0);
+        }
+        // Values from 50 to 150 should only go up
+        prev = -0.01;
+        for (int i = 50; i <= 150; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 200.01);
+            prev = current;
+        }
+        // Values from 150 to 260 should only go down
+        prev = 200.01;
+        for (int i = 150; i <= 260; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current < prev);
+            prev = current;
+        }
+        // Values from 260 to 300 should only go up
+        prev = 49.99;
+        for (int i = 260; i <= 300; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 200.01);
+            prev = current;
+        }
+        // Values above 301 to 350 should go up from 10 to 11
+        prev = 9.99;
+        for (int i = 301; i <= 350; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 11.01);
+            prev = current;
+        }
+        // Values above 350 should be 11
+        for (int i = 350; i <= 360; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 11);
+        }
     }
 };
 

--- a/src/tests/test_properties/test_properties.cpp
+++ b/src/tests/test_properties/test_properties.cpp
@@ -1153,11 +1153,11 @@ private Q_SLOTS:
         QCOMPARE(p.anim_get_rect("key", 50).w, 400.0);
         QCOMPARE(p.anim_get_rect("key", 50).h, 400.0);
         QCOMPARE(p.anim_get_rect("key", 50).o, 1.0);
-        QCOMPARE(p.anim_get_rect("key", 15).x, 25.8);
-        QCOMPARE(p.anim_get_rect("key", 15).y, 25.8);
-        QCOMPARE(p.anim_get_rect("key", 15).w, 251.6);
-        QCOMPARE(p.anim_get_rect("key", 15).h, 251.6);
-        QCOMPARE(p.anim_get_rect("key", 15).o, 0.258);
+        QCOMPARE(p.anim_get_rect("key", 15).x, 21.6);
+        QCOMPARE(p.anim_get_rect("key", 15).y, 21.6);
+        QCOMPARE(p.anim_get_rect("key", 15).w, 243.2);
+        QCOMPARE(p.anim_get_rect("key", 15).h, 243.2);
+        QCOMPARE(p.anim_get_rect("key", 15).o, 0.216);
 
         // Using percentages
         p.set("key", "0=0 0; 50=100% 200%");
@@ -1273,12 +1273,12 @@ private Q_SLOTS:
         QCOMPARE(p.anim_get_color("key", 50).g, 255);
         QCOMPARE(p.anim_get_color("key", 50).b, 171);
         QCOMPARE(p.anim_get_color("key", 50).a, 223);
-        QCOMPARE(p.anim_get_color("key", 60).a, 237);
-        QCOMPARE(p.anim_get_color("key", 70).a, 239);
+        QCOMPARE(p.anim_get_color("key", 60).a, 223);
+        QCOMPARE(p.anim_get_color("key", 70).a, 223);
         QCOMPARE(p.anim_get_color("key", 75).r, 0);
         QCOMPARE(p.anim_get_color("key", 75).g, 255);
         QCOMPARE(p.anim_get_color("key", 75).b, 171);
-        QCOMPARE(p.anim_get_color("key", 75).a, 236);
+        QCOMPARE(p.anim_get_color("key", 75).a, 223);
         QCOMPARE(p.anim_get_color("key", 100).r, 0);
         QCOMPARE(p.anim_get_color("key", 100).g, 255);
         QCOMPARE(p.anim_get_color("key", 100).b, 171);


### PR DESCRIPTION
Change the catmull-rom interpolation method to be "centripetal". The current implementatoin uses the "unity" method. The centripetal method ensures there will be no cusps in the spline. Additionally, modify the interpolation to avoid overshoot.

These changes ensure that a line will interpolate directly from one value to another without allowing the interpolated values to reverse along the way.

This implementation changes the existing keyframe_type_smooth behavior. If we prefer to make a new keyframe type, instead, then this patch can easily be adapted to add a new type. The old  behavior can be easily restored by changing alpha to 0 in the new function.

Here is a comparison of the old vs new implementation - as well as with linear. This comparison uses the keyframe sequence from the unit test that was added: "50~=0; 60~=100; 100~=110; 150~=200; 200~=110; 240~=100; 260~=50; 300~=200; 301~=10; 350~=11"
![image](https://github.com/mltframework/mlt/assets/821968/0bc8af89-8c7d-4f39-ac55-b34e89400050)
In the case of the last overshoot, I do not think that the user would have expected the value to actually go negative. In this case, the user would probably be forced to "coerce" the value by adding some linear keyframes in between. But this proposed method does not overshoot - which I think would be more in line with expectations.
