### PR TITLE
switch AV1 encode presets to SVT-AV1

### DIFF
--- a/presets/consumer/avformat/AV1
+++ b/presets/consumer/avformat/AV1
@@ -16,3 +16,4 @@ strict=experimental
 meta.preset.name=AV1 WebM
 meta.preset.extension=webm
 meta.preset.note=AV1 video with Opus audio in Matroska container: Just say no to patents
+meta.preset.hidden=1

--- a/presets/consumer/avformat/SVT-AV1
+++ b/presets/consumer/avformat/SVT-AV1
@@ -1,0 +1,16 @@
+f=webm
+
+acodec=libopus
+ar=48000
+ab=192k
+vbr=off
+
+vcodec=libsvtav1
+crf=32
+bf=1
+svtav1-params=preset=5:tile-columns=1:fast-decode=0:tune=0:film-grain=0:film-grain-denoise=0:enable-overlays=1:enable-variance-boost=1:variance-boost-strength=1:variance-octile=7:enable-qm=1:qm-min=0
+progressive=1
+
+meta.preset.name=AV1 WebM
+meta.preset.extension=webm
+meta.preset.note=AV1 video with Opus audio in WebM container: Just say no to patents

--- a/presets/consumer/avformat/ten_bit/AV1
+++ b/presets/consumer/avformat/ten_bit/AV1
@@ -17,3 +17,4 @@ pix_fmt=yuv420p10le
 meta.preset.name=ten_bit/10-bit AV1 WebM
 meta.preset.extension=webm
 meta.preset.note=10-bit AV1 video with Opus audio in Matroska container: Just say no to patents
+meta.preset.hidden=1

--- a/presets/consumer/avformat/ten_bit/SVT-AV1
+++ b/presets/consumer/avformat/ten_bit/SVT-AV1
@@ -1,0 +1,17 @@
+f=webm
+
+acodec=libopus
+ar=48000
+ab=192k
+vbr=off
+
+vcodec=libsvtav1
+crf=32
+bf=1
+svtav1-params=preset=5:tile-columns=1:fast-decode=0:tune=0:film-grain=0:film-grain-denoise=0:enable-overlays=1:enable-variance-boost=1:variance-boost-strength=1:variance-octile=7:enable-qm=1:qm-min=0
+pix_fmt=yuv420p10le
+progressive=1
+
+meta.preset.name=ten_bit/10-bit AV1 WebM
+meta.preset.extension=webm
+meta.preset.note=10-bit AV1 video with Opus audio in WebM container: Just say no to patents


### PR DESCRIPTION
After much testing, the new Variance Boost feature proved itself worthwhile. CRF 32 with Variance Boost is the same visual quality as CRF 28 without it, while retaining the smaller CRF 32 file size. Pretty amazing.

Overview of the new AV1 presets:

* They look good at both 1080p and 2160p
* File size is 20-35% smaller than Shotcut's x264 default preset
* Quality is noticeably better than Shotcut's x264 default preset
* Exported videos should gracefully survive transcoding by social media platforms
* Encoding time is 3-5x of x264's Fast preset

In particular, the new presets hold up well against these challenging subjects, much better than the x264 default:

* Grass
* Foliage
* Animal fur
* Waves on a river
* Water droplet spray
* Dark areas prone to banding

Although the 8-bit preset generally looks fine, the 10-bit preset is still preferred for exporting. The file size difference is usually negligible, but 10-bit has less risk of banding.

Advanced users can change the CRF to 48 if they want to cut the new presets' already-small file size in half with passable quality, but I wouldn't expect the resulting file to transcode well on social media.

I am certainly willing to tweak the settings if your priorities are different, such as wanting faster encode time. I figured that this combination of smaller size yet higher quality would be ideal for social media and personal/family one-click video archiving... not quite visually lossless, but still really good.