### PR TITLE
FIX: support compilation with libxml2 2.12.0

### DIFF
--- a/src/modules/jackrack/jack_rack.c
+++ b/src/modules/jackrack/jack_rack.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 
 #include <ladspa.h>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
 
 #include "jack_rack.h"


### PR DESCRIPTION
libxml2 2.12.0 does some refactoring about functions prototypes places. `xmlParseFile` definition is in `libxml/parser.h` anyway so include this header file.

Closes #962 .