### PR TITLE
cmake: Fix linking on OpenBSD

### DIFF
--- a/src/modules/plusgpl/CMakeLists.txt
+++ b/src/modules/plusgpl/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(mltplusgpl PRIVATE mlt m Threads::Threads)
 
 if(WIN32)
   target_link_libraries(mltplusgpl PRIVATE ws2_32)
-elseif(UNIX AND NOT APPLE AND NOT ANDROID)
+elseif(UNIX AND NOT APPLE AND NOT ANDROID AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
   target_link_libraries(mltplusgpl PRIVATE rt)
 endif()
 


### PR DESCRIPTION
OpenBSD does not have librt.