### PR TITLE
Fix pixel format detection for VP8/VP9 streams

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -490,7 +490,7 @@ static mlt_properties find_default_streams(producer_avformat self)
     // Allow for multiple audio and video streams in the file and select first of each (if available)
     for (i = 0; i < context->nb_streams; i++) {
         // Get the codec context
-        AVFormatContext *vpxContext = NULL;
+        AVFormatContext *vpx_context = NULL;
         AVStream *stream = context->streams[i];
         if (!stream)
             continue;
@@ -498,33 +498,33 @@ static mlt_properties find_default_streams(producer_avformat self)
         const AVCodec *codec = avcodec_find_decoder(codec_params->codec_id);
         if (!codec)
             continue;
-        int switchToVpxCodec = 0;
+        int switch_to_vpx = 0;
         if (codec_params->codec_id == AV_CODEC_ID_VP9) {
             if (!(codec = avcodec_find_decoder_by_name("libvpx-vp9"))) {
                 codec = avcodec_find_decoder(codec_params->codec_id);
             } else {
-                switchToVpxCodec = 1;
+                switch_to_vpx = 1;
             }
         } else if (codec_params->codec_id == AV_CODEC_ID_VP8) {
             if (!(codec = avcodec_find_decoder_by_name("libvpx"))) {
                 codec = avcodec_find_decoder(codec_params->codec_id);
             } else {
-                switchToVpxCodec = 1;
+                switch_to_vpx = 1;
             }
         }
-        if (switchToVpxCodec) {
+        if (switch_to_vpx) {
             // Use a temporary format context to get the real pixel format with the libvpx decoder,
             // since the native decoder incorreclty detects yuva420p as yuv420p
-            int error = avformat_open_input(&vpxContext,
+            int error = avformat_open_input(&vpx_context,
                                             mlt_properties_get(meta_media, "resource"),
                                             NULL,
                                             NULL);
             if (!error) {
-                vpxContext->video_codec = codec;
-                avformat_find_stream_info(vpxContext, NULL);
-                AVStream *vpxStream = vpxContext->streams[i];
-                if (vpxStream) {
-                    codec_params = vpxStream->codecpar;
+                vpx_context->video_codec = codec;
+                avformat_find_stream_info(vpx_context, NULL);
+                AVStream *vpx_stream = vpx_context->streams[i];
+                if (vpx_stream) {
+                    codec_params = vpx_stream->codecpar;
                 }
             }
         }
@@ -665,9 +665,9 @@ static mlt_properties find_default_streams(producer_avformat self)
                 free(value);
             }
         }
-        if (vpxContext) {
-            avformat_close_input(&vpxContext);
-            vpxContext = NULL;
+        if (vpx_context) {
+            avformat_close_input(&vpx_context);
+            vpx_context = NULL;
         }
     }
 


### PR DESCRIPTION
FFmpeg's native VP8 / VP9 decoders don't support alpha channel, while the libvpx versions do. A workaround to correctly play the video is implemented in MLT to switch to the vpx versions of the decoders if available:
https://github.com/mltframework/mlt/blob/master/src/modules/avformat/producer_avformat.c#L2715

However the pixel format info is still incorrect: clips with alpha are reported as yuv420p instead of yuva420p, because the native decoder is used when calling `avformat_find_stream_info` , so we get info from the native decoder, see for reference this tread : 
https://stackoverflow.com/questions/66702932/is-there-a-way-to-force-ffmpeg-to-decode-a-video-stream-with-alpha-from-a-webm

This is problematic as for example in Kdenlive we rely on the pixel format to detect alpha.

Below is a sample clip that can be used to reproduce the problem:
https://invent.kde.org/-/project/19/uploads/3104b97f60c00a07dddb9d0343465fc2/Directed_Exit_short.webm

`melt Directed_Exit_short.webm -consumer xml:`
Reports a meta.media.0.codec.pix_fmt as **yuv420p** despite the clip having an alpha channel

With my change, the same command correctly reports **yuva420p**.

Note that I am not so familiar with avformat code so any suggestion to improve or a different way to fix is welcome.
