### PR TITLE
fix color shift in stills/JPEG export preset

### DIFF
--- a/presets/consumer/avformat/stills/JPEG
+++ b/presets/consumer/avformat/stills/JPEG
@@ -1,3 +1,4 @@
+color_range=pc
 progressive=1
 f=image2
 vcodec=mjpeg
@@ -6,5 +7,7 @@ an=1
 audio_off=1
 g=1
 bf=0
+pix_fmt=yuvj422p
+colorspace=srgb
 
 meta.preset.extension=jpg


### PR DESCRIPTION
The current JPEG export preset usually produces a color shift when exporting. This is due to typical BT.601/709 mismatch-type stuff. I have added JPEG-standard values to the export preset to ensure that all conversions/signaling/tagging is explicit.

Investigated due to the bug report at https://forum.shotcut.org/t/exported-image-color-is-different-from-the-video/45736