### PR TITLE
Add a loop range feature to MLT Producer

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -688,3 +688,8 @@ MLT_7.22.0 {
     mlt_property_is_numeric;
     mlt_property_is_rect;
 } MLT_7.18.0;
+
+MLT_7.24.0 {
+  global:
+    mlt_producer_set_loop_range;
+} MLT_7.22.0;

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -145,5 +145,6 @@ extern void mlt_producer_close(mlt_producer self);
 int64_t mlt_producer_get_creation_time(mlt_producer self);
 void mlt_producer_set_creation_time(mlt_producer self, int64_t creation_time);
 extern int mlt_producer_probe(mlt_producer self);
+extern void mlt_producer_set_loop_range(mlt_producer self, int start, int end);
 
 #endif

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -266,3 +266,8 @@ bool Producer::probe()
 {
     return mlt_producer_probe(get_producer());
 }
+
+void Producer::set_loop_range(int start, int end)
+{
+    return mlt_producer_set_loop_range(get_producer(), start, end);
+}

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -78,6 +78,7 @@ public:
     int64_t get_creation_time();
     void set_creation_time(int64_t creation_time);
     bool probe();
+    void set_loop_range(int start, int end);
 };
 } // namespace Mlt
 

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -733,3 +733,10 @@ MLT_7.14.0 {
       "Mlt::Chain::attach_normalizers()";
     };
 } MLT_7.12.0;
+
+MLT_7.24.0 {
+  global:
+    extern "C++" {
+      "Mlt::Producer::set_loop_range(int, int)";
+    };
+} MLT_7.14.0;


### PR DESCRIPTION
This allows an application to request a producer loop between a start and end frame.