### PR TITLE
Fix building on musl libc

### DIFF
--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -30,7 +30,7 @@
 #include <sys/param.h>
 #endif
 
-#if defined(__linux__) || defined(__GLIBC__)
+#if defined(__GLIBC__)
 #include <locale.h>
 typedef locale_t mlt_locale_t;
 #elif defined(__APPLE__) || (defined(__FreeBSD_version) && __FreeBSD_version >= 900506)


### PR DESCRIPTION
Not every Linux distribution uses GLibc, hence the code under
```
\#if defined(__linux__) || defined(__GLIBC__)
```
is not evaluated properly on non GLibc Linux distributions resulting in build errors such as:

```
/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_properties.c: In function 'mlt_properties_set_lcnumeric':
/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_properties.c:154:22: error: assignment to 'mlt_locale_t' {aka 'struct __locale_struct *'} from incompatible pointer type 'char *' [-Wincompatible-pointer-types]
  154 |         list->locale = strdup(locale);
      |                      ^
/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_properties.c: In function 'mlt_properties_get_lcnumeric':
/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_properties.c:186:16: error: assignment to 'const char *' from incompatible pointer type 'mlt_locale_t' {aka 'struct __locale_struct *'} [-Wincompatible-pointer-types]
  186 |         result = list->locale;
      |                ^
[11/173] /usr/bin/x86_64-pc-linux-musl-gcc -DPREFIX_DATA=\"/usr/share/mlt-7\" -DPREFIX_LIB=\"/usr/lib/mlt-7\" -Dmlt_EXPORTS -I/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/..  -O2 -march=x86-64 -pipe -pipe -frecord-gcc-switches -fno-diagnostics-color -fmessage-length=0 -std=gnu11 -fPIC -mmmx -msse -msse2 -MD -MT src/framework/CMakeFiles/mlt.dir/mlt_property.c.o -MF src/framework/CMakeFiles/mlt.dir/mlt_property.c.o.d -o src/framework/CMakeFiles/mlt.dir/mlt_property.c.o -c /var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_property.c
FAILED: src/framework/CMakeFiles/mlt.dir/mlt_property.c.o
/usr/bin/x86_64-pc-linux-musl-gcc -DPREFIX_DATA=\"/usr/share/mlt-7\" -DPREFIX_LIB=\"/usr/lib/mlt-7\" -Dmlt_EXPORTS -I/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/..  -O2 -march=x86-64 -pipe -pipe -frecord-gcc-switches -fno-diagnostics-color -fmessage-length=0 -std=gnu11 -fPIC -mmmx -msse -msse2 -MD -MT src/framework/CMakeFiles/mlt.dir/mlt_property.c.o -MF src/framework/CMakeFiles/mlt.dir/mlt_property.c.o.d -o src/framework/CMakeFiles/mlt.dir/mlt_property.c.o -c /var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_property.c
/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_property.c: In function 'time_clock_to_frames':
/var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_property.c:331:31: error: passing argument 2 of 'setlocale' from incompatible pointer type [-Wincompatible-pointer-types]
  331 |         setlocale(LC_NUMERIC, locale);
      |                               ^~~~~~
      |                               |
      |                               mlt_locale_t {aka struct __locale_struct *}
In file included from /var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_property.h:34,
                 from /var/tmp/portage/media-libs/mlt-7.24.0/work/mlt-7.24.0/src/framework/mlt_property.c:28:
/usr/include/locale.h:55:23: note: expected 'const char *' but argument is of type 'mlt_locale_t' {aka 'struct __locale_struct *'}
   55 | char *setlocale (int, const char *);
```

Reported on Gentoo Linux with musl libc.
Please refer bug: https://bugs.gentoo.org/936747 for more details.