### PR TITLE
producer_avformat: Check audio_index=all and astream=all before using them as ints

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -3690,28 +3690,28 @@ static int pick_audio_stream(producer_avformat self)
 
     // Are both audio_index != all and astream != all?
     if (absolute_index == -1) {
-    if (context && mlt_properties_get(properties, "astream")) {
-        // Get the relative stream index
-        absolute_index = absolute_stream_index(context,
-                                               AVMEDIA_TYPE_AUDIO,
-                                               mlt_properties_get_int(properties, "astream"));
-    } else {
-        // Failover to the absolute index
-        absolute_index = mlt_properties_get_int(properties, "audio_index");
-        if (context) {
-            // Compute the relative stream index
-            mlt_properties_set_int(properties,
-                                   "astream",
-                                   relative_stream_index(context,
-                                                         AVMEDIA_TYPE_AUDIO,
-                                                         absolute_index));
+        if (context && mlt_properties_get(properties, "astream")) {
+            // Get the relative stream index
+            absolute_index = absolute_stream_index(context,
+                                                   AVMEDIA_TYPE_AUDIO,
+                                                   mlt_properties_get_int(properties, "astream"));
+        } else {
+            // Failover to the absolute index
+            absolute_index = mlt_properties_get_int(properties, "audio_index");
+            if (context) {
+                // Compute the relative stream index
+                mlt_properties_set_int(properties,
+                                       "astream",
+                                       relative_stream_index(context,
+                                                             AVMEDIA_TYPE_AUDIO,
+                                                             absolute_index));
+            }
         }
-    }
-    if (mlt_properties_get_int(properties, "audio_index") != absolute_index) {
-        // Update the absolute index
-        mlt_properties_set_int(properties, "audio_index", absolute_index);
-        self->audio_index = absolute_index;
-    }
+        if (mlt_properties_get_int(properties, "audio_index") != absolute_index) {
+            // Update the absolute index
+            mlt_properties_set_int(properties, "audio_index", absolute_index);
+            self->audio_index = absolute_index;
+        }
     }
 
     // Exception handling for audio_index

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -3672,8 +3672,24 @@ static int pick_audio_stream(producer_avformat self)
 {
     AVFormatContext *context = self->audio_format;
     mlt_properties properties = MLT_PRODUCER_PROPERTIES(self->parent);
-    int absolute_index;
+    int absolute_index = -1;
 
+    // Handle all audio tracks
+    if (self->audio_index > -1) {
+        if (mlt_properties_get(properties, "audio_index")
+            && !strcmp(mlt_properties_get(properties, "audio_index"), "all")) {
+            absolute_index = INT_MAX;
+            mlt_properties_set(properties, "astream", "all");
+        }
+        if (mlt_properties_get(properties, "astream")
+            && !strcmp(mlt_properties_get(properties, "astream"), "all")) {
+            absolute_index = INT_MAX;
+            mlt_properties_set(properties, "audio_index", "all");
+        }
+    }
+
+    // Are both audio_index != all and astream != all?
+    if (absolute_index == -1) {
     if (context && mlt_properties_get(properties, "astream")) {
         // Get the relative stream index
         absolute_index = absolute_stream_index(context,
@@ -3696,19 +3712,6 @@ static int pick_audio_stream(producer_avformat self)
         mlt_properties_set_int(properties, "audio_index", absolute_index);
         self->audio_index = absolute_index;
     }
-
-    // Handle all audio tracks
-    if (self->audio_index > -1) {
-        if (mlt_properties_get(properties, "audio_index")
-            && !strcmp(mlt_properties_get(properties, "audio_index"), "all")) {
-            absolute_index = INT_MAX;
-            mlt_properties_set(properties, "astream", "all");
-        }
-        if (mlt_properties_get(properties, "astream")
-            && !strcmp(mlt_properties_get(properties, "astream"), "all")) {
-            absolute_index = INT_MAX;
-            mlt_properties_set(properties, "audio_index", "all");
-        }
     }
 
     // Exception handling for audio_index


### PR DESCRIPTION
Tested with a stereo file (Sintel), an 8-channel single-stream file and a file with multiple streams with different numbers of channels per stream:

```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'tron-sines.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2mp41
    encoder         : Lavf59.27.100
  Duration: 00:00:46.53, start: 0.000000, bitrate: 1309 kb/s
  Stream #0:0[0x1](und): Video: mpeg4 (Advanced Simple Profile) (mp4v / 0x7634706D), yuv420p, 688x320 [SAR 1:1 DAR 43:20], 900 kb/s, 25 fps, 25 tbr, 25k tbn (default)
      Metadata:
        handler_name    : GPAC ISO Video Handler
        vendor_id       : [0][0][0][0]
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, mono, fltp, 69 kb/s
      Metadata:
        handler_name    : SoundHandler
        vendor_id       : [0][0][0][0]
  Stream #0:2[0x3](und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 128 kb/s
      Metadata:
        handler_name    : SoundHandler
        vendor_id       : [0][0][0][0]
  Stream #0:3[0x4](eng): Audio: aac (Main) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 105 kb/s (default)
      Metadata:
        handler_name    : GPAC ISO Audio Handler
        vendor_id       : [0][0][0][0]
  Stream #0:4[0x5](ger): Audio: aac (Main) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 111 kb/s (default)
      Metadata:
        handler_name    : GPAC ISO Audio Handler
        vendor_id       : [0][0][0][0]
  Stream #0:5[0x6](ger): Subtitle: mov_text (tx3g / 0x67337874), 688x320, 0 kb/s (default)
      Metadata:
        handler_name    : GPAC Streaming Text Handler
  Stream #0:6[0x7](eng): Subtitle: mov_text (tx3g / 0x67337874), 688x320, 0 kb/s (default)
      Metadata:
        handler_name    : GPAC Streaming Text Handler
```

Behaves as expected. This fixes #993.