### PR TITLE
Fix double free crash

### DIFF
--- a/src/mlt++/MltService.cpp
+++ b/src/mlt++/MltService.cpp
@@ -117,7 +117,7 @@ Service *Service::consumer()
 
 Profile *Service::profile()
 {
-    return new Profile(mlt_service_profile(get_service()));
+    return new Profile(mlt_profile_clone(mlt_service_profile(get_service())));
 }
 
 mlt_profile Service::get_profile()


### PR DESCRIPTION
If the caller frees the returned object (which they should), then a double free error will occur because the encapsulated mlt_profile will be freed by the Profile and by the origional service that owned it.