### PR TITLE
Fix setting avfilter channel count

### DIFF
--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -288,15 +288,6 @@ static void init_audio_filtergraph(mlt_filter filter,
         mlt_log_error(filter, "Cannot set sink sample rates\n");
         goto fail;
     }
-    ret = av_opt_set_int_list(pdata->avbuffsink_ctx,
-                              "channel_counts",
-                              channel_counts,
-                              -1,
-                              AV_OPT_SEARCH_CHILDREN);
-    if (ret < 0) {
-        mlt_log_error(filter, "Cannot set sink channel counts\n");
-        goto fail;
-    }
 #if HAVE_FFMPEG_CH_LAYOUT
     ret = av_opt_set(pdata->avbuffsink_ctx,
                      "ch_layouts",
@@ -307,6 +298,15 @@ static void init_audio_filtergraph(mlt_filter filter,
         goto fail;
     }
 #else
+    ret = av_opt_set_int_list(pdata->avbuffsink_ctx,
+                              "channel_counts",
+                              channel_counts,
+                              -1,
+                              AV_OPT_SEARCH_CHILDREN);
+    if (ret < 0) {
+        mlt_log_error(filter, "Cannot set sink channel counts\n");
+        goto fail;
+    }
     ret = av_opt_set_int_list(pdata->avbuffsink_ctx,
                               "channel_layouts",
                               channel_layouts,


### PR DESCRIPTION
Audio avfilters using filter_avfilter are currently broken and show the "Cannot set sink channel counts" error.
This requires the same fix that was applied to link_avfilter in
https://github.com/mltframework/mlt/commit/1493ced9dc9968c358c2bbb9edf8b8a6122b9216