### PR TITLE
Fix randomly broken mlt_repository with relocatable flag

### DIFF
--- a/src/framework/mlt_factory.c
+++ b/src/framework/mlt_factory.c
@@ -153,7 +153,10 @@ mlt_repository mlt_factory_init(const char *directory)
 #ifdef __APPLE__
         _NSGetExecutablePath(path, &size);
 #else
-        readlink("/proc/self/exe", path, size);
+        ssize_t len = readlink("/proc/self/exe", path, size - 1);
+        if (len != -1) {
+            path[len] = '\0';
+        }
 #endif
         char *appdir = mlt_dirname(mlt_dirname(strdup(path)));
         mlt_properties_set(global_properties, "MLT_APPDIR", appdir);


### PR DESCRIPTION
While working on our automated render tests suite, I came across seemingly random failures rendering with our AppImage with an error message like:
mlt_repository_init: no plugins found in "`/$HOME/git/kdenlive-test-suite/squashfs-root/usr/bin/lib/mlt-7`"
Looking into the details, I realized that the path set for `mlt_repository_init` was randomly incorrect when MLT is compiled with the relocatable flag.

Turns out the `readlink` [1] method used to retrieve the current path returns a string that is not terminated by a null character, so some garbage was appended to the path. Currently, the path returned by readlink looks like:

/$HOME/git/kdenlive-test-suite/squashfs-root/usr/bin/melt-7N� or
/$HOME/git/kdenlive-test-suite/squashfs-root/usr/bin/melt-7n/@�~

Whenever a slash happens to be in these garbage chars, the path points to the wrong folder.

This patch ensures the string return by readlink is correctly terminated.

[1] https://github.com/mltframework/mlt/blob/master/src/framework/mlt_factory.c#L156