### PR TITLE
src/modules/core/transition_mix.c: Increase MAX_CHANNELS to 32

### DIFF
--- a/src/modules/core/transition_mix.c
+++ b/src/modules/core/transition_mix.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_CHANNELS (6)
+#define MAX_CHANNELS (32)
 #define MAX_SAMPLES (192000)
 #define SAMPLE_BYTES(samples, channels) ((samples) * (channels) * sizeof(float))
 #define MAX_BYTES SAMPLE_BYTES(MAX_SAMPLES, MAX_CHANNELS)


### PR DESCRIPTION
This matches filter_audiomap.c

Perhaps this should be a project-wide CMake option? Conform them for now.