### PR TITLE
Fix a race condition when starting a video thread

### DIFF
--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -63,7 +63,6 @@ struct consumer_sdl_s
     int width;
     int height;
     int out_channels;
-    atomic_int playing;
     SDL_Window *sdl_window;
     SDL_Renderer *sdl_renderer;
     SDL_Texture *sdl_texture;
@@ -342,9 +341,6 @@ static void sdl_fill_audio(void *udata, uint8_t *stream, int len)
         self->audio_avail = 0;
     }
 
-    // We're definitely playing now
-    self->playing = 1;
-
     pthread_cond_broadcast(&self->audio_cond);
     pthread_mutex_unlock(&self->audio_mutex);
 }
@@ -371,7 +367,6 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
     pcm += mlt_properties_get_int(properties, "audio_offset");
 
     if (mlt_properties_get_int(properties, "audio_off")) {
-        self->playing = 1;
         init_audio = 1;
         return init_audio;
     }
@@ -384,7 +379,6 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
 
         // specify audio format
         memset(&request, 0, sizeof(SDL_AudioSpec));
-        self->playing = 0;
         request.freq = frequency;
         request.format = AUDIO_S16SYS;
         request.channels = mlt_properties_get_int(properties, "channels");
@@ -472,8 +466,6 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
             pthread_cond_broadcast(&self->audio_cond);
         }
         pthread_mutex_unlock(&self->audio_mutex);
-    } else {
-        self->playing = 1;
     }
 
     return init_audio;
@@ -808,9 +800,6 @@ static void *consumer_thread(void *arg)
             // Play audio
             init_audio = consumer_play_audio(self, frame, init_audio, &duration);
 
-            // Start the video thread unconditionally. We cannot check for self->playing,
-            // because the variable may be initialized with a delay by a backdround SDL
-            // thread and cause race condition
             if (init_video) {
                 // Create the video thread
                 pthread_create(&thread, NULL, video_thread, self);

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -708,8 +708,12 @@ static void *video_thread(void *arg)
         }
         pthread_mutex_unlock(&self->video_mutex);
 
-        if (!self->running || next == NULL)
+        if (!self->running || next == NULL) {
+            if (self->running) {
+                mlt_log_warning(MLT_CONSUMER_SERVICE(&self->parent), "video thread got a null frame even though the consumer is still running!\n");
+            }
             break;
+        }
 
         // Get the properties
         properties = MLT_FRAME_PROPERTIES(next);
@@ -804,8 +808,10 @@ static void *consumer_thread(void *arg)
             // Play audio
             init_audio = consumer_play_audio(self, frame, init_audio, &duration);
 
-            // Determine the start time now
-            if (self->playing && init_video) {
+            // Start the video thread unconditionally. We cannot check for self->playing,
+            // because the variable may be initialized with a delay by a backdround SDL
+            // thread and cause race condition
+            if (init_video) {
                 // Create the video thread
                 pthread_create(&thread, NULL, video_thread, self);
 

--- a/src/modules/sdl2/consumer_sdl2_audio.c
+++ b/src/modules/sdl2/consumer_sdl2_audio.c
@@ -55,7 +55,6 @@ struct consumer_sdl_s
     pthread_mutex_t video_mutex;
     pthread_cond_t video_cond;
     int out_channels;
-    atomic_int playing;
 
     pthread_cond_t refresh_cond;
     pthread_mutex_t refresh_mutex;
@@ -295,9 +294,6 @@ static void sdl_fill_audio(void *udata, uint8_t *stream, int len)
     // Remove the samples
     memmove(self->audio_buffer, self->audio_buffer + bytes, self->audio_avail);
 
-    // We're definitely playing now
-    self->playing = 1;
-
     pthread_cond_broadcast(&self->audio_cond);
     pthread_mutex_unlock(&self->audio_mutex);
 }
@@ -324,7 +320,6 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
     pcm += mlt_properties_get_int(properties, "audio_offset");
 
     if (mlt_properties_get_int(properties, "audio_off")) {
-        self->playing = 1;
         init_audio = 1;
         return init_audio;
     }
@@ -337,7 +332,6 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
 
         // specify audio format
         memset(&request, 0, sizeof(SDL_AudioSpec));
-        self->playing = 0;
         request.freq = frequency;
         request.format = AUDIO_S16SYS;
         request.channels = mlt_properties_get_int(properties, "channels");
@@ -425,8 +419,6 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
             pthread_cond_broadcast(&self->audio_cond);
         }
         pthread_mutex_unlock(&self->audio_mutex);
-    } else {
-        self->playing = 1;
     }
 
     return init_audio;
@@ -597,9 +589,6 @@ static void *consumer_thread(void *arg)
             // Play audio
             init_audio = consumer_play_audio(self, frame, init_audio, &duration);
 
-            // Start the video thread unconditionally. We cannot check for self->playing,
-            // because the variable may be initialized with a delay by a backdround SDL
-            // thread and cause race condition
             if (init_video) {
                 // Create the video thread
                 pthread_create(&thread, NULL, video_thread, self);


### PR DESCRIPTION
Variable `self->playing` is initialized by a background SDL thread that we start in `consumer_play_audio`. When FPS value is too hight (e.g. 100fps) or when the system is too slow, `self->playing` may be initialized **after** the actual check is done. It will end-up in a deadlock in `consumer_thread` because video_thread will never be started and noone will ever consume the frames from the queue.

The patch just starts the video thread unconditionally, making sure the frame will always be consumed.

See: https://bugs.kde.org/show_bug.cgi?id=489146