### PR TITLE
Add mlt_service_set_consumer

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -662,3 +662,8 @@ MLT_7.30.0 {
   global:
     mlt_image_full_range;
 } MLT_7.22.0;
+
+MLT_7.32.0 {
+  global:
+    mlt_service_set_consumer;
+} MLT_7.30.0;

--- a/src/framework/mlt_service.c
+++ b/src/framework/mlt_service.c
@@ -383,6 +383,26 @@ static void mlt_service_disconnect(mlt_service self)
     }
 }
 
+/** Set the consumer this service is connected to.
+ *
+ * Set the value that is returned by mlt_service_consumer()
+ *
+ * \public \memberof mlt_service_s
+ * \param self a service
+ * \param consumer the consumer to set
+ */
+
+void mlt_service_set_consumer(mlt_service self, mlt_service consumer)
+{
+    if (self) {
+        // Get the service base
+        mlt_service_base *base = self->local;
+
+        // Return the connected consumer
+        base->out = consumer;
+    }
+}
+
 /** Obtain the consumer a service is connected to.
  *
  * \public \memberof mlt_service_s

--- a/src/framework/mlt_service.h
+++ b/src/framework/mlt_service.h
@@ -88,6 +88,7 @@ extern int mlt_service_disconnect_all_producers(mlt_service self);
 extern mlt_service mlt_service_get_producer(mlt_service self);
 extern int mlt_service_get_frame(mlt_service self, mlt_frame_ptr frame, int index);
 extern mlt_properties mlt_service_properties(mlt_service self);
+extern void mlt_service_set_consumer(mlt_service self, mlt_service consumer);
 extern mlt_service mlt_service_consumer(mlt_service self);
 extern mlt_service mlt_service_producer(mlt_service self);
 extern int mlt_service_attach(mlt_service self, mlt_filter filter);

--- a/src/mlt++/MltService.cpp
+++ b/src/mlt++/MltService.cpp
@@ -110,6 +110,11 @@ Service *Service::producer()
     return new Service(mlt_service_producer(get_service()));
 }
 
+void Service::set_consumer(Service &service)
+{
+    mlt_service_set_consumer(get_service(), service.get_service());
+}
+
 Service *Service::consumer()
 {
     return new Service(mlt_service_consumer(get_service()));

--- a/src/mlt++/MltService.h
+++ b/src/mlt++/MltService.h
@@ -54,6 +54,7 @@ public:
     int insert_producer(Service &producer, int index = 0);
     int disconnect_producer(int index = 0);
     int disconnect_all_producers();
+    void set_consumer(Service &service);
     Service *consumer();
     Service *producer();
     Profile *profile();

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -714,3 +714,10 @@ MLT_7.14.0 {
       "Mlt::Chain::attach_normalizers()";
     };
 } MLT_7.12.0;
+
+MLT_7.32.0 {
+  global:
+    extern "C++" {
+      "Mlt::Service::set_consumer(Mlt::Service&)";
+    };
+} MLT_7.14.0;

--- a/src/tests/test_service/test_service.cpp
+++ b/src/tests/test_service/test_service.cpp
@@ -65,6 +65,39 @@ private Q_SLOTS:
         QCOMPARE(mlt_service_identify(MLT_CONSUMER_SERVICE(consumer)), mlt_service_consumer_type);
     }
 
+    void GetSetConsumer()
+    {
+        Service *service;
+        Profile profile;
+        Producer producer(profile, "color");
+
+        // Test a default consumer (should be null or invalid)
+        service = producer.consumer();
+        QVERIFY(!service->is_valid());
+        delete service;
+
+        // Test a service connected to a consumer
+        Consumer c(profile, "xml", "string");
+        c.connect(producer);
+        c.start();
+        service = producer.consumer();
+        QCOMPARE(c.get_service(), service->get_service());
+        delete service;
+
+        // Replace the consumer service
+        Service invalidService;
+        producer.set_consumer(invalidService);
+        service = producer.consumer();
+        QCOMPARE(invalidService.get_service(), service->get_service());
+        delete service;
+
+        // Restore the consumer service
+        producer.set_consumer(c);
+        service = producer.consumer();
+        QCOMPARE(c.get_service(), service->get_service());
+        delete service;
+    }
+
 private:
     Repository *repo;
 };


### PR DESCRIPTION
This can be used to restore a consumer in case it is stolen temporarily (for example to run the XML consumer).