### PR TITLE
Add support for SMPTE-esque timecodes

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -657,3 +657,9 @@ MLT_7.22.0 {
     mlt_property_is_numeric;
     mlt_property_is_rect;
 } MLT_7.18.0;
+
+MLT_7.226.0 {
+  global:
+    mlt_producer_set_timecode;
+    mlt_producer_get_timecode;
+} MLT_7.22.0;

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -144,6 +144,8 @@ extern int mlt_producer_optimise(mlt_producer self);
 extern void mlt_producer_close(mlt_producer self);
 int64_t mlt_producer_get_creation_time(mlt_producer self);
 void mlt_producer_set_creation_time(mlt_producer self, int64_t creation_time);
+extern int64_t mlt_producer_get_timecode(mlt_producer self);
+extern void mlt_producer_set_timecode(mlt_producer self, int64_t timecode);
 extern int mlt_producer_probe(mlt_producer self);
 
 #endif

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -262,6 +262,17 @@ void Producer::set_creation_time(int64_t creation_time)
     mlt_producer_set_creation_time(get_producer(), creation_time);
 }
 
+int64_t Producer::get_timecode()
+{
+    int64_t tc = mlt_producer_get_timecode(get_producer());
+    return tc;
+}
+
+void Producer::set_timecode(int64_t timecode)
+{
+    mlt_producer_set_timecode(get_producer(), timecode);
+}
+
 bool Producer::probe()
 {
     return mlt_producer_probe(get_producer());

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -77,6 +77,8 @@ public:
     int clear();
     int64_t get_creation_time();
     void set_creation_time(int64_t creation_time);
+    int64_t get_timecode();
+    void set_timecode(int64_t timecode);
     bool probe();
 };
 } // namespace Mlt

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -710,5 +710,15 @@ MLT_7.14.0 {
     extern "C++" {
       "Mlt::Producer::probe()";
       "Mlt::Chain::attach_normalizers()";
+      "Mlt::Producer::get_timecode()";
+      "Mlt::Producer::set_timecode(int64_t)";
     };
 } MLT_7.12.0;
+
+MLT_7.26.0 {
+  global:
+    extern "C++" {
+      "Mlt::Producer::get_timecode()";
+      "Mlt::Producer::set_timecode(int64_t)";
+    };
+} MLT_7.14.0;


### PR DESCRIPTION
This reads burned in timecodes from the headers of the two timecode flavors I have floating around (Tentacle and GoPro), and provides them to users.