### PR TITLE
Fix various aspect ratio issues with qtblend filter/transition

### DIFF
--- a/src/modules/qt/common.h
+++ b/src/modules/qt/common.h
@@ -21,7 +21,6 @@
 
 #include <framework/mlt.h>
 
-#define MLT_QTBLEND_MAX_DIMENSION (16000)
 
 class QImage;
 

--- a/src/modules/qt/common.h
+++ b/src/modules/qt/common.h
@@ -21,6 +21,8 @@
 
 #include <framework/mlt.h>
 
+#define MLT_QTBLEND_MAX_DIMENSION (16000)
+
 class QImage;
 
 bool createQApplicationIfNeeded(mlt_service service);

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_qtblend.cpp -- Qt composite filter
- * Copyright (C) 2015 Meltytech, LLC
+ * Copyright (C) 2015-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -81,7 +81,7 @@ static int filter_get_image(mlt_frame frame,
     double opacity = 1.0;
 
     // If the _qtblend_scaled property is defined, a qtblend filter was already applied
-    int qtblendRescaled = mlt_properties_get_int(frame_properties, "_qtblend_scaled");
+    int qtblendRescaled = mlt_properties_get_int(frame_properties, "qtblend_scaled");
     if (mlt_properties_get(properties, "rect")) {
         rect = mlt_properties_anim_get_rect(properties, "rect", position, length);
         if (::strchr(mlt_properties_get(properties, "rect"), '%')) {
@@ -95,7 +95,8 @@ static int filter_get_image(mlt_frame frame,
             // In this case, the *width and *height are set to the source resolution to ensure we don't lose too much details on multiple scaling operations
             // We requested a image with full media resolution, adjust rect to profile
             // Check if we have consumer scaling enabled since we cannot use *width and *height
-            double consumerScale = mlt_properties_get_double(frame_properties, "_qtblend_scalex");
+            double consumerScale = mlt_properties_get_double(frame_properties,
+                                                             "qtblend_preview_scaling");
             if (consumerScale > 0.) {
                 b_width *= consumerScale;
                 b_height *= consumerScale;
@@ -137,8 +138,8 @@ static int filter_get_image(mlt_frame frame,
             // First instance of a qtblend filter
             double scale = mlt_profile_scale_width(profile, *width);
             // Store consumer scaling for further uses
-            mlt_properties_set_int(frame_properties, "_qtblend_scaled", 1);
-            mlt_properties_set_double(frame_properties, "_qtblend_scalex", scale);
+            mlt_properties_set_int(frame_properties, "qtblend_scaled", 1);
+            mlt_properties_set_double(frame_properties, "qtblend_preview_scaling", scale);
             // Apply scaling
             if (scale != 1.0) {
                 rect.x *= scale;

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -26,6 +26,9 @@
 #include <QPainter>
 #include <QTransform>
 
+#define MLT_QTBLEND_MAX_DIMENSION (16000)
+
+
 /** Get the image.
 */
 static int filter_get_image(mlt_frame frame,

--- a/src/modules/sdl2/common.c
+++ b/src/modules/sdl2/common.c
@@ -20,6 +20,7 @@
 #include "common.h"
 
 #include <framework/mlt_log.h>
+#include <string.h>
 
 SDL_AudioDeviceID sdl2_open_audio(const SDL_AudioSpec *desired, SDL_AudioSpec *obtained)
 {


### PR DESCRIPTION
This fixes multiple issues when applying several qtblend filters on the same frame.
One issue is that the qtblend filter, like the affine filter/transition, sometimes query an image using the producer's original resolution, not in profile resolution in order to be able to display for example to zoom in a 4k clip with an HD profile, while keeping the 4K resolution.

However this caused issues because in several parts of the code, we calculate the preview scaling by comparing the size of the requested image with the size of the project profile.

Among the several fixes in this patch, we now check if another qtblend filter was applies and use a cached value for consumer scaling.