### PR TITLE
SDL2 consumer resize fix

### DIFF
--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -134,7 +134,7 @@ mlt_consumer consumer_sdl2_init(mlt_profile profile,
 
         // Default scrub audio
         mlt_properties_set_int(self->properties, "scrub_audio", 1);
-
+       
         // Ensure we don't join on a non-running object
         self->joined = 1;
 
@@ -517,6 +517,7 @@ static int setup_sdl_video(consumer_sdl self)
 
     if (window_id) {
         self->sdl_window = SDL_CreateWindowFrom((void *) window_id);
+        SDL_SetWindowResizable(self->sdl_window, SDL_TRUE);
     } else {
         self->sdl_window = SDL_CreateWindow("MLT",
                                             SDL_WINDOWPOS_UNDEFINED,

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -134,7 +134,7 @@ mlt_consumer consumer_sdl2_init(mlt_profile profile,
 
         // Default scrub audio
         mlt_properties_set_int(self->properties, "scrub_audio", 1);
-       
+
         // Ensure we don't join on a non-running object
         self->joined = 1;
 


### PR DESCRIPTION
With Flowblade setting window resizable was required to get resize working correctly when resizing panel from the *left*. Without this patch the video area maintained its position relative to window top left corner and slid out of panel area when resizing from left.