### PR TITLE
Reduce log level of this VST message

### DIFF
--- a/src/modules/jackrack/plugin_mgr.c
+++ b/src/modules/jackrack/plugin_mgr.c
@@ -1018,8 +1018,8 @@ vst2_mgr_t *vst2_mgr_new()
     vst2_mgr_get_path_plugins(pm);
 
     if (!pm->all_plugins)
-        mlt_log_warning(
-            NULL, "No VST2 plugins were found!\n\nCheck your VST_PATH environment variable.\n");
+        mlt_log_info(
+            NULL, "No VST2 plugins were found! Check your VST_PATH environment variable.\n");
     else
         pm->all_plugins = g_slist_sort(pm->all_plugins, vst2_mgr_sort);
 


### PR DESCRIPTION
This three line message was spitting out every time I ran a melt command. I propose that this does not need to be a run-time warning. Maybe a compile warning?