### PR TITLE
Also check for Wayland's WAYLAND_DISPLAY to detect a graphical session

### DIFF
--- a/src/modules/glaxnimate/producer_glaxnimate.cpp
+++ b/src/modules/glaxnimate/producer_glaxnimate.cpp
@@ -140,7 +140,7 @@ static bool createQApplicationIfNeeded(mlt_service service)
                                          + QStringLiteral("/plugins"));
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-        if (getenv("DISPLAY") == 0) {
+        if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
             mlt_log_error(
                 service,
                 "The MLT Qt module requires a X11 environment.\n"

--- a/src/modules/glaxnimate/producer_glaxnimate.cpp
+++ b/src/modules/glaxnimate/producer_glaxnimate.cpp
@@ -143,8 +143,8 @@ static bool createQApplicationIfNeeded(mlt_service service)
         if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
             mlt_log_error(
                 service,
-                "The MLT Qt module requires a X11 environment.\n"
-                "Please either run melt from an X session or use a fake X server like xvfb:\n"
+                "The MLT Glaxnimate module requires a X11 or Wayland environment.\n"
+                "Please either run melt from a session with a display server or use a fake X server like xvfb:\n"
                 "xvfb-run -a melt (...)\n");
             return false;
         }

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -36,7 +36,7 @@ bool createQApplicationIfNeeded(mlt_service service)
                                          + QStringLiteral("/plugins"));
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(Q_OS_ANDROID)
-        if (getenv("DISPLAY") == 0) {
+        if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
             mlt_log_error(
                 service,
                 "The MLT Qt module requires a X11 environment.\n"

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -39,8 +39,8 @@ bool createQApplicationIfNeeded(mlt_service service)
         if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
             mlt_log_error(
                 service,
-                "The MLT Qt module requires a X11 environment.\n"
-                "Please either run melt from an X session or use a fake X server like xvfb:\n"
+                "The MLT Qt module requires a X11 or Wayland environment.\n"
+                "Please either run melt from a session with a display server or use a fake X server like xvfb:\n"
                 "xvfb-run -a melt (...)\n");
             return false;
         }


### PR DESCRIPTION
Following a recent rendering failure in Kdenlive's Flatpak ( https://github.com/flathub/org.kde.kdenlive/issues/335 ), it seems that `DISPLAY` cannot reliably be used to detect a graphical session with wayland, which uses the `WAYLAND_DISPLAY` variable instead.

So check for both variables before aborting modules load