### PR TITLE
New keyframe types

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -682,7 +682,7 @@ MLT_7.18.0 {
     mlt_audio_free_data;
 } MLT_7.16.0;
 
-MLT_7.20.0 {
+MLT_7.22.0 {
   global:
     mlt_property_is_color;
     mlt_property_is_numeric;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -681,3 +681,10 @@ MLT_7.18.0 {
   global:
     mlt_audio_free_data;
 } MLT_7.16.0;
+
+MLT_7.20.0 {
+  global:
+    mlt_property_is_color;
+    mlt_property_is_numeric;
+    mlt_property_is_rect;
+} MLT_7.18.0;

--- a/src/framework/mlt_animation.c
+++ b/src/framework/mlt_animation.c
@@ -3,7 +3,7 @@
  * \brief Property Animation class definition
  * \see mlt_animation_s
  *
- * Copyright (C) 2004-2021 Meltytech, LLC
+ * Copyright (C) 2004-2023 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,6 +26,8 @@
 #include "mlt_properties.h"
 #include "mlt_tokeniser.h"
 
+#include <float.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -69,9 +71,16 @@ struct
     {mlt_keyframe_discrete, "!"},
     {mlt_keyframe_linear, ""},
     {mlt_keyframe_smooth, "~"},
+    {mlt_keyframe_smooth_loose, "~"},
+    {mlt_keyframe_smooth_natural, "$"},
+    {mlt_keyframe_smooth_tight, "-"},
 };
 
 static void mlt_animation_clear_string(mlt_animation self);
+static int interpolate_item(mlt_animation_item item,
+                            mlt_animation_item p[],
+                            double fps,
+                            mlt_locale_t locale);
 
 static const char *keyframe_type_to_str(mlt_keyframe_type t)
 {
@@ -122,8 +131,7 @@ void mlt_animation_interpolate(mlt_animation self)
         animation_node current = self->nodes;
         while (current) {
             if (!current->item.is_key) {
-                double progress;
-                mlt_property points[4];
+                mlt_animation_item points[4];
                 animation_node prev = current->prev;
                 animation_node next = current->next;
 
@@ -139,18 +147,11 @@ void mlt_animation_interpolate(mlt_animation self)
                 if (!next) {
                     next = current;
                 }
-                points[0] = prev->prev ? prev->prev->item.property : prev->item.property;
-                points[1] = prev->item.property;
-                points[2] = next->item.property;
-                points[3] = next->next ? next->next->item.property : next->item.property;
-                progress = current->item.frame - prev->item.frame;
-                progress /= next->item.frame - prev->item.frame;
-                mlt_property_interpolate(current->item.property,
-                                         points,
-                                         progress,
-                                         self->fps,
-                                         self->locale,
-                                         current->item.keyframe_type);
+                points[0] = prev->prev ? &prev->prev->item : &prev->item;
+                points[1] = &prev->item;
+                points[2] = &next->item;
+                points[3] = next->next ? &next->next->item : &next->item;
+                interpolate_item(&current->item, points, self->fps, self->locale);
             }
 
             // Move to the next item
@@ -456,21 +457,13 @@ int mlt_animation_get_item(mlt_animation self, mlt_animation_item item, int posi
         // Interpolation needed.
         else {
             if (item->property) {
-                double progress;
-                mlt_property points[4];
-                points[0] = node->prev ? node->prev->item.property : node->item.property;
-                points[1] = node->item.property;
-                points[2] = node->next->item.property;
-                points[3] = node->next->next ? node->next->next->item.property
-                                             : node->next->item.property;
-                progress = position - node->item.frame;
-                progress /= node->next->item.frame - node->item.frame;
-                mlt_property_interpolate(item->property,
-                                         points,
-                                         progress,
-                                         self->fps,
-                                         self->locale,
-                                         item->keyframe_type);
+                mlt_animation_item points[4];
+                points[0] = node->prev ? &node->prev->item : &node->item;
+                points[1] = &node->item;
+                points[2] = &node->next->item;
+                points[3] = node->next->next ? &node->next->next->item : &node->next->item;
+                item->frame = position;
+                interpolate_item(item, points, self->fps, self->locale);
             }
             item->is_key = 0;
         }
@@ -997,4 +990,294 @@ void mlt_animation_clear_string(mlt_animation self)
         return;
     free(self->data);
     self->data = NULL;
+}
+
+/** A linear interpolation function.
+ *
+ * \private \memberof mlt_animation_s
+ */
+
+static inline double linear_interpolate(double y1, double y2, double t)
+{
+    return y1 + (y2 - y1) * t;
+}
+
+/** Calculate the distance between two points.
+ *
+ * \private \memberof mlt_animation_s
+ */
+
+static inline double distance(double x0, double y0, double x1, double y1)
+{
+    return sqrt(pow(x1 - x0, 2) + pow(y1 - y0, 2));
+}
+
+/** A Catmull–Rom interpolation function.
+ *
+ * As described here:
+ *   https://en.wikipedia.org/wiki/Centripetal_Catmull%E2%80%93Rom_spline
+ * And further reduced here with tension added:
+ *   https://qroph.github.io/2018/07/30/smooth-paths-using-catmull-rom-splines.html
+ *
+ * This imlementation supports the alpha value which can be set to 0.5 to result in
+ * centripetal Catmull–Rom splines. Centripital Catmull–Rom splines are guaranteed
+ * to not have any cusps or loops. These are not desirable because they result in the
+ * value reversing direction when interpolation from one point to the next.
+ *
+ * To use this function for animation item interpolation, provide 4 points: two points preceeding t
+ * and two points following t. Use the item frame number as the x and the item value as y for each
+ * point. t should represent the fractional progress between point 1 and point 2.
+ *
+ * If fewer than 2 points are available, then duplicate the first and/or last points as necessary to
+ * meet the requirement for 4 points.
+ 
+ * \private \memberof mlt_animation_s
+ * \param alpha
+ *      0.0 for the uniform spline
+ *      0.5 for the centripetal spline (no cusps)
+ *      1.0 for the chordal spline.
+ * \param tension
+ *      1.0 results in the most natural slope at x1,y1 and x2,y2
+ *      0.0 results in a horizontal tangent at x1,y1 and x2,y2 (slope of 0).
+ *      -1.0 results in the most natural slope at x1,y1 and x2,y2 unless x1 or x2 represents a peak.
+ *      In the case of peaks, a horizontal tangent will be used to avoid overshoot.
+
+ */
+
+static inline double catmull_rom_interpolate(double x0,
+                                             double y0,
+                                             double x1,
+                                             double y1,
+                                             double x2,
+                                             double y2,
+                                             double x3,
+                                             double y3,
+                                             double t,
+                                             double alpha,
+                                             double tension)
+{
+    double m1 = 0;
+    double m2 = 0;
+    double t12 = pow(distance(x1, y1, x2, y2), alpha);
+    if (tension > 0.0 || (y1 < y0 && y1 > y2) || (y1 > y0 && y1 < y2)) {
+        double t01 = pow(distance(x0, y0, x1, y1), alpha);
+        m1 = abs(tension) * (y2 - y1 + t12 * ((y1 - y0) / t01 - (y2 - y0) / (t01 + t12)));
+    }
+    if (tension > 0.0 || (y2 < y1 && y2 > y3) || (y2 > y1 && y2 < y3)) {
+        double t23 = pow(distance(x2, y2, x3, y3), alpha);
+        m2 = abs(tension) * (y2 - y1 + t12 * ((y3 - y2) / t23 - (y3 - y1) / (t12 + t23)));
+    }
+    double a = 2.0 * (y1 - y2) + m1 + m2;
+    double b = -3.0 * (y1 - y2) - m1 - m1 - m2;
+    double c = m1;
+    double d = y1;
+    return a * t * t * t + b * t * t + c * t + d;
+}
+
+static inline double interpolate_value(double x0,
+                                       double y0,
+                                       double x1,
+                                       double y1,
+                                       double x2,
+                                       double y2,
+                                       double x3,
+                                       double y3,
+                                       double t,
+                                       mlt_keyframe_type type)
+{
+    // Correct first and last values.
+    // If points are duplicated (e.g. for the first and last segments) assume the duplicated point
+    // is far away to create a horizontal segment.
+    if (x0 == x1) {
+        x0 -= 10000;
+    }
+    if (x3 == x2) {
+        x3 += 10000;
+    }
+    switch (type) {
+    case mlt_keyframe_discrete:
+        return y1;
+    case mlt_keyframe_linear:
+        return linear_interpolate(y1, y2, t);
+    case mlt_keyframe_smooth_loose:
+        return catmull_rom_interpolate(x0, y0, x1, y1, x2, y2, x3, y3, t, 0.0, 1.0);
+    case mlt_keyframe_smooth_natural:
+        return catmull_rom_interpolate(x0, y0, x1, y1, x2, y2, x3, y3, t, 0.5, -1.0);
+    case mlt_keyframe_smooth_tight:
+        return catmull_rom_interpolate(x0, y0, x1, y1, x2, y2, x3, y3, t, 0.5, 0.0);
+    }
+    return y1;
+}
+
+/** Interpolate a new animation item given a set of other items.
+ *
+ * \private \memberof mlt_animation_s
+ *
+ * \param item an unpopulated animation item to be interpolated.
+ *  The frame and keyframe_type fields must already be set. The value for "frame" is the postion
+ *  at which the value will be interpolated. The value for "keyframe_type" determines which
+ *  interpolation will be used.
+ * \param p a sequential array of 4 animation items. The frame value for item must lie between the
+    frame values for p[1] and p[2].
+ * \param fps the frame rate, which may be needed for converting a time string to frame units
+ * \param locale the locale, which may be needed for converting a string to a real number
+  * \return true if there was an error
+ */
+
+static int interpolate_item(mlt_animation_item item,
+                            mlt_animation_item p[],
+                            double fps,
+                            mlt_locale_t locale)
+{
+    int error = 0;
+    double progress = (double) (item->frame - p[1]->frame) / (double) (p[2]->frame - p[1]->frame);
+    if (item->keyframe_type == mlt_keyframe_discrete) {
+        mlt_property_pass(item->property, p[1]->property);
+    } else if (mlt_property_is_color(p[1]->property)) {
+        mlt_color value = {0xff, 0xff, 0xff, 0xff};
+        mlt_color colors[4];
+        mlt_color zero = {0xff, 0xff, 0xff, 0xff};
+        colors[1] = p[1] ? mlt_property_get_color(p[1]->property, fps, locale) : zero;
+        if (p[2]) {
+            colors[0] = p[0] ? mlt_property_get_color(p[0]->property, fps, locale) : zero;
+            colors[2] = p[2] ? mlt_property_get_color(p[2]->property, fps, locale) : zero;
+            colors[3] = p[3] ? mlt_property_get_color(p[3]->property, fps, locale) : zero;
+            value.r = CLAMP(interpolate_value(p[0]->frame,
+                                              colors[0].r,
+                                              p[1]->frame,
+                                              colors[1].r,
+                                              p[2]->frame,
+                                              colors[2].r,
+                                              p[3]->frame,
+                                              colors[3].r,
+                                              progress,
+                                              item->keyframe_type),
+                            0,
+                            255);
+            value.g = CLAMP(interpolate_value(p[0]->frame,
+                                              colors[0].g,
+                                              p[1]->frame,
+                                              colors[1].g,
+                                              p[2]->frame,
+                                              colors[2].g,
+                                              p[3]->frame,
+                                              colors[3].g,
+                                              progress,
+                                              item->keyframe_type),
+                            0,
+                            255);
+            value.b = CLAMP(interpolate_value(p[0]->frame,
+                                              colors[0].b,
+                                              p[1]->frame,
+                                              colors[1].b,
+                                              p[2]->frame,
+                                              colors[2].b,
+                                              p[3]->frame,
+                                              colors[3].b,
+                                              progress,
+                                              item->keyframe_type),
+                            0,
+                            255);
+            value.a = CLAMP(interpolate_value(p[0]->frame,
+                                              colors[0].a,
+                                              p[1]->frame,
+                                              colors[1].a,
+                                              p[2]->frame,
+                                              colors[2].a,
+                                              p[3]->frame,
+                                              colors[3].a,
+                                              progress,
+                                              item->keyframe_type),
+                            0,
+                            255);
+        } else {
+            value = colors[1];
+        }
+        error = mlt_property_set_color(item->property, value);
+    } else if (mlt_property_is_rect(item->property)) {
+        mlt_rect value = {DBL_MIN, DBL_MIN, DBL_MIN, DBL_MIN, DBL_MIN};
+        mlt_rect points[4];
+        mlt_rect zero = {0, 0, 0, 0, 0};
+        points[1] = p[1] ? mlt_property_get_rect(p[1]->property, locale) : zero;
+        if (p[2]) {
+            points[0] = p[0] ? mlt_property_get_rect(p[0]->property, locale) : zero;
+            points[2] = p[2] ? mlt_property_get_rect(p[2]->property, locale) : zero;
+            points[3] = p[3] ? mlt_property_get_rect(p[3]->property, locale) : zero;
+            value.x = interpolate_value(p[0]->frame,
+                                        points[0].x,
+                                        p[1]->frame,
+                                        points[1].x,
+                                        p[2]->frame,
+                                        points[2].x,
+                                        p[3]->frame,
+                                        points[3].x,
+                                        progress,
+                                        item->keyframe_type);
+            value.y = interpolate_value(p[0]->frame,
+                                        points[0].y,
+                                        p[1]->frame,
+                                        points[1].y,
+                                        p[2]->frame,
+                                        points[2].y,
+                                        p[3]->frame,
+                                        points[3].y,
+                                        progress,
+                                        item->keyframe_type);
+            value.w = interpolate_value(p[0]->frame,
+                                        points[0].w,
+                                        p[1]->frame,
+                                        points[1].w,
+                                        p[2]->frame,
+                                        points[2].w,
+                                        p[3]->frame,
+                                        points[3].w,
+                                        progress,
+                                        item->keyframe_type);
+            value.h = interpolate_value(p[0]->frame,
+                                        points[0].h,
+                                        p[1]->frame,
+                                        points[1].h,
+                                        p[2]->frame,
+                                        points[2].h,
+                                        p[3]->frame,
+                                        points[3].h,
+                                        progress,
+                                        item->keyframe_type);
+            value.o = interpolate_value(p[0]->frame,
+                                        points[0].o,
+                                        p[1]->frame,
+                                        points[1].o,
+                                        p[2]->frame,
+                                        points[2].o,
+                                        p[3]->frame,
+                                        points[3].o,
+                                        progress,
+                                        item->keyframe_type);
+        } else {
+            value = points[1];
+        }
+        error = mlt_property_set_rect(item->property, value);
+    } else if (mlt_property_is_numeric(p[1]->property, locale)) {
+        double value = 0.0;
+        double points[4];
+        points[0] = p[0] ? mlt_property_get_double(p[0]->property, fps, locale) : 0;
+        points[1] = p[1] ? mlt_property_get_double(p[1]->property, fps, locale) : 0;
+        points[2] = p[2] ? mlt_property_get_double(p[2]->property, fps, locale) : 0;
+        points[3] = p[3] ? mlt_property_get_double(p[3]->property, fps, locale) : 0;
+        value = p[2] ? interpolate_value(p[0]->frame,
+                                         points[0],
+                                         p[1]->frame,
+                                         points[1],
+                                         p[2]->frame,
+                                         points[2],
+                                         p[3]->frame,
+                                         points[3],
+                                         progress,
+                                         item->keyframe_type)
+                     : points[1];
+        error = mlt_property_set_double(item->property, value);
+    } else {
+        mlt_property_pass(item->property, p[1]->property);
+    }
+    return error;
 }

--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -3,7 +3,7 @@
  * \brief Property class declaration
  * \see mlt_property_s
  *
- * Copyright (C) 2003-2021 Meltytech, LLC
+ * Copyright (C) 2003-2023 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -126,5 +126,8 @@ extern mlt_rect mlt_property_anim_get_rect(
 
 extern int mlt_property_set_properties(mlt_property self, mlt_properties properties);
 extern mlt_properties mlt_property_get_properties(mlt_property self);
+extern int mlt_property_is_color(mlt_property self);
+extern int mlt_property_is_numeric(mlt_property self, mlt_locale_t locale);
+extern int mlt_property_is_rect(mlt_property self);
 
 #endif

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -144,7 +144,11 @@ typedef enum {
     mlt_keyframe_discrete
     = 0,                 /**< non-interpolated; value changes instantaneously at the key frame */
     mlt_keyframe_linear, /**< simple, constant pace from this key frame to the next */
-    mlt_keyframe_smooth /**< eased pacing from this keyframe to the next using a Catmull-Rom spline */
+    mlt_keyframe_smooth, /**< deprecated use mlt_keyframe_smooth_loose */
+    mlt_keyframe_smooth_loose
+    = mlt_keyframe_smooth, /**< Unity Catmull-Rom spline interpolation. May have cusps or overshoots*/
+    mlt_keyframe_smooth_natural, /**< Centripetal Catmull-Rom spline interpolation with natural slope at each keyframe. Will not have cusps or overshoots*/
+    mlt_keyframe_smooth_tight, /**< Centripetal Catmull-Rom spline interpolation with 0 slope at each keyframe. Will not have cusps or overshoots*/
 } mlt_keyframe_type;
 
 /** The relative time qualifiers */

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -149,6 +149,36 @@ typedef enum {
     = mlt_keyframe_smooth, /**< Unity Catmull-Rom spline interpolation. May have cusps or overshoots*/
     mlt_keyframe_smooth_natural, /**< Centripetal Catmull-Rom spline interpolation with natural slope at each keyframe. Will not have cusps or overshoots*/
     mlt_keyframe_smooth_tight, /**< Centripetal Catmull-Rom spline interpolation with 0 slope at each keyframe. Will not have cusps or overshoots*/
+    mlt_keyframe_sinusoidal_in,
+    mlt_keyframe_sinusoidal_out,
+    mlt_keyframe_sinusoidal_in_out,
+    mlt_keyframe_quadratic_in,
+    mlt_keyframe_quadratic_out,
+    mlt_keyframe_quadratic_in_out,
+    mlt_keyframe_cubic_in,
+    mlt_keyframe_cubic_out,
+    mlt_keyframe_cubic_in_out,
+    mlt_keyframe_quartic_in,
+    mlt_keyframe_quartic_out,
+    mlt_keyframe_quartic_in_out,
+    mlt_keyframe_quintic_in,
+    mlt_keyframe_quintic_out,
+    mlt_keyframe_quintic_in_out,
+    mlt_keyframe_exponential_in,
+    mlt_keyframe_exponential_out,
+    mlt_keyframe_exponential_in_out,
+    mlt_keyframe_circular_in,
+    mlt_keyframe_circular_out,
+    mlt_keyframe_circular_in_out,
+    mlt_keyframe_back_in,
+    mlt_keyframe_back_out,
+    mlt_keyframe_back_in_out,
+    mlt_keyframe_elastic_in,
+    mlt_keyframe_elastic_out,
+    mlt_keyframe_elastic_in_out,
+    mlt_keyframe_bounce_in,
+    mlt_keyframe_bounce_out,
+    mlt_keyframe_bounce_in_out,
 } mlt_keyframe_type;
 
 /** The relative time qualifiers */

--- a/src/tests/test_animation/test_animation.cpp
+++ b/src/tests/test_animation/test_animation.cpp
@@ -462,6 +462,228 @@ private Q_SLOTS:
         QCOMPARE(ret, false);
         QCOMPARE(key, 100);
     }
+
+    void LinearInterpolationOneKey()
+    {
+        Properties p;
+        p.set("foo", "50=10");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 10
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 10);
+        }
+    }
+
+    void SmoothInterpolationOneKey()
+    {
+        Properties p;
+        p.set("foo", "50~=10");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 10
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 10);
+        }
+    }
+
+    void LinearInterpolationTwoKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10=50; 20=100");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should step by 5
+        prev = 50 - 5;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, prev + 5);
+            prev = current;
+        }
+        // Values after 20 should all be 100
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 100);
+        }
+    }
+
+    void SmoothInterpolationTwoKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10~=50; 20~=100");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should increase but not exceed 100
+        prev = 49;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current <= 100);
+            prev = current;
+        }
+        // Values after 20 should all be 100
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 100);
+        }
+    }
+
+    void LinearInterpolationThreeKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10=50; 20=100; 30=50");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should step up by 5
+        prev = 50 - 5;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, prev + 5);
+            prev = current;
+        }
+        // Values from 20 to 30 should step down by 5
+        prev = 100 + 5;
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, prev - 5);
+            prev = current;
+        }
+        // Values after 30 should all be 50
+        for (int i = 30; i <= 40; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+    }
+
+    void SmoothInterpolationThreeKey()
+    {
+        Properties p;
+        double prev;
+        p.set("foo", "10~=50; 20~=100; 30~=50");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 10 should all be 50
+        for (int i = 0; i <= 10; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+        // Values from 10 to 20 should increase but not exceed 100
+        prev = 49;
+        for (int i = 10; i <= 20; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current <= 100);
+            prev = current;
+        }
+        // Test two arbitrary intermediate points
+        QCOMPARE(p.anim_get_double("foo", 13), 64.475);
+        QCOMPARE(p.anim_get_double("foo", 18), 95.6);
+        // Values from 20 to 30 should decrease but not exceed 50
+        prev = 101;
+        for (int i = 20; i <= 30; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current < prev);
+            QVERIFY(current >= 50);
+            prev = current;
+        }
+        // Test two arbitrary intermediate points
+        QCOMPARE(p.anim_get_double("foo", 23), 90.775);
+        QCOMPARE(p.anim_get_double("foo", 28), 58.4);
+        // Values after 30 should all be 50
+        for (int i = 30; i <= 40; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 50);
+        }
+    }
+
+    void LinearDoesNotReverse()
+    {
+        Properties p;
+        double prev;
+        // This sequence of keyframes has abrupt changes. For some interpolation algorithms, this
+        // can result in values changing direction along the interpolation path (cusp or
+        // overshoot).
+        // The purpose of this test is to ensure that values do not reverse direction (exept as
+        // expected at keyframes if the user specified a direction change).
+        p.set("foo",
+              "50=0; 60=100; 100=110; 150=200; 200=110; 240=100; 260=50; 300=200; 301=10; 350=11");
+        // Cause the string to be interpreted as animated value.
+        p.anim_get_int("foo", 0);
+        Animation a = p.get_animation("foo");
+        QVERIFY(a.is_valid());
+        // Values from 0 to 50 should all be 0
+        for (int i = 0; i <= 50; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 0);
+        }
+        // Values from 50 to 150 should only go up
+        prev = 0;
+        for (int i = 50; i <= 150; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current >= prev);
+            prev = current;
+        }
+        // Values from 150 to 260 should only go down
+        prev = 201;
+        for (int i = 150; i <= 260; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current < prev);
+            prev = current;
+        }
+        // Values from 260 to 300 should only go up
+        prev = 49;
+        for (int i = 260; i <= 300; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 200.01);
+            prev = current;
+        }
+        // Values above 301 to 350 should go up from 10 to 11
+        prev = 9.99;
+        for (int i = 301; i <= 350; i++) {
+            double current = p.anim_get_double("foo", i);
+            QVERIFY(current > prev);
+            QVERIFY(current < 11.01);
+            prev = current;
+        }
+        // Values above 350 should be 11
+        for (int i = 350; i <= 360; i++) {
+            double current = p.anim_get_double("foo", i);
+            QCOMPARE(current, 11);
+        }
+    }
 };
 
 QTEST_APPLESS_MAIN(TestAnimation)

--- a/src/tests/test_animation/test_animation.cpp
+++ b/src/tests/test_animation/test_animation.cpp
@@ -848,6 +848,214 @@ private Q_SLOTS:
             QCOMPARE(current, 11);
         }
     }
+
+    void EaseIn()
+    {
+        Properties p;
+        p.set("sinu", "0a=0; 100a=100;");
+        p.set("quad", "0d=0; 100d=100;");
+        p.set("cube", "0g=0; 100g=100;");
+        p.set("quar", "0j=0; 100j=100;");
+        p.set("quin", "0m=0; 100m=100;");
+        p.set("expo", "0p=0; 100p=100;");
+        p.set("circ", "0s=0; 100s=100;");
+        p.set("back", "0v=0; 100v=100;");
+        p.set("elas", "0y=0; 100y=100;");
+        p.set("boun", "0B=0; 100B=100;");
+        p.anim_get_int("sinu", 0);
+        p.anim_get_int("quad", 0);
+        p.anim_get_int("cube", 0);
+        p.anim_get_int("quar", 0);
+        p.anim_get_int("quin", 0);
+        p.anim_get_int("expo", 0);
+        p.anim_get_int("circ", 0);
+        p.anim_get_int("back", 0);
+        p.anim_get_int("elas", 0);
+        p.anim_get_int("boun", 0);
+
+        // fprintf(stderr, "sinu\tquad\tcube\tquar\tquin\texpo\tcirc\tback\telas\tboun\n");
+
+        for (int i = 0; i <= 100; i++) {
+            double sinu = p.anim_get_double("sinu", i);
+            double quad = p.anim_get_double("quad", i);
+            double cube = p.anim_get_double("cube", i);
+            double quar = p.anim_get_double("quar", i);
+            double quin = p.anim_get_double("quin", i);
+            double expo = p.anim_get_double("expo", i);
+            double circ = p.anim_get_double("circ", i);
+            double back = p.anim_get_double("back", i);
+            double elas = p.anim_get_double("elas", i);
+            double boun = p.anim_get_double("boun", i);
+
+            // fprintf(stderr,"%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\n", sinu, quad, cube, quar, quin, expo, circ, back, elas, boun);
+
+            QVERIFY(sinu >= 0.0);
+            QVERIFY(sinu <= 100.0);
+            QVERIFY(quad >= 0.0);
+            QVERIFY(quad <= 100.0);
+            QVERIFY(quad <= sinu);
+            QVERIFY(cube >= 0.0);
+            QVERIFY(cube <= 100.0);
+            QVERIFY(cube <= quad);
+            QVERIFY(quar >= 0.0);
+            QVERIFY(quar <= 100.0);
+            QVERIFY(quar <= cube);
+            QVERIFY(quin >= 0.0);
+            QVERIFY(quin <= 100.0);
+            QVERIFY(quin <= quar);
+            QVERIFY(expo >= 0.0);
+            QVERIFY(expo <= 100.0);
+            QVERIFY(circ >= 0.0);
+            QVERIFY(circ <= 100.0);
+            QVERIFY(back >= -37.88);
+            QVERIFY(back <= 100.0);
+            QVERIFY(elas >= -36.39);
+            QVERIFY(elas <= 100.0);
+            QVERIFY(boun >= -0.00000001);
+            QVERIFY(boun <= 100.0);
+        }
+    }
+
+    void EaseOut()
+    {
+        Properties p;
+        p.set("sinu", "0b=0; 100b=100;");
+        p.set("quad", "0e=0; 100e=100;");
+        p.set("cube", "0h=0; 100h=100;");
+        p.set("quar", "0k=0; 100k=100;");
+        p.set("quin", "0n=0; 100n=100;");
+        p.set("expo", "0q=0; 100q=100;");
+        p.set("circ", "0t=0; 100t=100;");
+        p.set("back", "0w=0; 100w=100;");
+        p.set("elas", "0z=0; 100z=100;");
+        p.set("boun", "0C=0; 100C=100;");
+        p.anim_get_int("sinu", 0);
+        p.anim_get_int("quad", 0);
+        p.anim_get_int("cube", 0);
+        p.anim_get_int("quar", 0);
+        p.anim_get_int("quin", 0);
+        p.anim_get_int("expo", 0);
+        p.anim_get_int("circ", 0);
+        p.anim_get_int("back", 0);
+        p.anim_get_int("elas", 0);
+        p.anim_get_int("boun", 0);
+
+        // fprintf(stderr, "sinu\tquad\tcube\tquar\tquin\texpo\tcirc\tback\telas\tboun\n");
+
+        for (int i = 0; i <= 100; i++) {
+            double sinu = p.anim_get_double("sinu", i);
+            double quad = p.anim_get_double("quad", i);
+            double cube = p.anim_get_double("cube", i);
+            double quar = p.anim_get_double("quar", i);
+            double quin = p.anim_get_double("quin", i);
+            double expo = p.anim_get_double("expo", i);
+            double circ = p.anim_get_double("circ", i);
+            double back = p.anim_get_double("back", i);
+            double elas = p.anim_get_double("elas", i);
+            double boun = p.anim_get_double("boun", i);
+
+            // fprintf(stderr,"%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\n", sinu, quad, cube, quar, quin, expo, circ, back, elas, boun);
+
+            QVERIFY(sinu >= 0.0);
+            QVERIFY(sinu <= 100.0);
+            QVERIFY(quad >= 0.0);
+            QVERIFY(quad <= 100.0);
+            QVERIFY(quad >= sinu);
+            QVERIFY(cube >= 0.0);
+            QVERIFY(cube <= 100.0);
+            QVERIFY(cube >= quad);
+            QVERIFY(quar >= 0.0);
+            QVERIFY(quar <= 100.0);
+            QVERIFY(quar >= cube);
+            QVERIFY(quin >= 0.0);
+            QVERIFY(quin <= 100.0);
+            QVERIFY(quin >= quar);
+            QVERIFY(expo >= 0.0);
+            QVERIFY(expo <= 100.0);
+            QVERIFY(circ >= 0.0);
+            QVERIFY(circ <= 100.0);
+            QVERIFY(back >= 0.0);
+            QVERIFY(back <= 137.9);
+            QVERIFY(elas >= 0.0);
+            QVERIFY(elas <= 136.4);
+            QVERIFY(boun >= 0.0);
+            QVERIFY(boun <= 100.1);
+        }
+    }
+
+    void EaseInOut()
+    {
+        Properties p;
+        p.set("sinu", "0c=0; 100c=100;");
+        p.set("quad", "0f=0; 100f=100;");
+        p.set("cube", "0i=0; 100i=100;");
+        p.set("quar", "0l=0; 100l=100;");
+        p.set("quin", "0o=0; 100o=100;");
+        p.set("expo", "0r=0; 100r=100;");
+        p.set("circ", "0u=0; 100u=100;");
+        p.set("back", "0x=0; 100x=100;");
+        p.set("elas", "0A=0; 100A=100;");
+        p.set("boun", "0D=0; 100D=100;");
+        p.anim_get_int("sinu", 0);
+        p.anim_get_int("quad", 0);
+        p.anim_get_int("cube", 0);
+        p.anim_get_int("quar", 0);
+        p.anim_get_int("quin", 0);
+        p.anim_get_int("expo", 0);
+        p.anim_get_int("circ", 0);
+        p.anim_get_int("back", 0);
+        p.anim_get_int("elas", 0);
+        p.anim_get_int("boun", 0);
+
+        // fprintf(stderr, "sinu\tquad\tcube\tquar\tquin\texpo\tcirc\tback\telas\tboun\n");
+
+        for (int i = 0; i <= 100; i++) {
+            double sinu = p.anim_get_double("sinu", i);
+            double quad = p.anim_get_double("quad", i);
+            double cube = p.anim_get_double("cube", i);
+            double quar = p.anim_get_double("quar", i);
+            double quin = p.anim_get_double("quin", i);
+            double expo = p.anim_get_double("expo", i);
+            double circ = p.anim_get_double("circ", i);
+            double back = p.anim_get_double("back", i);
+            double elas = p.anim_get_double("elas", i);
+            double boun = p.anim_get_double("boun", i);
+
+            // fprintf(stderr,"%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\n", sinu, quad, cube, quar, quin, expo, circ, back, elas, boun);
+
+            if (i < 50) {
+                QVERIFY(quad <= sinu);
+                QVERIFY(cube <= quad);
+                QVERIFY(quar <= cube);
+                QVERIFY(quin <= quar);
+            } else {
+                QVERIFY(quad >= sinu);
+                QVERIFY(cube >= quad);
+                QVERIFY(quar >= cube);
+                QVERIFY(quin >= quar);
+            }
+            QVERIFY(sinu >= 0.0);
+            QVERIFY(sinu <= 100.0);
+            QVERIFY(quad >= 0.0);
+            QVERIFY(quad <= 100.0);
+            QVERIFY(cube >= 0.0);
+            QVERIFY(cube <= 100.0);
+            QVERIFY(quar >= 0.0);
+            QVERIFY(quar <= 100.0);
+            QVERIFY(quin >= 0.0);
+            QVERIFY(quin <= 100.0);
+            QVERIFY(expo >= 0.0);
+            QVERIFY(expo <= 100.0);
+            QVERIFY(circ >= 0.0);
+            QVERIFY(circ <= 100.0);
+            QVERIFY(back >= -19.0);
+            QVERIFY(back <= 119.0);
+            QVERIFY(elas >= -18.2);
+            QVERIFY(elas <= 118.2);
+            QVERIFY(boun >= -0.01);
+            QVERIFY(boun <= 100.1);
+        }
+    }
 };
 
 QTEST_APPLESS_MAIN(TestAnimation)


### PR DESCRIPTION
Add new keyframe types: smooth_natural and smooth_tight . Both new types use centripetal catmull-rom interpolation.
The centripetal method ensures there will be no cusps in the spline. Additionally, modify the interpolation to avoid overshoot. These changes ensure that a line will interpolate directly from one value to another without allowing the interpolated values to reverse along the way.

The previous "smooth" type is aliased to "smooth_loose" and maintained for backwards compatibility.

This chart shows the difference in the curves:
![image](https://github.com/mltframework/mlt/assets/821968/eaee095e-8a46-4435-9be6-4a1e1f11662b)
