### PR TITLE
Update common.c to include string.h

### DIFF
--- a/src/modules/sdl2/common.c
+++ b/src/modules/sdl2/common.c
@@ -20,6 +20,7 @@
 #include "common.h"
 
 #include <framework/mlt_log.h>
+#include <string.h>
 
 SDL_AudioDeviceID sdl2_open_audio(const SDL_AudioSpec *desired, SDL_AudioSpec *obtained)
 {


### PR DESCRIPTION
There is a compile error in Arch Linux. 
Including string.h here silences that error, and allows mlt to build from source. 