### PR TITLE
Check for QT's offscreen platform

### DIFF
--- a/src/modules/glaxnimate/producer_glaxnimate.cpp
+++ b/src/modules/glaxnimate/producer_glaxnimate.cpp
@@ -141,12 +141,15 @@ static bool createQApplicationIfNeeded(mlt_service service)
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
         if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
-            mlt_log_error(service,
+            const char* s = getenv("QT_QPA_PLATFORM");
+            if (s == 0 || strcmp(s, "offscreen") != 0) {
+                mlt_log_error(service,
                           "The MLT Glaxnimate module requires a X11 or Wayland environment.\n"
                           "Please either run melt from a session with a display server or use a "
                           "fake X server like xvfb:\n"
                           "xvfb-run -a melt (...)\n");
-            return false;
+                return false;
+            }
         }
 #endif
         if (!mlt_properties_get(mlt_global_properties(), "qt_argv"))

--- a/src/modules/glaxnimate/producer_glaxnimate.cpp
+++ b/src/modules/glaxnimate/producer_glaxnimate.cpp
@@ -141,8 +141,8 @@ static bool createQApplicationIfNeeded(mlt_service service)
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
         if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
-            const char* s = getenv("QT_QPA_PLATFORM");
-            if (s == 0 || strcmp(s, "offscreen") != 0) {
+            const char *qt_qpa = getenv("QT_QPA_PLATFORM");
+            if (qt_qpa == 0 || strcmp(qt_qpa, "offscreen") != 0) {
                 mlt_log_error(service,
                           "The MLT Glaxnimate module requires a X11 or Wayland environment.\n"
                           "Please either run melt from a session with a display server or use a "

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -37,8 +37,8 @@ bool createQApplicationIfNeeded(mlt_service service)
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(Q_OS_ANDROID)
         if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
-            const char* s = getenv("QT_QPA_PLATFORM");
-            if (s == 0 || strcmp(s, "offscreen") != 0) {
+            const char *qt_qpa = getenv("QT_QPA_PLATFORM");
+            if (qt_qpa == 0 || strcmp(qt_qpa, "offscreen") != 0) {
                 mlt_log_error(service,
                           "The MLT Qt module requires a X11 or Wayland environment.\n"
                           "Please either run melt from a session with a display server or use a "

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -37,12 +37,15 @@ bool createQApplicationIfNeeded(mlt_service service)
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(Q_OS_ANDROID)
         if (getenv("DISPLAY") == 0 && getenv("WAYLAND_DISPLAY") == 0) {
-            mlt_log_error(service,
+            const char* s = getenv("QT_QPA_PLATFORM");
+            if (s == 0 || strcmp(s, "offscreen") != 0) {
+                mlt_log_error(service,
                           "The MLT Qt module requires a X11 or Wayland environment.\n"
                           "Please either run melt from a session with a display server or use a "
                           "fake X server like xvfb:\n"
                           "xvfb-run -a melt (...)\n");
-            return false;
+                return false;
+            }
         }
 #endif
         if (!mlt_properties_get(mlt_global_properties(), "qt_argv"))


### PR DESCRIPTION
Currently the Qt module (and Glaxnimate) abort when the `DISPLAY` or `WAYLAND_DISPLAY` variables are not set, meaning there is a graphical server running. However, use of Qt modules is also possible using Qt's offscreen rendering, which is enabled by setting the QT_QPA_PLATFORM to `offscreen`.

This patch checks for this condition and allows running the Qt modules in this case.