### PR TITLE
Add subtitle feed filter, overlay filter and producer.

### DIFF
--- a/src/modules/plus/CMakeLists.txt
+++ b/src/modules/plus/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(mltplus MODULE
+  subtitles/subtitles.cpp
   consumer_blipflash.c
   factory.c
   filter_affine.c
@@ -17,6 +18,8 @@ add_library(mltplus MODULE
   filter_shape.c
   filter_spot_remover.c
   filter_strobe.c
+  filter_subtitle_feed.cpp
+  filter_subtitle.cpp
   filter_text.c
   filter_threshold.c
   filter_timer.c
@@ -24,6 +27,7 @@ add_library(mltplus MODULE
   producer_blipflash.c
   producer_count.c
   producer_pgm.c
+  producer_subtitle.c
   transition_affine.c
 )
 
@@ -73,6 +77,8 @@ install(FILES
   filter_shape.yml
   filter_spot_remover.yml
   filter_strobe.yml
+  filter_subtitle_feed.yml
+  filter_subtitle.yml
   filter_text.yml
   filter_threshold.yml
   filter_timer.yml

--- a/src/modules/plus/factory.c
+++ b/src/modules/plus/factory.c
@@ -1,6 +1,6 @@
 /*
  * factory.c -- the factory method interfaces
- * Copyright (C) 2003-2018 Meltytech, LLC
+ * Copyright (C) 2003-2024 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -89,6 +89,14 @@ extern mlt_filter filter_strobe_init(mlt_profile profile,
                                      mlt_service_type type,
                                      const char *id,
                                      char *arg);
+extern mlt_filter filter_subtitle_feed_init(mlt_profile profile,
+                                            mlt_service_type type,
+                                            const char *id,
+                                            char *arg);
+extern mlt_filter filter_subtitle_init(mlt_profile profile,
+                                       mlt_service_type type,
+                                       const char *id,
+                                       char *arg);
 extern mlt_filter filter_text_init(mlt_profile profile,
                                    mlt_service_type type,
                                    const char *id,
@@ -113,6 +121,10 @@ extern mlt_producer producer_pgm_init(mlt_profile profile,
                                       mlt_service_type type,
                                       const char *id,
                                       char *arg);
+extern mlt_producer producer_subtitle_init(mlt_profile profile,
+                                           mlt_service_type type,
+                                           const char *id,
+                                           char *arg);
 extern mlt_transition transition_affine_init(mlt_profile profile,
                                              mlt_service_type type,
                                              const char *id,
@@ -155,12 +167,15 @@ MLT_REPOSITORY
     MLT_REGISTER(mlt_service_filter_type, "shape", filter_shape_init);
     MLT_REGISTER(mlt_service_filter_type, "spot_remover", filter_spot_remover_init);
     MLT_REGISTER(mlt_service_filter_type, "strobe", filter_strobe_init);
+    MLT_REGISTER(mlt_service_filter_type, "subtitle_feed", filter_subtitle_feed_init);
+    MLT_REGISTER(mlt_service_filter_type, "subtitle", filter_subtitle_init);
     MLT_REGISTER(mlt_service_filter_type, "text", filter_text_init);
     MLT_REGISTER(mlt_service_filter_type, "threshold", filter_threshold_init);
     MLT_REGISTER(mlt_service_filter_type, "timer", filter_timer_init);
     MLT_REGISTER(mlt_service_producer_type, "blipflash", producer_blipflash_init);
     MLT_REGISTER(mlt_service_producer_type, "count", producer_count_init);
     MLT_REGISTER(mlt_service_producer_type, "pgm", producer_pgm_init);
+    MLT_REGISTER(mlt_service_producer_type, "subtitle", producer_subtitle_init);
     MLT_REGISTER(mlt_service_transition_type, "affine", transition_affine_init);
 #ifdef USE_FFTW
     MLT_REGISTER(mlt_service_filter_type, "dance", filter_dance_init);
@@ -205,6 +220,11 @@ MLT_REPOSITORY
                           metadata,
                           "filter_spot_remover.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "strobe", metadata, "filter_strobe.yml");
+    MLT_REGISTER_METADATA(mlt_service_filter_type,
+                          "subtitle_feed",
+                          metadata,
+                          "filter_subtitle_feed.yml");
+    MLT_REGISTER_METADATA(mlt_service_filter_type, "subtitle", metadata, "filter_subtitle.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "text", metadata, "filter_text.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "threshold", metadata, "filter_threshold.yml");
     MLT_REGISTER_METADATA(mlt_service_filter_type, "timer", metadata, "filter_timer.yml");
@@ -214,6 +234,7 @@ MLT_REPOSITORY
                           "producer_blipflash.yml");
     MLT_REGISTER_METADATA(mlt_service_producer_type, "count", metadata, "producer_count.yml");
     MLT_REGISTER_METADATA(mlt_service_producer_type, "pgm", metadata, "producer_pgm.yml");
+    MLT_REGISTER_METADATA(mlt_service_producer_type, "subtitle", metadata, "producer_subtitle.yml");
     MLT_REGISTER_METADATA(mlt_service_transition_type, "affine", metadata, "transition_affine.yml");
 #ifdef USE_FFTW
     MLT_REGISTER_METADATA(mlt_service_filter_type, "dance", metadata, "filter_dance.yml");

--- a/src/modules/plus/filter_subtitle.cpp
+++ b/src/modules/plus/filter_subtitle.cpp
@@ -1,0 +1,226 @@
+/*
+ * filter_subtitle.cpp -- subtitle overlay filter
+ * Copyright (C) 2024 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt.h>
+
+#include "subtitles/subtitles.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>  // for stat()
+#include <sys/types.h> // for stat()
+
+static void destroy_subtitles(void *p)
+{
+    delete static_cast<Subtitles::SubtitleVector *>(p);
+}
+
+static void property_changed(mlt_service owner, mlt_filter filter, mlt_event_data event_data)
+{
+    const char *name = mlt_event_data_to_string(event_data);
+    if (name && !strcmp(name, "text")) {
+        mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+        mlt_properties_set_int(properties, "_reset", 1);
+    }
+}
+
+static void refresh_resource_subtitles(mlt_filter filter)
+{
+    mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+    const char *resource = mlt_properties_get(properties, "resource");
+
+    struct stat file_info;
+    if (mlt_stat(resource, &file_info)) {
+        mlt_log_debug(filter, "File not found %s\n", resource);
+        return;
+    }
+
+    int64_t mtime = (int64_t) file_info.st_mtime;
+    if (mtime != mlt_properties_get_int64(properties, "_mtime")) {
+        mlt_log_info(filter, "File has changed. Reopen: %s\n", resource);
+        Subtitles::SubtitleVector *psubtitles = new Subtitles::SubtitleVector();
+        if (!psubtitles) {
+            mlt_log_error(filter, "Unable to allocate subtitles %s\n", resource);
+            return;
+        }
+        *psubtitles = Subtitles::readFromSrtFile(resource);
+        mlt_properties_set_data(properties,
+                                "_subtitles",
+                                psubtitles,
+                                0,
+                                (mlt_destructor) destroy_subtitles,
+                                NULL);
+        mlt_properties_set_int64(properties, "_mtime", mtime);
+    }
+}
+
+static void refresh_text_subtitles(mlt_filter filter)
+{
+    mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+    if (mlt_properties_get_int(properties, "_reset")) {
+        const char *text = mlt_properties_get(properties, "text");
+        Subtitles::SubtitleVector *psubtitles = new Subtitles::SubtitleVector();
+        if (!psubtitles) {
+            mlt_log_error(filter, "Unable to allocate subtitles\n");
+            return;
+        }
+        *psubtitles = Subtitles::readFromSrtString(text);
+        mlt_properties_set_data(properties,
+                                "_subtitles",
+                                psubtitles,
+                                0,
+                                (mlt_destructor) destroy_subtitles,
+                                NULL);
+        mlt_properties_clear(properties, "_reset");
+    }
+}
+
+static mlt_frame filter_process(mlt_filter filter, mlt_frame frame)
+{
+    mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+    const char *text = NULL;
+    if (mlt_properties_exists(properties, "resource") || mlt_properties_exists(properties, "text")) {
+        if (mlt_properties_exists(properties, "resource")) {
+            refresh_resource_subtitles(filter);
+        } else if (mlt_properties_exists(properties, "text")) {
+            refresh_text_subtitles(filter);
+        }
+        Subtitles::SubtitleVector *psubtitles = static_cast<Subtitles::SubtitleVector *>(
+            mlt_properties_get_data(properties, "_subtitles", NULL));
+        if (!psubtitles) {
+            psubtitles = new Subtitles::SubtitleVector();
+            if (!psubtitles) {
+                mlt_log_error(filter, "Unable to allocate subtitles\n");
+                return frame;
+            }
+            mlt_properties_set_data(properties,
+                                    "_subtitles",
+                                    psubtitles,
+                                    0,
+                                    (mlt_destructor) destroy_subtitles,
+                                    NULL);
+        }
+        const Subtitles::SubtitleVector &subtitles = *psubtitles;
+        mlt_profile profile = mlt_service_profile(MLT_FILTER_SERVICE(filter));
+        int64_t frameMs = (int64_t) mlt_frame_get_position(frame) * 1000 * profile->frame_rate_den
+                          / profile->frame_rate_num;
+        int prevIndex = mlt_properties_get_int(properties, "_prevIndex");
+        int index = Subtitles::indexForTime(subtitles, frameMs, prevIndex);
+        if (index > -1) {
+            text = subtitles[index].text.c_str();
+            mlt_properties_set_int(properties, "_prevIndex", index);
+        } else {
+            return frame;
+        }
+    } else if (mlt_properties_exists(properties, "feed")) {
+        mlt_properties frame_properties = MLT_FRAME_PROPERTIES(frame);
+        mlt_properties subtitle_properties = mlt_properties_get_properties(frame_properties,
+                                                                           "subtitles");
+        if (!subtitle_properties) {
+            mlt_log_info(filter, "No feed subtitles found\n");
+            return frame;
+        }
+        char *feed = mlt_properties_get(properties, "feed");
+        mlt_properties feed_properties = mlt_properties_get_properties(subtitle_properties, feed);
+        if (!feed_properties) {
+            mlt_log_info(filter, "Feed %s not found\n", feed);
+            return frame;
+        }
+        text = mlt_properties_get(feed_properties, "text");
+    }
+
+    if (!text || !strcmp(text, "")) {
+        // Do not draw empty text
+        return frame;
+    }
+
+    mlt_filter text_filter = (mlt_filter) mlt_properties_get_data(properties, "_t", NULL);
+    if (!text_filter) {
+        mlt_log_error(MLT_FILTER_SERVICE(filter), "Text filter not found\n");
+        return frame;
+    }
+
+    // We have some text and a text filter. Let's apply them to the frame.
+    mlt_properties text_filter_properties
+        = mlt_frame_unique_properties(frame, MLT_FILTER_SERVICE(text_filter));
+    mlt_properties_set_string(text_filter_properties, "argument", text);
+    mlt_properties_pass_list(text_filter_properties,
+                             properties,
+                             "geometry family size weight style fgcolour bgcolour olcolour pad "
+                             "halign valign outline opacity");
+    mlt_filter_set_in_and_out(text_filter, mlt_filter_get_in(filter), mlt_filter_get_out(filter));
+    return mlt_filter_process(text_filter, frame);
+}
+
+extern "C" {
+
+mlt_filter filter_subtitle_init(mlt_profile profile,
+                                mlt_service_type type,
+                                const char *id,
+                                char *arg)
+{
+    mlt_filter text_filter = mlt_factory_filter(profile, "qtext", NULL);
+    if (!text_filter)
+        text_filter = mlt_factory_filter(profile, "text", NULL);
+    if (!text_filter) {
+        mlt_log_error(NULL, "[filter_subtitle] Unable to create text filter.\n");
+        return NULL;
+    }
+
+    mlt_filter filter = mlt_filter_new();
+
+    if (filter) {
+        mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+
+        // Assign default values
+        if (arg && strcmp(arg, "")) {
+            mlt_properties_set_string(properties, "resource", arg);
+        }
+        mlt_properties_set_string(properties, "geometry", "20%/80%:60%x20%:100");
+        mlt_properties_set_string(properties, "family", "Sans");
+        mlt_properties_set_string(properties, "size", "48");
+        mlt_properties_set_string(properties, "weight", "400");
+        mlt_properties_set_string(properties, "style", "normal");
+        mlt_properties_set_string(properties, "fgcolour", "0x000000ff");
+        mlt_properties_set_string(properties, "bgcolour", "0x00000020");
+        mlt_properties_set_string(properties, "olcolour", "0x00000000");
+        mlt_properties_set_string(properties, "pad", "0");
+        mlt_properties_set_string(properties, "halign", "left");
+        mlt_properties_set_string(properties, "valign", "top");
+        mlt_properties_set_string(properties, "outline", "0");
+        mlt_properties_set_string(properties, "opacity", "1.0");
+        mlt_properties_set_int(properties, "_filter_private", 1);
+
+        // Register the text filter for reuse/destruction
+        mlt_properties_set_data(properties,
+                                "_t",
+                                text_filter,
+                                0,
+                                (mlt_destructor) mlt_filter_close,
+                                NULL);
+
+        filter->process = filter_process;
+        mlt_events_listen(properties, filter, "property-changed", (mlt_listener) property_changed);
+    } else {
+        mlt_log_error(NULL, "[filter_subtitle] Unable to allocate filter.\n");
+        mlt_filter_close(text_filter);
+    }
+    return filter;
+}
+}

--- a/src/modules/plus/filter_subtitle.yml
+++ b/src/modules/plus/filter_subtitle.yml
@@ -1,0 +1,182 @@
+schema_version: 7.0
+type: filter
+identifier: subtitle
+title: Subtitle
+version: 1
+copyright: Meltytech, LLC
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+description: Overlay subtitles onto the video
+
+parameters:
+  - identifier: resource
+    argument: yes
+    title: Resource
+    type: string
+    description: The path to a text file that contains SRT subtitles
+    required: no
+    readonly: no
+
+  - identifier: text
+    title: Text
+    type: string
+    description: >
+        A string that containes a complete SRT document.
+        This parameter is ignored if resource is set.
+    required: no
+    readonly: no
+
+  - identifier: feed
+    title: Text
+    type: string
+    description: >
+        A string that identifies the feed in the MLT Frame to overlay.
+        This parameter is ignored if resource or text is set.
+    required: no
+    default: 0
+    readonly: no
+
+  - identifier: geometry
+    title: Geometry
+    type: rect
+    description: A set of X/Y coordinates by which to adjust the text.
+    default: 20%/80%:60%x20%:100
+
+  - identifier: family
+    title: Font family
+    type: string
+    description: >
+      The typeface of the font.
+    default: Sans
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: size
+    title: Font size
+    type: integer
+    description: >
+      The size in pixels of the font. 
+    default: 48
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: style
+    title: Font style
+    type: string
+    description: >
+      The style of the font.
+    values:
+      - normal
+      - italic
+    default: normal
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: weight
+    title: Font weight
+    type: integer
+    description: The weight of the font.
+    minimum: 100
+    maximum: 1000
+    default: 400
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: fgcolour
+    title: Foreground color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x000000ff
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: bgcolour
+    title: Background color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x00000020
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: olcolour
+    title: Outline color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: outline
+    title: Outline Width
+    type: string
+    description: >
+      The width of the outline in pixels.
+    readonly: no
+    default: 0
+    minimum: 0
+    mutable: yes
+    widget: spinner
+
+  - identifier: pad
+    title: Padding
+    type: integer
+    description: >
+      The number of pixels to pad the background rectangle beyond edges of text.
+    readonly: no
+    default: 0
+    mutable: yes
+    widget: spinner
+
+  - identifier: halign
+    title: Horizontal alignment
+    description: >
+      Set the horizontal alignment within the geometry rectangle.
+    type: string
+    default: left
+    values:
+      - left
+      - centre
+      - right
+    mutable: yes
+    widget: combo
+
+  - identifier: valign
+    title: Vertical alignment
+    description: >
+      Set the vertical alignment within the geometry rectangle.
+    type: string
+    default: top
+    values:
+      - top
+      - middle
+      - bottom
+    mutable: yes
+    widget: combo
+
+  - identifier: opacity
+    title: Opacity
+    type: float
+    description: Opacity of all elements - text, outline, and background
+    readonly: no
+    default: 1.0
+    minimum: 0
+    maximum: 1.0
+    mutable: yes
+    widget: slider

--- a/src/modules/plus/filter_subtitle_feed.cpp
+++ b/src/modules/plus/filter_subtitle_feed.cpp
@@ -1,0 +1,182 @@
+/*
+ * filter_subtitle_feed.cpp
+ * Copyright (C) 2024 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt.h>
+
+#include "subtitles/subtitles.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>  // for stat()
+#include <sys/types.h> // for stat()
+
+static void destroy_subtitles(void *p)
+{
+    delete static_cast<Subtitles::SubtitleVector *>(p);
+}
+
+static void property_changed(mlt_service owner, mlt_filter filter, mlt_event_data event_data)
+{
+    const char *name = mlt_event_data_to_string(event_data);
+    if (name && !strcmp(name, "text")) {
+        mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+        mlt_properties_set_int(properties, "_reset", 1);
+    }
+}
+
+static void refresh_resource_subtitles(mlt_filter filter)
+{
+    mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+    const char *resource = mlt_properties_get(properties, "resource");
+
+    struct stat file_info;
+    if (mlt_stat(resource, &file_info)) {
+        mlt_log_debug(filter, "File not found %s\n", resource);
+        return;
+    }
+
+    int64_t mtime = (int64_t) file_info.st_mtime;
+    if (mtime != mlt_properties_get_int64(properties, "_mtime")) {
+        mlt_log_info(filter, "File has changed. Reopen: %s\n", resource);
+        Subtitles::SubtitleVector *psubtitles = new Subtitles::SubtitleVector();
+        if (!psubtitles) {
+            mlt_log_error(filter, "Unable to allocate subtitles %s\n", resource);
+            return;
+        }
+        *psubtitles = Subtitles::readFromSrtFile(resource);
+        mlt_properties_set_data(properties,
+                                "_subtitles",
+                                psubtitles,
+                                0,
+                                (mlt_destructor) destroy_subtitles,
+                                NULL);
+        mlt_properties_set_int64(properties, "_mtime", mtime);
+    }
+}
+
+static void refresh_text_subtitles(mlt_filter filter)
+{
+    mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+    if (mlt_properties_get_int(properties, "_reset")) {
+        const char *text = mlt_properties_get(properties, "text");
+        Subtitles::SubtitleVector *psubtitles = new Subtitles::SubtitleVector();
+        if (!psubtitles) {
+            mlt_log_error(filter, "Unable to allocate subtitles\n");
+            return;
+        }
+        *psubtitles = Subtitles::readFromSrtString(text);
+        mlt_properties_set_data(properties,
+                                "_subtitles",
+                                psubtitles,
+                                0,
+                                (mlt_destructor) destroy_subtitles,
+                                NULL);
+        mlt_properties_clear(properties, "_reset");
+    }
+}
+
+static mlt_frame filter_process(mlt_filter filter, mlt_frame frame)
+{
+    mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+    if (mlt_properties_exists(properties, "resource")) {
+        refresh_resource_subtitles(filter);
+    } else if (mlt_properties_exists(properties, "text")) {
+        refresh_text_subtitles(filter);
+    }
+
+    Subtitles::SubtitleVector *psubtitles = static_cast<Subtitles::SubtitleVector *>(
+        mlt_properties_get_data(properties, "_subtitles", NULL));
+    if (!psubtitles) {
+        psubtitles = new Subtitles::SubtitleVector();
+        if (!psubtitles) {
+            mlt_log_error(filter, "Unable to allocate subtitles\n");
+            return frame;
+        }
+        mlt_properties_set_data(properties,
+                                "_subtitles",
+                                psubtitles,
+                                0,
+                                (mlt_destructor) destroy_subtitles,
+                                NULL);
+    }
+    const Subtitles::SubtitleVector &subtitles = *psubtitles;
+    mlt_profile profile = mlt_service_profile(MLT_FILTER_SERVICE(filter));
+    int64_t frameMs = (int64_t) mlt_frame_get_position(frame) * 1000 * profile->frame_rate_den
+                      / profile->frame_rate_num;
+    int prevIndex = mlt_properties_get_int(properties, "_prevIndex");
+    int index = Subtitles::indexForTime(subtitles, frameMs, prevIndex);
+    if (index > -1) {
+        mlt_properties_set_int(properties, "_prevIndex", index);
+    }
+    mlt_properties frame_properties = MLT_FRAME_PROPERTIES(frame);
+    mlt_properties subtitle_properties = mlt_properties_get_properties(frame_properties,
+                                                                       "subtitles");
+    if (!subtitle_properties) {
+        subtitle_properties = mlt_properties_new();
+        mlt_properties_set_properties(frame_properties, "subtitles", subtitle_properties);
+    }
+    mlt_properties feed_properties = mlt_properties_new();
+    mlt_properties_set(feed_properties, "lang", mlt_properties_get(properties, "lang"));
+    if (index > -1) {
+        mlt_position start = subtitles[index].start * profile->frame_rate_num
+                             / profile->frame_rate_den / 1000;
+        mlt_properties_set_position(feed_properties, "start", start);
+        mlt_position end = subtitles[index].end * profile->frame_rate_num / profile->frame_rate_den
+                           / 1000;
+        mlt_properties_set_position(feed_properties, "end", end);
+        mlt_properties_set(feed_properties, "text", subtitles[index].text.c_str());
+    } else {
+        mlt_properties_set_position(feed_properties, "start", -1);
+        mlt_properties_set_position(feed_properties, "end", -1);
+        mlt_properties_set(feed_properties, "text", "");
+    }
+    char *feed = mlt_properties_get(properties, "feed");
+    mlt_properties_set_properties(subtitle_properties, feed, feed_properties);
+
+    return frame;
+}
+
+extern "C" {
+
+mlt_filter filter_subtitle_feed_init(mlt_profile profile,
+                                     mlt_service_type type,
+                                     const char *id,
+                                     char *arg)
+{
+    mlt_filter filter = mlt_filter_new();
+
+    if (filter) {
+        mlt_properties properties = MLT_FILTER_PROPERTIES(filter);
+
+        // Assign default values
+        if (arg) {
+            mlt_properties_set_string(properties, "resource", arg);
+        }
+        mlt_properties_set_string(properties, "feed", "0");
+        mlt_properties_set_string(properties, "lang", "eng");
+        mlt_properties_set_int(properties, "_reset", 1);
+
+        filter->process = filter_process;
+        mlt_events_listen(properties, filter, "property-changed", (mlt_listener) property_changed);
+    } else {
+        mlt_log_error(NULL, "[filter_subtitle_feed] Unable to allocate filter.\n");
+    }
+    return filter;
+}
+}

--- a/src/modules/plus/filter_subtitle_feed.yml
+++ b/src/modules/plus/filter_subtitle_feed.yml
@@ -1,0 +1,49 @@
+schema_version: 7.0
+type: filter
+identifier: subtitle_feed
+title: Subtitle
+version: 1
+copyright: Meltytech, LLC
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+description: Attach subtitle data to MLT frames
+notes: >
+  This filter does not modify image or audio data. It only attaches subtitle
+  data to each frame to be used by downstream services.
+
+parameters:
+  - identifier: resource
+    argument: yes
+    title: Resource
+    type: string
+    description: The path to a text file that contains SRT subtitles
+    required: no
+    readonly: no
+
+  - identifier: text
+    title: Text
+    type: string
+    description: >
+        A string that containes a complete SRT document.
+        This parameter is ignored if resource is set.
+    required: no
+    readonly: no
+
+  - identifier: feed
+    title: Text
+    type: string
+    description: >
+        A string that identifies the feed to be output in the MLT Frame.
+    required: no
+    default: 0
+    readonly: no
+
+  - identifier: lang
+    title: Language
+    type: string
+    description: The three character language identifier for the subtitles.
+    required: no
+    default: eng
+    readonly: no

--- a/src/modules/plus/producer_subtitle.c
+++ b/src/modules/plus/producer_subtitle.c
@@ -1,0 +1,119 @@
+/*
+ * producer_subtitle.c
+ * Copyright (C) 2024 Meltytech, LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <framework/mlt.h>
+
+#include <stdlib.h>
+
+static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int index)
+{
+    mlt_properties producer_properties = MLT_PRODUCER_PROPERTIES(producer);
+    mlt_producer color_producer = mlt_properties_get_data(producer_properties, "_c", NULL);
+    mlt_producer_seek(color_producer, mlt_producer_position(producer));
+    mlt_service_get_frame(MLT_PRODUCER_SERVICE(color_producer), frame, index);
+
+    if (*frame != NULL) {
+        mlt_filter sub_filter = mlt_properties_get_data(producer_properties, "_s", NULL);
+        if (!sub_filter) {
+            sub_filter = mlt_factory_filter(mlt_service_profile(MLT_PRODUCER_SERVICE(producer)),
+                                            "subtitle",
+                                            NULL);
+            if (!sub_filter) {
+                mlt_log_error(MLT_PRODUCER_SERVICE(producer), "Unable to create subtitle filter.\n");
+                return 0;
+            }
+            // Register the subtitle filter for reuse/destruction
+            mlt_properties_set_data(producer_properties,
+                                    "_s",
+                                    sub_filter,
+                                    0,
+                                    (mlt_destructor) mlt_filter_close,
+                                    NULL);
+        }
+        mlt_properties_pass_list(MLT_FILTER_PROPERTIES(sub_filter),
+                                 producer_properties,
+                                 "resource geometry family size weight style fgcolour bgcolour "
+                                 "olcolour pad halign valign outline opacity");
+        mlt_filter_process(sub_filter, *frame);
+    }
+
+    // Calculate the next time code
+    mlt_producer_prepare_next(producer);
+
+    return 0;
+}
+
+static void producer_close(mlt_producer this)
+{
+    this->close = NULL;
+    mlt_producer_close(this);
+    free(this);
+}
+
+mlt_producer producer_subtitle_init(mlt_profile profile,
+                                    mlt_service_type type,
+                                    const char *id,
+                                    char *arg)
+{
+    // Create a new producer object
+    mlt_producer producer = mlt_producer_new(profile);
+    mlt_producer color_producer = mlt_factory_producer(profile, "loader-nogl", "color");
+
+    // Initialize the producer
+    if (producer && color_producer) {
+        mlt_properties producer_properties = MLT_PRODUCER_PROPERTIES(producer);
+        if (arg) {
+            mlt_properties_set_string(producer_properties, "resource", arg);
+        }
+        mlt_properties_set_string(producer_properties, "geometry", "0%/0%:100%x100%:100%");
+        mlt_properties_set_string(producer_properties, "family", "Sans");
+        mlt_properties_set_string(producer_properties, "size", "48");
+        mlt_properties_set_string(producer_properties, "weight", "400");
+        mlt_properties_set_string(producer_properties, "style", "normal");
+        mlt_properties_set_string(producer_properties, "fgcolour", "0xffffffff");
+        mlt_properties_set_string(producer_properties, "bgcolour", "0x00000020");
+        mlt_properties_set_string(producer_properties, "olcolour", "0x00000000");
+        mlt_properties_set_string(producer_properties, "pad", "0");
+        mlt_properties_set_string(producer_properties, "halign", "left");
+        mlt_properties_set_string(producer_properties, "valign", "top");
+        mlt_properties_set_string(producer_properties, "outline", "0");
+        mlt_properties_set_string(producer_properties, "opacity", "1.0");
+
+        // Register the color producer for reuse/destruction
+        mlt_properties_set(MLT_PRODUCER_PROPERTIES(color_producer), "resource", "0x00000000");
+        mlt_properties_set_data(producer_properties,
+                                "_c",
+                                color_producer,
+                                0,
+                                (mlt_destructor) mlt_producer_close,
+                                NULL);
+
+        // Callback registration
+        producer->get_frame = producer_get_frame;
+        producer->close = (mlt_destructor) producer_close;
+    } else {
+        if (!color_producer)
+            mlt_log_error(MLT_PRODUCER_SERVICE(producer), "Unable to create color producer.\n");
+        mlt_producer_close(producer);
+        mlt_producer_close(color_producer);
+        producer = NULL;
+    }
+
+    return producer;
+}

--- a/src/modules/plus/producer_subtitle.yml
+++ b/src/modules/plus/producer_subtitle.yml
@@ -1,0 +1,163 @@
+schema_version: 7.0
+type: producer
+identifier: subtitle
+title: Subtitle
+version: 1
+copyright: Meltytech, LLC
+license: LGPLv2.1
+language: en
+tags:
+  - Video
+description: Generate video frames with subtitle overlay
+  
+parameters:
+  - identifier: resource
+    argument: yes
+    title: Resource
+    type: string
+    description: The path to a text file that contains SRT subtitles
+    required: no
+    readonly: no
+
+  - identifier: geometry
+    title: Geometry
+    type: rect
+    description: A set of X/Y coordinates by which to adjust the text.
+    default: 0%/0%:100%x100%:100
+
+  - identifier: family
+    title: Font family
+    type: string
+    description: >
+      The typeface of the font.
+    default: Sans
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: size
+    title: Font size
+    type: integer
+    description: >
+      The size in pixels of the font. 
+    default: 48
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: style
+    title: Font style
+    type: string
+    description: >
+      The style of the font.
+    values:
+      - normal
+      - italic
+    default: normal
+    readonly: no
+    mutable: yes
+    widget: combo
+
+  - identifier: weight
+    title: Font weight
+    type: integer
+    description: The weight of the font.
+    minimum: 100
+    maximum: 1000
+    default: 400
+    readonly: no
+    mutable: yes
+    widget: spinner
+
+  - identifier: fgcolour
+    title: Foreground color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x000000ff
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: bgcolour
+    title: Background color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    default: 0x00000020
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: olcolour
+    title: Outline color
+    type: string
+    description: >
+      A color value is a hexadecimal representation of RGB plus alpha channel 
+      as 0xrrggbbaa. Colors can also be the words: white, black, red, green,
+      or blue. You can also use a HTML-style color values #rrggbb or #aarrggbb.
+    readonly: no
+    mutable: yes
+    widget: color
+
+  - identifier: outline
+    title: Outline Width
+    type: string
+    description: >
+      The width of the outline in pixels.
+    readonly: no
+    default: 0
+    minimum: 0
+    mutable: yes
+    widget: spinner
+
+  - identifier: pad
+    title: Padding
+    type: integer
+    description: >
+      The number of pixels to pad the background rectangle beyond edges of text.
+    readonly: no
+    default: 0
+    mutable: yes
+    widget: spinner
+
+  - identifier: halign
+    title: Horizontal alignment
+    description: >
+      Set the horizontal alignment within the geometry rectangle.
+    type: string
+    default: left
+    values:
+      - left
+      - centre
+      - right
+    mutable: yes
+    widget: combo
+
+  - identifier: valign
+    title: Vertical alignment
+    description: >
+      Set the vertical alignment within the geometry rectangle.
+    type: string
+    default: top
+    values:
+      - top
+      - middle
+      - bottom
+    mutable: yes
+    widget: combo
+
+  - identifier: opacity
+    title: Opacity
+    type: float
+    description: Opacity of all elements - text, outline, and background
+    readonly: no
+    default: 1.0
+    minimum: 0
+    maximum: 1.0
+    mutable: yes
+    widget: slider

--- a/src/modules/plus/subtitles/subtitles.cpp
+++ b/src/modules/plus/subtitles/subtitles.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "subtitles.h"
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+static Subtitles::SubtitleVector readFromSrtStream(std::istream &stream)
+{
+    enum {
+        STATE_SEEKING_NUM,
+        STATE_READING_TIME,
+        STATE_READING_TEXT,
+    };
+
+    std::string line;
+    std::string text;
+    int state = STATE_SEEKING_NUM;
+    Subtitles::SubtitleItem item;
+    Subtitles::SubtitleVector ret;
+
+    while (std::getline(stream, line)) {
+        switch (state) {
+        case STATE_SEEKING_NUM: {
+            state = STATE_READING_TIME;
+            for (char &c : line) {
+                if (!std::isdigit(c)) {
+                    // Bad line. Keep seeking
+                    state = STATE_SEEKING_NUM;
+                    break;
+                }
+            }
+            break;
+        }
+
+        case STATE_READING_TIME: {
+            int sHours, sMinutes, sSeconds, sMiliseconds, eHours, eMinutes, eSeconds, eMiliseconds;
+            const int ret = std::sscanf(line.c_str(),
+                                        "%d:%d:%d,%d --> %d:%d:%d,%d",
+                                        &sHours,
+                                        &sMinutes,
+                                        &sSeconds,
+                                        &sMiliseconds,
+                                        &eHours,
+                                        &eMinutes,
+                                        &eSeconds,
+                                        &eMiliseconds);
+            if (ret != 8) {
+                state = STATE_SEEKING_NUM;
+                break;
+            }
+            item.start = (((((sHours * 60) + sMinutes) * 60) + sSeconds) * 1000) + sMiliseconds;
+            item.end = (((((eHours * 60) + eMinutes) * 60) + eSeconds) * 1000) + eMiliseconds;
+            item.text.clear();
+            state = STATE_READING_TEXT;
+            break;
+        }
+
+        case STATE_READING_TEXT: {
+            if (!line.empty()) {
+                if (!item.text.empty()) {
+                    item.text += "\n";
+                }
+                item.text += line;
+            } else {
+                ret.push_back(item);
+                state = STATE_SEEKING_NUM;
+            }
+            break;
+        }
+        }
+    }
+
+    if (state == STATE_READING_TEXT) {
+        ret.push_back(item);
+    }
+
+    return ret;
+}
+
+static std::string msToSrtTime(int64_t ms)
+{
+    int hours = std::floor(ms / 1000.0 / 60.0 / 60.0);
+    int minutes = std::floor((ms - (hours * 60 * 60 * 1000)) / 1000.0 / 60.0);
+    int seconds = std::floor((ms - ((hours * 60 + minutes) * 60 * 1000)) / 1000.0);
+    int miliseconds = ms - (((hours * 60 + minutes) * 60 + seconds) * 1000);
+    char buff[13];
+    std::snprintf(buff, sizeof(buff), "%02d:%02d:%02d,%03d", hours, minutes, seconds, miliseconds);
+    return std::string(buff);
+}
+
+static bool writeToSrtStream(std::ostream &stream, const Subtitles::SubtitleVector &items)
+{
+    if (items.size() == 0) {
+        return true;
+    }
+    int i = 1;
+    for (auto item : items) {
+        stream << i << "\n";
+        stream << msToSrtTime(item.start) << " --> " << msToSrtTime(item.end) << "\n";
+        stream << item.text;
+        if (!item.text.empty() && item.text.back() != '\n') {
+            stream << "\n";
+        }
+        stream << "\n";
+        i++;
+    }
+    return true;
+}
+
+Subtitles::SubtitleVector Subtitles::readFromSrtFile(const std::string &path)
+{
+    std::ifstream fileStream(path);
+    return readFromSrtStream(fileStream);
+}
+
+bool Subtitles::writeToSrtFile(const std::string &path, const SubtitleVector &items)
+{
+    std::ofstream fileStream(path.c_str(), std::ios::out | std::ios::trunc);
+    if (!fileStream.is_open()) {
+        return false;
+    }
+    return writeToSrtStream(fileStream, items);
+}
+
+Subtitles::SubtitleVector Subtitles::readFromSrtString(const std::string &text)
+{
+    std::istringstream textStream(text);
+    return readFromSrtStream(textStream);
+}
+
+bool Subtitles::writeToSrtString(std::string &text, const Subtitles::SubtitleVector &items)
+{
+    std::ostringstream textStream(text);
+    return writeToSrtStream(textStream, items);
+}
+
+int Subtitles::indexForTime(const Subtitles::SubtitleVector &items, int64_t msTime, int searchStart)
+{
+    // Return -1 if there is no subtitle for the time.
+    int index = -1;
+    int count = (int) items.size();
+    if (count == 0) {
+        // Nothing to search
+    } else if (count > 0 && items[0].start > msTime) {
+        // No text if before the first item;
+    } else if (count > 1 && items[count - 1].end < msTime) {
+        // No text if after the last item;
+    } else if (searchStart > -1 && searchStart < count && items[searchStart].start <= msTime
+               && items[searchStart].end >= msTime) {
+        // First see if this is the same as the last subtitle
+        index = searchStart;
+    } else if (searchStart > -1 && (searchStart + 1) < count && items[searchStart].end < msTime
+               && items[searchStart + 1].start > msTime) {
+        // No text if between the previous and next subtitle
+    } else if (searchStart > -1 && (searchStart + 1) < count
+               && items[searchStart + 1].start <= msTime && items[searchStart + 1].end >= msTime) {
+        // See if this is the next subtitle
+        index = searchStart + 1;
+    } else {
+        // Perform a full search from the beginning
+        int i = 0;
+        for (i = 0; i < count; i++) {
+            if (items[i].start <= msTime && items[i].end >= msTime) {
+                index = i;
+                break;
+            } else if (items[i].end > msTime) {
+                break;
+            }
+        }
+    }
+    return index;
+}

--- a/src/modules/plus/subtitles/subtitles.h
+++ b/src/modules/plus/subtitles/subtitles.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Meltytech, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SUBTITLES_H
+#define SUBTITLES_H
+
+#include <string>
+#include <vector>
+
+namespace Subtitles {
+
+struct SubtitleItem
+{
+    int64_t start;
+    int64_t end;
+    std::string text;
+};
+
+typedef std::vector<Subtitles::SubtitleItem> SubtitleVector;
+
+SubtitleVector readFromSrtFile(const std::string &path);
+bool writeToSrtFile(const std::string &path, const SubtitleVector &items);
+SubtitleVector readFromSrtString(const std::string &text);
+bool writeToSrtString(std::string &text, const SubtitleVector &items);
+int indexForTime(const SubtitleVector &items, int64_t msTime, int searchStart);
+} // namespace Subtitles
+
+#endif // SUBTITLES_H


### PR DESCRIPTION
Add two new filters:

filter_subtitle_feed can add subtitle properties to a frame. The subtitle data can come from an SRT file, or as SRT string attached to the filter.

filter_subtitle can receive subtitle properties from a frame and burn them into the video

producer_subtitle is a convenience producer that puts a filter_subtitle on top of a color produced frame.