### PR TITLE
Fix crash connecting a NULL producer

### DIFF
--- a/src/framework/mlt_service.c
+++ b/src/framework/mlt_service.c
@@ -207,13 +207,12 @@ int mlt_service_connect_producer(mlt_service self, mlt_service producer, int ind
     }
 
     // If we have space, assign the input
-    if (base->in != NULL && index >= 0 && index < base->size) {
+    if (producer != NULL && base->in != NULL && index >= 0 && index < base->size) {
         // Get the current service
         mlt_service current = (index < base->count) ? base->in[index] : NULL;
 
         // Increment the reference count on this producer
-        if (producer != NULL)
-            mlt_properties_inc_ref(MLT_SERVICE_PROPERTIES(producer));
+        mlt_properties_inc_ref(MLT_SERVICE_PROPERTIES(producer));
 
         // Now we disconnect the producer service from its consumer
         mlt_service_disconnect(producer);


### PR DESCRIPTION
Debugging a Kdenlive crash, I came upon an MLT file that consistently crashed melt. 
The .mlt file was buggy, missing an XML playlist, still I think it's good if we can fix the crash in MLT.
My patch doesn't allow anymore to connect a null producer to the service. Let me know if you think there is a reason to allow that.

A sample of a crashing malformed .mlt file, the `playlist1` defined at the end as a track producer is never defined :
```

<?xml version="1.0"?>
<mlt LC_NUMERIC="C" version="7.23.0">
  <producer id="producer0" in="0" out="14999">
    <property name="length">15000</property>
    <property name="eof">pause</property>
    <property name="resource">red</property>
    <property name="mlt_service">color</property>
  </producer>
  <playlist id="playlist0">
    <entry producer="producer0" in="0" out="14999"/>
  </playlist>
  <tractor id="tractor0" title="color:red" in="0" out="14999">
    <track producer="playlist0"/>
    <track producer="playlist1"/>
  </tractor>
</mlt>
```