### PR TITLE
build(MSVC): 修复 MSVC 链接错误并添加 POSIX 兼容性代码

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ out
 src/swig/ruby/markdown/
 CMakeLists.txt.user
 .cache/
-
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/modules/glaxnimate/glaxnimate"]
 	path = src/modules/glaxnimate/glaxnimate
-	url = https://gitlab.com/mattbas/glaxnimate.git
+	url = https://gitlab.com/sammiler/glaxnimate
 	ignore = dirty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,24 @@ project(MLT
   HOMEPAGE_URL "https://www.mltframework.org"
   LANGUAGES C CXX
 )
+# ====================================================================
+# 全局输出目录设置 (强制统一所有目标的输出路径)
+# ====================================================================
+# 设置所有 Release 类型的库文件的输出目录
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin")
 
+# 设置所有 Debug 类型的库文件的输出目录
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/debug/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/debug/bin")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/debug/bin")
+
+# 对于不区分配置的生成器（如 Ninja），直接设置通用变量
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out/bin") # 改为 bin
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out/bin") # 改为 bin
+# ====================================================================
 option(GPL "Enable GPLv2 components" ON)
 option(GPL3 "Enable GPLv3 components" ON)
 option(BUILD_TESTING "Enable tests" OFF)
@@ -74,7 +91,9 @@ include(GNUInstallDirs)
 if(WINDOWS_DEPLOY)
   set(CMAKE_INSTALL_BINDIR .)
 endif()
-
+if (MSVC)
+  find_package(PThreads4W REQUIRED)
+endif ()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/out/lib")
@@ -123,10 +142,17 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
+if (MSVC)
+  # 将 /Zc:C11Atomics 标志附加到所有 C 语言编译器的标志后面
+  # 换成你的编译器版本可能认识的实验性标志
+  add_compile_options("$<$<COMPILE_LANGUAGE:C>:/experimental:c11atomics>")
+#  add_compile_options("/FI${CMAKE_SOURCE_DIR}/src/framework/msvc_posix_compat.h")
+  # 为项目中所有的 target 添加 _USE_MATH_DEFINES 定义
+  add_compile_definitions(_USE_MATH_DEFINES)
+endif()
 list(APPEND MLT_COMPILE_OPTIONS "")
 
 # MSVC cl doesn't support GNU inline assembly (but MSVC-compatible clang-cl does)

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -66,7 +66,7 @@ add_library(mlt SHARED
   mlt_types.c
   mlt_version.c
 )
-
+target_compile_definitions(mlt PRIVATE MLT_EXPORTS)
 add_custom_target("Other_mlt_Files" SOURCES
   chain_normalizers.ini
   metaschema.yaml
@@ -79,9 +79,21 @@ add_library(Mlt${MLT_VERSION_MAJOR}::mlt ALIAS mlt)
 target_sources(mlt PRIVATE ${MLT_PUBLIC_HEADERS})
 
 target_compile_options(mlt PRIVATE ${MLT_COMPILE_OPTIONS})
+if (NOT MSVC)
+  target_link_libraries(mlt PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+else ()
+  # 手动寻找 gettimeofday.lib
+  find_library(GETTIMEOFDAY_LIBRARY
+          NAMES gettimeofday
+          # vcpkg 会自动把正确的搜索路径加进来
+  )
 
-target_link_libraries(mlt PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
-
+  if (NOT GETTIMEOFDAY_LIBRARY)
+    message(FATAL_ERROR "Could not find gettimeofday.lib")
+  endif()
+  target_link_libraries(mlt PUBLIC  PThreads4W::PThreads4W ${CMAKE_DL_LIBS})
+  target_link_libraries(mlt PUBLIC  ${GETTIMEOFDAY_LIBRARY})
+endif ()
 if(NOT MSVC)
   target_link_libraries(mlt PRIVATE m)
 endif()

--- a/src/framework/mlt.h
+++ b/src/framework/mlt.h
@@ -34,7 +34,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#include "mlt_api.h"
 #include "mlt_animation.h"
 #include "mlt_audio.h"
 #include "mlt_cache.h"

--- a/src/framework/mlt_animation.h
+++ b/src/framework/mlt_animation.h
@@ -25,6 +25,7 @@
 
 #include "mlt_property.h"
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /** \brief Animation class
  *
@@ -48,29 +49,29 @@ struct mlt_animation_item_s
 };
 typedef struct mlt_animation_item_s *mlt_animation_item; /**< pointer to an animation item */
 
-extern mlt_animation mlt_animation_new();
-extern int mlt_animation_parse(
+MLT_API extern mlt_animation mlt_animation_new();
+MLT_API extern int mlt_animation_parse(
     mlt_animation self, const char *data, int length, double fps, mlt_locale_t locale);
-extern int mlt_animation_refresh(mlt_animation self, const char *data, int length);
-extern int mlt_animation_get_length(mlt_animation self);
-extern void mlt_animation_set_length(mlt_animation self, int length);
-extern int mlt_animation_parse_item(mlt_animation self, mlt_animation_item item, const char *data);
-extern int mlt_animation_get_item(mlt_animation self, mlt_animation_item item, int position);
-extern int mlt_animation_insert(mlt_animation self, mlt_animation_item item);
-extern int mlt_animation_remove(mlt_animation self, int position);
-extern void mlt_animation_interpolate(mlt_animation self);
-extern int mlt_animation_next_key(mlt_animation self, mlt_animation_item item, int position);
-extern int mlt_animation_prev_key(mlt_animation self, mlt_animation_item item, int position);
-extern char *mlt_animation_serialize_cut_tf(mlt_animation self, int in, int out, mlt_time_format);
-extern char *mlt_animation_serialize_cut(mlt_animation self, int in, int out);
-extern char *mlt_animation_serialize_tf(mlt_animation self, mlt_time_format);
-extern char *mlt_animation_serialize(mlt_animation self);
-extern int mlt_animation_key_count(mlt_animation self);
-extern int mlt_animation_key_get(mlt_animation self, mlt_animation_item item, int index);
-extern void mlt_animation_close(mlt_animation self);
-extern int mlt_animation_key_set_type(mlt_animation self, int index, mlt_keyframe_type type);
-extern int mlt_animation_key_set_frame(mlt_animation self, int index, int frame);
-extern void mlt_animation_shift_frames(mlt_animation self, int shift);
-extern const char *mlt_animation_get_string(mlt_animation self);
+MLT_API extern int mlt_animation_refresh(mlt_animation self, const char *data, int length);
+MLT_API extern int mlt_animation_get_length(mlt_animation self);
+MLT_API extern void mlt_animation_set_length(mlt_animation self, int length);
+MLT_API extern int mlt_animation_parse_item(mlt_animation self, mlt_animation_item item, const char *data);
+MLT_API extern int mlt_animation_get_item(mlt_animation self, mlt_animation_item item, int position);
+MLT_API extern int mlt_animation_insert(mlt_animation self, mlt_animation_item item);
+MLT_API extern int mlt_animation_remove(mlt_animation self, int position);
+MLT_API extern void mlt_animation_interpolate(mlt_animation self);
+MLT_API extern int mlt_animation_next_key(mlt_animation self, mlt_animation_item item, int position);
+MLT_API extern int mlt_animation_prev_key(mlt_animation self, mlt_animation_item item, int position);
+MLT_API extern char *mlt_animation_serialize_cut_tf(mlt_animation self, int in, int out, mlt_time_format);
+MLT_API extern char *mlt_animation_serialize_cut(mlt_animation self, int in, int out);
+MLT_API extern char *mlt_animation_serialize_tf(mlt_animation self, mlt_time_format);
+MLT_API extern char *mlt_animation_serialize(mlt_animation self);
+MLT_API extern int mlt_animation_key_count(mlt_animation self);
+MLT_API extern int mlt_animation_key_get(mlt_animation self, mlt_animation_item item, int index);
+MLT_API extern void mlt_animation_close(mlt_animation self);
+MLT_API extern int mlt_animation_key_set_type(mlt_animation self, int index, mlt_keyframe_type type);
+MLT_API extern int mlt_animation_key_set_frame(mlt_animation self, int index, int frame);
+MLT_API extern void mlt_animation_shift_frames(mlt_animation self, int shift);
+MLT_API extern const char *mlt_animation_get_string(mlt_animation self);
 
 #endif

--- a/src/framework/mlt_api.h
+++ b/src/framework/mlt_api.h
@@ -1,0 +1,17 @@
+//
+// Created by sammiller on 2025/6/21.
+//
+
+#ifndef MLT_API_H
+#define MLT_API_H
+#if defined(_WIN32) && defined(_MSC_VER)
+  #ifdef MLT_EXPORTS
+    #define MLT_API __declspec(dllexport)
+  #else
+    #define MLT_API __declspec(dllimport)
+  #endif
+#else
+  #define MLT_API
+#endif
+
+#endif //MLT_API_H

--- a/src/framework/mlt_audio.h
+++ b/src/framework/mlt_audio.h
@@ -24,7 +24,7 @@
 #define MLT_AUDIO_H
 
 #include "mlt_types.h"
-
+#include "mlt_api.h"
 /** \brief Audio class
  *
  * Audio is the data object that represents audio for a period of time.
@@ -42,33 +42,33 @@ struct mlt_audio_s
     mlt_destructor close;
 };
 
-extern mlt_audio mlt_audio_new();
-extern void mlt_audio_close(mlt_audio self);
-extern void mlt_audio_set_values(
+MLT_API extern mlt_audio mlt_audio_new();
+MLT_API extern void mlt_audio_close(mlt_audio self);
+MLT_API extern void mlt_audio_set_values(
     mlt_audio self, void *data, int frequency, mlt_audio_format format, int samples, int channels);
-extern void mlt_audio_get_values(mlt_audio self,
+MLT_API extern void mlt_audio_get_values(mlt_audio self,
                                  void **data,
                                  int *frequency,
                                  mlt_audio_format *format,
                                  int *samples,
                                  int *channels);
-extern void mlt_audio_alloc_data(mlt_audio self);
-extern void mlt_audio_free_data(mlt_audio self);
-extern int mlt_audio_calculate_size(mlt_audio self);
-extern int mlt_audio_plane_count(mlt_audio self);
-extern int mlt_audio_plane_size(mlt_audio self);
-extern void mlt_audio_get_planes(mlt_audio self, uint8_t **planes);
-extern void mlt_audio_silence(mlt_audio self, int samples, int start);
-extern void mlt_audio_shrink(mlt_audio self, int samples);
-extern void mlt_audio_reverse(mlt_audio self);
-extern void mlt_audio_copy(mlt_audio dst, mlt_audio src, int samples, int src_start, int dst_start);
-extern int mlt_audio_calculate_frame_samples(float fps, int frequency, int64_t position);
-extern int64_t mlt_audio_calculate_samples_to_position(float fps, int frequency, int64_t position);
-extern const char *mlt_audio_format_name(mlt_audio_format format);
-extern int mlt_audio_format_size(mlt_audio_format format, int samples, int channels);
-extern const char *mlt_audio_channel_layout_name(mlt_channel_layout layout);
-extern mlt_channel_layout mlt_audio_channel_layout_id(const char *name);
-extern int mlt_audio_channel_layout_channels(mlt_channel_layout layout);
-extern mlt_channel_layout mlt_audio_channel_layout_default(int channels);
+MLT_API extern void mlt_audio_alloc_data(mlt_audio self);
+MLT_API extern void mlt_audio_free_data(mlt_audio self);
+MLT_API extern int mlt_audio_calculate_size(mlt_audio self);
+MLT_API extern int mlt_audio_plane_count(mlt_audio self);
+MLT_API extern int mlt_audio_plane_size(mlt_audio self);
+MLT_API extern void mlt_audio_get_planes(mlt_audio self, uint8_t **planes);
+MLT_API extern void mlt_audio_silence(mlt_audio self, int samples, int start);
+MLT_API extern void mlt_audio_shrink(mlt_audio self, int samples);
+MLT_API extern void mlt_audio_reverse(mlt_audio self);
+MLT_API extern void mlt_audio_copy(mlt_audio dst, mlt_audio src, int samples, int src_start, int dst_start);
+MLT_API extern int mlt_audio_calculate_frame_samples(float fps, int frequency, int64_t position);
+MLT_API extern int64_t mlt_audio_calculate_samples_to_position(float fps, int frequency, int64_t position);
+MLT_API extern const char *mlt_audio_format_name(mlt_audio_format format);
+MLT_API extern int mlt_audio_format_size(mlt_audio_format format, int samples, int channels);
+MLT_API extern const char *mlt_audio_channel_layout_name(mlt_channel_layout layout);
+MLT_API extern mlt_channel_layout mlt_audio_channel_layout_id(const char *name);
+MLT_API extern int mlt_audio_channel_layout_channels(mlt_channel_layout layout);
+MLT_API extern mlt_channel_layout mlt_audio_channel_layout_default(int channels);
 
 #endif

--- a/src/framework/mlt_cache.h
+++ b/src/framework/mlt_cache.h
@@ -24,21 +24,22 @@
 #define MLT_CACHE_H
 
 #include "mlt_types.h"
+#include "mlt_api.h"
 
-extern void *mlt_cache_item_data(mlt_cache_item item, int *size);
-extern void mlt_cache_item_close(mlt_cache_item item);
+MLT_API extern void *mlt_cache_item_data(mlt_cache_item item, int *size);
+MLT_API extern void mlt_cache_item_close(mlt_cache_item item);
 
-extern mlt_cache mlt_cache_init();
-extern void mlt_cache_set_size(mlt_cache cache, int size);
-extern int mlt_cache_get_size(mlt_cache cache);
-extern void mlt_cache_close(mlt_cache cache);
-extern void mlt_cache_purge(mlt_cache cache, void *object);
-extern void mlt_cache_put(
+MLT_API extern mlt_cache mlt_cache_init();
+MLT_API extern void mlt_cache_set_size(mlt_cache cache, int size);
+MLT_API extern int mlt_cache_get_size(mlt_cache cache);
+MLT_API extern void mlt_cache_close(mlt_cache cache);
+MLT_API extern void mlt_cache_purge(mlt_cache cache, void *object);
+MLT_API extern void mlt_cache_put(
     mlt_cache cache, void *object, void *data, int size, mlt_destructor destructor);
-extern mlt_cache_item mlt_cache_get(mlt_cache cache, void *object);
-extern void mlt_cache_put_frame(mlt_cache cache, mlt_frame frame);
-extern void mlt_cache_put_frame_audio(mlt_cache cache, mlt_frame frame);
-extern void mlt_cache_put_frame_image(mlt_cache cache, mlt_frame frame);
-extern mlt_frame mlt_cache_get_frame(mlt_cache cache, mlt_position position);
+MLT_API extern mlt_cache_item mlt_cache_get(mlt_cache cache, void *object);
+MLT_API extern void mlt_cache_put_frame(mlt_cache cache, mlt_frame frame);
+MLT_API extern void mlt_cache_put_frame_audio(mlt_cache cache, mlt_frame frame);
+MLT_API extern void mlt_cache_put_frame_image(mlt_cache cache, mlt_frame frame);
+MLT_API extern mlt_frame mlt_cache_get_frame(mlt_cache cache, mlt_position position);
 
 #endif

--- a/src/framework/mlt_chain.h
+++ b/src/framework/mlt_chain.h
@@ -25,6 +25,7 @@
 
 #include "mlt_link.h"
 #include "mlt_producer.h"
+#include "mlt_api.h"
 
 /** \brief Chain class
  *
@@ -43,15 +44,15 @@ struct mlt_chain_s
 #define MLT_CHAIN_SERVICE(chain) MLT_PRODUCER_SERVICE(MLT_CHAIN_PRODUCER(chain))
 #define MLT_CHAIN_PROPERTIES(chain) MLT_SERVICE_PROPERTIES(MLT_CHAIN_SERVICE(chain))
 
-extern mlt_chain mlt_chain_init(mlt_profile);
-extern void mlt_chain_set_source(mlt_chain self, mlt_producer source);
-extern mlt_producer mlt_chain_get_source(mlt_chain self);
-extern int mlt_chain_attach(mlt_chain self, mlt_link link);
-extern int mlt_chain_detach(mlt_chain self, mlt_link link);
-extern int mlt_chain_link_count(mlt_chain self);
-extern int mlt_chain_move_link(mlt_chain self, int from, int to);
-extern mlt_link mlt_chain_link(mlt_chain self, int index);
-extern void mlt_chain_close(mlt_chain self);
-extern void mlt_chain_attach_normalizers(mlt_chain self);
+MLT_API extern mlt_chain mlt_chain_init(mlt_profile);
+MLT_API extern void mlt_chain_set_source(mlt_chain self, mlt_producer source);
+MLT_API extern mlt_producer mlt_chain_get_source(mlt_chain self);
+MLT_API extern int mlt_chain_attach(mlt_chain self, mlt_link link);
+MLT_API extern int mlt_chain_detach(mlt_chain self, mlt_link link);
+MLT_API extern int mlt_chain_link_count(mlt_chain self);
+MLT_API extern int mlt_chain_move_link(mlt_chain self, int from, int to);
+MLT_API extern mlt_link mlt_chain_link(mlt_chain self, int index);
+MLT_API extern void mlt_chain_close(mlt_chain self);
+MLT_API extern void mlt_chain_attach_normalizers(mlt_chain self);
 
 #endif

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -31,7 +31,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 /** Define this if you want an automatic deinterlace (if necessary) when the
  * consumer's producer is not running at normal speed.
@@ -40,11 +44,11 @@
 
 /** This is not the ideal place for this, but it is needed by VDPAU as well.
  */
-pthread_mutex_t mlt_sdl_mutex = PTHREAD_MUTEX_INITIALIZER;
+MLT_API  pthread_mutex_t mlt_sdl_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /** mlt_frame_s::is_processing can not be made atomic, so protect it with a mutex.
  */
-pthread_mutex_t mlt_frame_processing_mutex = PTHREAD_MUTEX_INITIALIZER;
+MLT_API  pthread_mutex_t mlt_frame_processing_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /** \brief private members of mlt_consumer */
 

--- a/src/framework/mlt_consumer.h
+++ b/src/framework/mlt_consumer.h
@@ -25,6 +25,7 @@
 
 #include "mlt_events.h"
 #include "mlt_service.h"
+#include "mlt_api.h"
 #include <pthread.h>
 
 /** \brief Consumer abstract service class
@@ -135,20 +136,21 @@ struct mlt_consumer_s
 #define MLT_CONSUMER_SERVICE(consumer) (&(consumer)->parent)
 #define MLT_CONSUMER_PROPERTIES(consumer) MLT_SERVICE_PROPERTIES(MLT_CONSUMER_SERVICE(consumer))
 
-extern int mlt_consumer_init(mlt_consumer self, void *child, mlt_profile profile);
-extern mlt_consumer mlt_consumer_new(mlt_profile profile);
-extern mlt_service mlt_consumer_service(mlt_consumer self);
-extern mlt_properties mlt_consumer_properties(mlt_consumer self);
-extern int mlt_consumer_connect(mlt_consumer self, mlt_service producer);
-extern int mlt_consumer_start(mlt_consumer self);
-extern void mlt_consumer_purge(mlt_consumer self);
-extern int mlt_consumer_put_frame(mlt_consumer self, mlt_frame frame);
-extern mlt_frame mlt_consumer_get_frame(mlt_consumer self);
-extern mlt_frame mlt_consumer_rt_frame(mlt_consumer self);
-extern int mlt_consumer_stop(mlt_consumer self);
-extern int mlt_consumer_is_stopped(mlt_consumer self);
-extern void mlt_consumer_stopped(mlt_consumer self);
-extern void mlt_consumer_close(mlt_consumer);
-extern mlt_position mlt_consumer_position(mlt_consumer);
+MLT_API extern int mlt_consumer_init(mlt_consumer self, void *child, mlt_profile profile);
+MLT_API extern mlt_consumer mlt_consumer_new(mlt_profile profile);
+MLT_API extern mlt_service mlt_consumer_service(mlt_consumer self);
+MLT_API extern mlt_properties mlt_consumer_properties(mlt_consumer self);
+MLT_API extern int mlt_consumer_connect(mlt_consumer self, mlt_service producer);
+MLT_API extern int mlt_consumer_start(mlt_consumer self);
+MLT_API extern void mlt_consumer_purge(mlt_consumer self);
+MLT_API extern int mlt_consumer_put_frame(mlt_consumer self, mlt_frame frame);
+MLT_API extern mlt_frame mlt_consumer_get_frame(mlt_consumer self);
+MLT_API extern mlt_frame mlt_consumer_rt_frame(mlt_consumer self);
+MLT_API extern int mlt_consumer_stop(mlt_consumer self);
+MLT_API extern int mlt_consumer_is_stopped(mlt_consumer self);
+MLT_API extern void mlt_consumer_stopped(mlt_consumer self);
+MLT_API extern void mlt_consumer_close(mlt_consumer);
+MLT_API extern mlt_position mlt_consumer_position(mlt_consumer);
 
+extern MLT_API pthread_mutex_t mlt_sdl_mutex;
 #endif

--- a/src/framework/mlt_deque.h
+++ b/src/framework/mlt_deque.h
@@ -24,7 +24,7 @@
 #define MLT_DEQUE_H
 
 #include "mlt_types.h"
-
+#include "mlt_api.h"
 /** The callback function used to compare items for insert sort.
  *
  * \public \memberof mlt_deque_s
@@ -34,31 +34,31 @@
 */
 typedef int (*mlt_deque_compare)(void *a, void *b);
 
-extern mlt_deque mlt_deque_init();
-extern int mlt_deque_count(mlt_deque self);
-extern int mlt_deque_push_back(mlt_deque self, void *item);
-extern void *mlt_deque_pop_back(mlt_deque self);
-extern int mlt_deque_push_front(mlt_deque self, void *item);
-extern void *mlt_deque_pop_front(mlt_deque self);
-extern void *mlt_deque_peek_back(mlt_deque self);
-extern void *mlt_deque_peek_front(mlt_deque self);
-extern void *mlt_deque_peek(mlt_deque self, int index);
-extern int mlt_deque_insert(mlt_deque self, void *item, mlt_deque_compare);
+MLT_API extern mlt_deque mlt_deque_init();
+MLT_API extern int mlt_deque_count(mlt_deque self);
+MLT_API extern int mlt_deque_push_back(mlt_deque self, void *item);
+MLT_API extern void *mlt_deque_pop_back(mlt_deque self);
+MLT_API extern int mlt_deque_push_front(mlt_deque self, void *item);
+MLT_API extern void *mlt_deque_pop_front(mlt_deque self);
+MLT_API extern void *mlt_deque_peek_back(mlt_deque self);
+MLT_API extern void *mlt_deque_peek_front(mlt_deque self);
+MLT_API extern void *mlt_deque_peek(mlt_deque self, int index);
+MLT_API extern int mlt_deque_insert(mlt_deque self, void *item, mlt_deque_compare);
 
-extern int mlt_deque_push_back_int(mlt_deque self, int item);
-extern int mlt_deque_pop_back_int(mlt_deque self);
-extern int mlt_deque_push_front_int(mlt_deque self, int item);
-extern int mlt_deque_pop_front_int(mlt_deque self);
-extern int mlt_deque_peek_back_int(mlt_deque self);
-extern int mlt_deque_peek_front_int(mlt_deque self);
+MLT_API extern int mlt_deque_push_back_int(mlt_deque self, int item);
+MLT_API extern int mlt_deque_pop_back_int(mlt_deque self);
+MLT_API extern int mlt_deque_push_front_int(mlt_deque self, int item);
+MLT_API extern int mlt_deque_pop_front_int(mlt_deque self);
+MLT_API extern int mlt_deque_peek_back_int(mlt_deque self);
+MLT_API extern int mlt_deque_peek_front_int(mlt_deque self);
 
-extern int mlt_deque_push_back_double(mlt_deque self, double item);
-extern double mlt_deque_pop_back_double(mlt_deque self);
-extern int mlt_deque_push_front_double(mlt_deque self, double item);
-extern double mlt_deque_pop_front_double(mlt_deque self);
-extern double mlt_deque_peek_back_double(mlt_deque self);
-extern double mlt_deque_peek_front_double(mlt_deque self);
+MLT_API extern int mlt_deque_push_back_double(mlt_deque self, double item);
+MLT_API extern double mlt_deque_pop_back_double(mlt_deque self);
+MLT_API extern int mlt_deque_push_front_double(mlt_deque self, double item);
+MLT_API extern double mlt_deque_pop_front_double(mlt_deque self);
+MLT_API extern double mlt_deque_peek_back_double(mlt_deque self);
+MLT_API extern double mlt_deque_peek_front_double(mlt_deque self);
 
-extern void mlt_deque_close(mlt_deque self);
+MLT_API extern void mlt_deque_close(mlt_deque self);
 
 #endif

--- a/src/framework/mlt_events.h
+++ b/src/framework/mlt_events.h
@@ -24,7 +24,7 @@
 #define MLT_EVENTS_H
 
 #include "mlt_types.h"
-
+#include "mlt_api.h"
 /** A container for data that may be supplied with an event */
 typedef struct
 {
@@ -50,34 +50,34 @@ typedef struct
  */
 typedef void (*mlt_listener)(mlt_properties, void *, mlt_event_data);
 
-extern void mlt_events_init(mlt_properties self);
-extern int mlt_events_register(mlt_properties self, const char *id);
-extern int mlt_events_fire(mlt_properties self, const char *id, mlt_event_data);
-extern mlt_event mlt_events_listen(mlt_properties self,
+MLT_API extern void mlt_events_init(mlt_properties self);
+MLT_API extern int mlt_events_register(mlt_properties self, const char *id);
+MLT_API extern int mlt_events_fire(mlt_properties self, const char *id, mlt_event_data);
+MLT_API extern mlt_event mlt_events_listen(mlt_properties self,
                                    void *listener_data,
                                    const char *id,
                                    mlt_listener listener);
-extern void mlt_events_block(mlt_properties self, void *listener_data);
-extern void mlt_events_unblock(mlt_properties self, void *listener_data);
-extern void mlt_events_disconnect(mlt_properties self, void *listener_data);
+MLT_API extern void mlt_events_block(mlt_properties self, void *listener_data);
+MLT_API extern void mlt_events_unblock(mlt_properties self, void *listener_data);
+MLT_API extern void mlt_events_disconnect(mlt_properties self, void *listener_data);
 
-extern mlt_event mlt_events_setup_wait_for(mlt_properties self, const char *id);
-extern void mlt_events_wait_for(mlt_properties self, mlt_event event);
-extern void mlt_events_close_wait_for(mlt_properties self, mlt_event event);
+MLT_API extern mlt_event mlt_events_setup_wait_for(mlt_properties self, const char *id);
+MLT_API extern void mlt_events_wait_for(mlt_properties self, mlt_event event);
+MLT_API extern void mlt_events_close_wait_for(mlt_properties self, mlt_event event);
 
-extern void mlt_event_inc_ref(mlt_event self);
-extern void mlt_event_block(mlt_event self);
-extern void mlt_event_unblock(mlt_event self);
-extern void mlt_event_close(mlt_event self);
+MLT_API extern void mlt_event_inc_ref(mlt_event self);
+MLT_API extern void mlt_event_block(mlt_event self);
+MLT_API extern void mlt_event_unblock(mlt_event self);
+MLT_API extern void mlt_event_close(mlt_event self);
 
-extern mlt_event_data mlt_event_data_none();
-extern mlt_event_data mlt_event_data_from_int(int value);
-extern int mlt_event_data_to_int(mlt_event_data);
-extern mlt_event_data mlt_event_data_from_string(const char *value);
-extern const char *mlt_event_data_to_string(mlt_event_data);
-extern mlt_event_data mlt_event_data_from_frame(mlt_frame);
-extern mlt_frame mlt_event_data_to_frame(mlt_event_data);
-extern mlt_event_data mlt_event_data_from_object(void *);
-extern void *mlt_event_data_to_object(mlt_event_data);
+MLT_API extern mlt_event_data mlt_event_data_none();
+MLT_API extern mlt_event_data mlt_event_data_from_int(int value);
+MLT_API extern int mlt_event_data_to_int(mlt_event_data);
+MLT_API extern mlt_event_data mlt_event_data_from_string(const char *value);
+MLT_API extern const char *mlt_event_data_to_string(mlt_event_data);
+MLT_API extern mlt_event_data mlt_event_data_from_frame(mlt_frame);
+MLT_API extern mlt_frame mlt_event_data_to_frame(mlt_event_data);
+MLT_API extern mlt_event_data mlt_event_data_from_object(void *);
+MLT_API extern void *mlt_event_data_to_object(mlt_event_data);
 
 #endif

--- a/src/framework/mlt_factory.c
+++ b/src/framework/mlt_factory.c
@@ -22,7 +22,40 @@
 #include "mlt.h"
 #include "mlt_repository.h"
 
-#include <libgen.h>
+#ifdef _MSC_VER
+    #include <string.h> // for strrchr
+
+    // 为 MSVC 提供一个简单的 basename 实现
+    // 注意：这个实现返回一个指向原始字符串内部的指针
+    static inline char *basename(char *path) {
+        if (path == NULL || *path == '\0') {
+            // 如果路径为空或空字符串，返回"."
+            return ".";
+        }
+
+        // 查找最后一个路径分隔符（'/' 或 '\'）
+        char *last_slash = strrchr(path, '/');
+        char *last_bslash = strrchr(path, '\\');
+
+        if (last_slash && last_bslash) {
+            // 如果两者都存在，取后面的那一个
+            last_slash = (last_slash > last_bslash) ? last_slash : last_bslash;
+        } else if (last_bslash) {
+            // 如果只有反斜杠
+            last_slash = last_bslash;
+        }
+
+        if (last_slash != NULL) {
+            // 如果找到了分隔符，返回它后面的字符
+            return last_slash + 1;
+        } else {
+            // 如果没有找到分隔符，整个字符串就是文件名
+            return path;
+        }
+    }
+#else
+    #include <libgen.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -57,7 +90,9 @@
 /** the default subdirectory of the install prefix for holding module (plugin) data */
 #define PREFIX_DATA "/Resources/mlt"
 #else
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #define PREFIX_LIB "/lib/mlt-7"
 /** the default subdirectory of the install prefix for holding module (plugin) data */
 #define PREFIX_DATA "/share/mlt-7"

--- a/src/framework/mlt_factory.h
+++ b/src/framework/mlt_factory.h
@@ -25,6 +25,7 @@
 #include "mlt_profile.h"
 #include "mlt_repository.h"
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /**
  * \envvar \em MLT_PRODUCER the name of a default producer often used by other services, defaults to "loader"
@@ -59,26 +60,26 @@
  *   the event data is a pointer to mlt_factory_event_data
  */
 
-extern mlt_repository mlt_factory_init(const char *directory);
-extern mlt_repository mlt_factory_repository();
-extern const char *mlt_factory_directory();
-extern char *mlt_environment(const char *name);
-extern int mlt_environment_set(const char *name, const char *value);
-extern mlt_properties mlt_factory_event_object();
-extern mlt_producer mlt_factory_producer(mlt_profile profile,
+MLT_API extern mlt_repository mlt_factory_init(const char *directory);
+MLT_API extern mlt_repository mlt_factory_repository();
+MLT_API extern const char *mlt_factory_directory();
+MLT_API extern char *mlt_environment(const char *name);
+MLT_API extern int mlt_environment_set(const char *name, const char *value);
+MLT_API extern mlt_properties mlt_factory_event_object();
+MLT_API extern mlt_producer mlt_factory_producer(mlt_profile profile,
                                          const char *service,
                                          const void *resource);
-extern mlt_filter mlt_factory_filter(mlt_profile profile, const char *service, const void *input);
-extern mlt_link mlt_factory_link(const char *service, const void *input);
-extern mlt_transition mlt_factory_transition(mlt_profile profile,
+MLT_API extern mlt_filter mlt_factory_filter(mlt_profile profile, const char *service, const void *input);
+MLT_API extern mlt_link mlt_factory_link(const char *service, const void *input);
+MLT_API extern mlt_transition mlt_factory_transition(mlt_profile profile,
                                              const char *service,
                                              const void *input);
-extern mlt_consumer mlt_factory_consumer(mlt_profile profile,
+MLT_API extern mlt_consumer mlt_factory_consumer(mlt_profile profile,
                                          const char *service,
                                          const void *input);
-extern void mlt_factory_register_for_clean_up(void *ptr, mlt_destructor destructor);
-extern void mlt_factory_close();
-extern mlt_properties mlt_global_properties();
+MLT_API extern void mlt_factory_register_for_clean_up(void *ptr, mlt_destructor destructor);
+MLT_API extern void mlt_factory_close();
+MLT_API extern mlt_properties mlt_global_properties();
 
 /** The event data for all factory-related events */
 

--- a/src/framework/mlt_field.h
+++ b/src/framework/mlt_field.h
@@ -24,16 +24,17 @@
 #define MLT_FIELD_H
 
 #include "mlt_types.h"
+#include "mlt_api.h"
 
-extern mlt_field mlt_field_init();
-extern mlt_field mlt_field_new(mlt_multitrack multitrack, mlt_tractor tractor);
-extern mlt_service mlt_field_service(mlt_field self);
-extern mlt_tractor mlt_field_tractor(mlt_field self);
-extern mlt_multitrack mlt_field_multitrack(mlt_field self);
-extern mlt_properties mlt_field_properties(mlt_field self);
-extern int mlt_field_plant_filter(mlt_field self, mlt_filter that, int track);
-extern int mlt_field_plant_transition(mlt_field self, mlt_transition that, int a_track, int b_track);
-extern void mlt_field_close(mlt_field self);
-extern void mlt_field_disconnect_service(mlt_field self, mlt_service service);
+MLT_API extern mlt_field mlt_field_init();
+MLT_API extern mlt_field mlt_field_new(mlt_multitrack multitrack, mlt_tractor tractor);
+MLT_API extern mlt_service mlt_field_service(mlt_field self);
+MLT_API extern mlt_tractor mlt_field_tractor(mlt_field self);
+MLT_API extern mlt_multitrack mlt_field_multitrack(mlt_field self);
+MLT_API extern mlt_properties mlt_field_properties(mlt_field self);
+MLT_API extern int mlt_field_plant_filter(mlt_field self, mlt_filter that, int track);
+MLT_API extern int mlt_field_plant_transition(mlt_field self, mlt_transition that, int a_track, int b_track);
+MLT_API extern void mlt_field_close(mlt_field self);
+MLT_API extern void mlt_field_disconnect_service(mlt_field self, mlt_service service);
 
 #endif

--- a/src/framework/mlt_filter.h
+++ b/src/framework/mlt_filter.h
@@ -24,6 +24,7 @@
 #define MLT_FILTER_H
 
 #include "mlt_service.h"
+#include "mlt_api.h"
 
 /** \brief Filter abstract service class
  *
@@ -54,20 +55,20 @@ struct mlt_filter_s
 #define MLT_FILTER_SERVICE(filter) (&(filter)->parent)
 #define MLT_FILTER_PROPERTIES(filter) MLT_SERVICE_PROPERTIES(MLT_FILTER_SERVICE(filter))
 
-extern int mlt_filter_init(mlt_filter self, void *child);
-extern mlt_filter mlt_filter_new();
-extern mlt_service mlt_filter_service(mlt_filter self);
-extern mlt_properties mlt_filter_properties(mlt_filter self);
-extern mlt_frame mlt_filter_process(mlt_filter self, mlt_frame that);
-extern int mlt_filter_connect(mlt_filter self, mlt_service producer, int index);
-extern void mlt_filter_set_in_and_out(mlt_filter self, mlt_position in, mlt_position out);
-extern int mlt_filter_get_track(mlt_filter self);
-extern mlt_position mlt_filter_get_in(mlt_filter self);
-extern mlt_position mlt_filter_get_out(mlt_filter self);
-extern mlt_position mlt_filter_get_length(mlt_filter self);
-extern mlt_position mlt_filter_get_length2(mlt_filter self, mlt_frame frame);
-extern mlt_position mlt_filter_get_position(mlt_filter self, mlt_frame frame);
-extern double mlt_filter_get_progress(mlt_filter self, mlt_frame frame);
-extern void mlt_filter_close(mlt_filter);
+MLT_API extern int mlt_filter_init(mlt_filter self, void *child);
+MLT_API extern mlt_filter mlt_filter_new();
+MLT_API extern mlt_service mlt_filter_service(mlt_filter self);
+MLT_API extern mlt_properties mlt_filter_properties(mlt_filter self);
+MLT_API extern mlt_frame mlt_filter_process(mlt_filter self, mlt_frame that);
+MLT_API extern int mlt_filter_connect(mlt_filter self, mlt_service producer, int index);
+MLT_API extern void mlt_filter_set_in_and_out(mlt_filter self, mlt_position in, mlt_position out);
+MLT_API extern int mlt_filter_get_track(mlt_filter self);
+MLT_API extern mlt_position mlt_filter_get_in(mlt_filter self);
+MLT_API extern mlt_position mlt_filter_get_out(mlt_filter self);
+MLT_API extern mlt_position mlt_filter_get_length(mlt_filter self);
+MLT_API extern mlt_position mlt_filter_get_length2(mlt_filter self, mlt_frame frame);
+MLT_API extern mlt_position mlt_filter_get_position(mlt_filter self, mlt_frame frame);
+MLT_API extern double mlt_filter_get_progress(mlt_filter self, mlt_frame frame);
+MLT_API extern void mlt_filter_close(mlt_filter);
 
 #endif

--- a/src/framework/mlt_frame.h
+++ b/src/framework/mlt_frame.h
@@ -28,7 +28,7 @@
 #include "mlt_image.h"
 #include "mlt_properties.h"
 #include "mlt_service.h"
-
+#include "mlt_api.h"
 /** Callback function to get video data.
  *
  */
@@ -125,57 +125,57 @@ struct mlt_frame_s
 #define MLT_FRAME_IMAGE_STACK(frame) ((frame)->stack_image)
 #define MLT_FRAME_AUDIO_STACK(frame) ((frame)->stack_audio)
 
-extern mlt_frame mlt_frame_init(mlt_service service);
-extern mlt_properties mlt_frame_properties(mlt_frame self);
-extern int mlt_frame_is_test_card(mlt_frame self);
-extern int mlt_frame_is_test_audio(mlt_frame self);
-extern double mlt_frame_get_aspect_ratio(mlt_frame self);
-extern int mlt_frame_set_aspect_ratio(mlt_frame self, double value);
-extern mlt_position mlt_frame_get_position(mlt_frame self);
-extern mlt_position mlt_frame_original_position(mlt_frame self);
-extern int mlt_frame_set_position(mlt_frame self, mlt_position value);
-extern int mlt_frame_set_image(mlt_frame self, uint8_t *image, int size, mlt_destructor destroy);
-extern int mlt_frame_set_alpha(mlt_frame self, uint8_t *alpha, int size, mlt_destructor destroy);
-extern void mlt_frame_replace_image(
+MLT_API extern mlt_frame mlt_frame_init(mlt_service service);
+MLT_API extern mlt_properties mlt_frame_properties(mlt_frame self);
+MLT_API extern int mlt_frame_is_test_card(mlt_frame self);
+MLT_API extern int mlt_frame_is_test_audio(mlt_frame self);
+MLT_API extern double mlt_frame_get_aspect_ratio(mlt_frame self);
+MLT_API extern int mlt_frame_set_aspect_ratio(mlt_frame self, double value);
+MLT_API extern mlt_position mlt_frame_get_position(mlt_frame self);
+MLT_API extern mlt_position mlt_frame_original_position(mlt_frame self);
+MLT_API extern int mlt_frame_set_position(mlt_frame self, mlt_position value);
+MLT_API extern int mlt_frame_set_image(mlt_frame self, uint8_t *image, int size, mlt_destructor destroy);
+MLT_API extern int mlt_frame_set_alpha(mlt_frame self, uint8_t *alpha, int size, mlt_destructor destroy);
+MLT_API extern void mlt_frame_replace_image(
     mlt_frame self, uint8_t *image, mlt_image_format format, int width, int height);
-extern int mlt_frame_get_image(mlt_frame self,
+MLT_API extern int mlt_frame_get_image(mlt_frame self,
                                uint8_t **buffer,
                                mlt_image_format *format,
                                int *width,
                                int *height,
                                int writable);
-extern uint8_t *mlt_frame_get_alpha(mlt_frame self);
-extern uint8_t *mlt_frame_get_alpha_size(mlt_frame self, int *size);
-extern int mlt_frame_get_audio(mlt_frame self,
+MLT_API extern uint8_t *mlt_frame_get_alpha(mlt_frame self);
+MLT_API extern uint8_t *mlt_frame_get_alpha_size(mlt_frame self, int *size);
+MLT_API extern int mlt_frame_get_audio(mlt_frame self,
                                void **buffer,
                                mlt_audio_format *format,
                                int *frequency,
                                int *channels,
                                int *samples);
-extern int mlt_frame_set_audio(
+MLT_API extern int mlt_frame_set_audio(
     mlt_frame self, void *buffer, mlt_audio_format, int size, mlt_destructor);
-extern unsigned char *mlt_frame_get_waveform(mlt_frame self, int w, int h);
-extern int mlt_frame_push_get_image(mlt_frame self, mlt_get_image get_image);
-extern mlt_get_image mlt_frame_pop_get_image(mlt_frame self);
-extern int mlt_frame_push_frame(mlt_frame self, mlt_frame that);
-extern mlt_frame mlt_frame_pop_frame(mlt_frame self);
-extern int mlt_frame_push_service(mlt_frame self, void *that);
-extern void *mlt_frame_pop_service(mlt_frame self);
-extern int mlt_frame_push_service_int(mlt_frame self, int that);
-extern int mlt_frame_pop_service_int(mlt_frame self);
-extern int mlt_frame_push_audio(mlt_frame self, void *that);
-extern void *mlt_frame_pop_audio(mlt_frame self);
-extern mlt_deque mlt_frame_service_stack(mlt_frame self);
-extern mlt_producer mlt_frame_get_original_producer(mlt_frame self);
-extern void mlt_frame_close(mlt_frame self);
-extern mlt_properties mlt_frame_unique_properties(mlt_frame self, mlt_service service);
-extern mlt_properties mlt_frame_get_unique_properties(mlt_frame self, mlt_service service);
-extern mlt_frame mlt_frame_clone(mlt_frame self, int is_deep);
-extern mlt_frame mlt_frame_clone_audio(mlt_frame self, int is_deep);
-extern mlt_frame mlt_frame_clone_image(mlt_frame self, int is_deep);
+MLT_API extern unsigned char *mlt_frame_get_waveform(mlt_frame self, int w, int h);
+MLT_API extern int mlt_frame_push_get_image(mlt_frame self, mlt_get_image get_image);
+MLT_API extern mlt_get_image mlt_frame_pop_get_image(mlt_frame self);
+MLT_API extern int mlt_frame_push_frame(mlt_frame self, mlt_frame that);
+MLT_API extern mlt_frame mlt_frame_pop_frame(mlt_frame self);
+MLT_API extern int mlt_frame_push_service(mlt_frame self, void *that);
+MLT_API extern void *mlt_frame_pop_service(mlt_frame self);
+MLT_API extern int mlt_frame_push_service_int(mlt_frame self, int that);
+MLT_API extern int mlt_frame_pop_service_int(mlt_frame self);
+MLT_API extern int mlt_frame_push_audio(mlt_frame self, void *that);
+MLT_API extern void *mlt_frame_pop_audio(mlt_frame self);
+MLT_API extern mlt_deque mlt_frame_service_stack(mlt_frame self);
+MLT_API extern mlt_producer mlt_frame_get_original_producer(mlt_frame self);
+MLT_API extern void mlt_frame_close(mlt_frame self);
+MLT_API extern mlt_properties mlt_frame_unique_properties(mlt_frame self, mlt_service service);
+MLT_API extern mlt_properties mlt_frame_get_unique_properties(mlt_frame self, mlt_service service);
+MLT_API extern mlt_frame mlt_frame_clone(mlt_frame self, int is_deep);
+MLT_API extern mlt_frame mlt_frame_clone_audio(mlt_frame self, int is_deep);
+MLT_API extern mlt_frame mlt_frame_clone_image(mlt_frame self, int is_deep);
 
 /* convenience functions */
-extern void mlt_frame_write_ppm(mlt_frame frame);
+MLT_API extern void mlt_frame_write_ppm(mlt_frame frame);
 
 /** This macro scales RGB into the YUV gamut - y is scaled by 219/255 and uv by 224/255. */
 #define RGB2YUV_601_SCALED(r, g, b, y, u, v) \

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -24,6 +24,7 @@
 #define MLT_IMAGE_H
 
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /** \brief Image class
  *
@@ -46,27 +47,27 @@ struct mlt_image_s
     mlt_destructor close;
 };
 
-extern mlt_image mlt_image_new();
-extern void mlt_image_close(mlt_image self);
-extern void mlt_image_set_values(
+MLT_API extern mlt_image mlt_image_new();
+MLT_API extern void mlt_image_close(mlt_image self);
+MLT_API extern void mlt_image_set_values(
     mlt_image self, void *data, mlt_image_format format, int width, int height);
-extern void mlt_image_get_values(
+MLT_API extern void mlt_image_get_values(
     mlt_image self, void **data, mlt_image_format *format, int *width, int *height);
-extern void mlt_image_alloc_data(mlt_image self);
-extern void mlt_image_alloc_alpha(mlt_image self);
-extern int mlt_image_calculate_size(mlt_image self);
-extern void mlt_image_fill_black(mlt_image self);
-extern void mlt_image_fill_checkerboard(mlt_image self, double sample_aspect_ratio);
-extern void mlt_image_fill_white(mlt_image self, int full_range);
-extern void mlt_image_fill_opaque(mlt_image self);
-extern const char *mlt_image_format_name(mlt_image_format format);
-extern mlt_image_format mlt_image_format_id(const char *name);
-extern int mlt_image_rgba_opaque(uint8_t *image, int width, int height);
-extern int mlt_image_full_range(const char *color_range);
+MLT_API extern void mlt_image_alloc_data(mlt_image self);
+MLT_API extern void mlt_image_alloc_alpha(mlt_image self);
+MLT_API extern int mlt_image_calculate_size(mlt_image self);
+MLT_API extern void mlt_image_fill_black(mlt_image self);
+MLT_API extern void mlt_image_fill_checkerboard(mlt_image self, double sample_aspect_ratio);
+MLT_API extern void mlt_image_fill_white(mlt_image self, int full_range);
+MLT_API extern void mlt_image_fill_opaque(mlt_image self);
+MLT_API extern const char *mlt_image_format_name(mlt_image_format format);
+MLT_API extern mlt_image_format mlt_image_format_id(const char *name);
+MLT_API extern int mlt_image_rgba_opaque(uint8_t *image, int width, int height);
+MLT_API extern int mlt_image_full_range(const char *color_range);
 
 // Deprecated functions
-extern int mlt_image_format_size(mlt_image_format format, int width, int height, int *bpp);
-extern void mlt_image_format_planes(
+MLT_API extern int mlt_image_format_size(mlt_image_format format, int width, int height, int *bpp);
+MLT_API extern void mlt_image_format_planes(
     mlt_image_format format, int width, int height, void *data, uint8_t *planes[4], int strides[4]);
 
 #endif

--- a/src/framework/mlt_link.h
+++ b/src/framework/mlt_link.h
@@ -24,6 +24,7 @@
 #define MLT_LINK_H
 
 #include "mlt_producer.h"
+#include "mlt_api.h"
 
 /** \brief Link class
  *
@@ -69,15 +70,15 @@ struct mlt_link_s
 #define MLT_LINK_SERVICE(link) MLT_PRODUCER_SERVICE(MLT_LINK_PRODUCER(link))
 #define MLT_LINK_PROPERTIES(link) MLT_SERVICE_PROPERTIES(MLT_LINK_SERVICE(link))
 
-extern mlt_link mlt_link_init();
-extern int mlt_link_connect_next(mlt_link self, mlt_producer next, mlt_profile chain_profile);
-extern void mlt_link_close(mlt_link self);
+MLT_API extern mlt_link mlt_link_init();
+MLT_API extern int mlt_link_connect_next(mlt_link self, mlt_producer next, mlt_profile chain_profile);
+MLT_API extern void mlt_link_close(mlt_link self);
 
 // Link filter wrapper functions
-extern mlt_link mlt_link_filter_init(mlt_profile profile,
+MLT_API extern mlt_link mlt_link_filter_init(mlt_profile profile,
                                      mlt_service_type type,
                                      const char *id,
                                      char *arg);
-extern mlt_properties mlt_link_filter_metadata(mlt_service_type type, const char *id, void *data);
+MLT_API extern mlt_properties mlt_link_filter_metadata(mlt_service_type type, const char *id, void *data);
 
 #endif

--- a/src/framework/mlt_log.c
+++ b/src/framework/mlt_log.c
@@ -24,7 +24,11 @@
 
 #include <string.h>
 #ifndef NDEBUG
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #include <time.h>
 #endif
 

--- a/src/framework/mlt_log.h
+++ b/src/framework/mlt_log.h
@@ -24,7 +24,7 @@
 
 #include <stdarg.h>
 #include <stdint.h>
-
+#include "mlt_api.h"
 #define MLT_LOG_QUIET -8
 
 /**
@@ -77,25 +77,42 @@
 void mlt_log(void *service, int level, const char *fmt, ...)
     __attribute__((__format__(__printf__, 3, 4)));
 #else
-void mlt_log(void *service, int level, const char *fmt, ...);
+MLT_API void mlt_log(void *service, int level, const char *fmt, ...);
 #endif
 
-#define mlt_log_panic(service, format, args...) mlt_log((service), MLT_LOG_PANIC, (format), ##args)
-#define mlt_log_fatal(service, format, args...) mlt_log((service), MLT_LOG_FATAL, (format), ##args)
-#define mlt_log_error(service, format, args...) mlt_log((service), MLT_LOG_ERROR, (format), ##args)
-#define mlt_log_warning(service, format, args...) \
-    mlt_log((service), MLT_LOG_WARNING, (format), ##args)
-#define mlt_log_info(service, format, args...) mlt_log((service), MLT_LOG_INFO, (format), ##args)
-#define mlt_log_verbose(service, format, args...) \
-    mlt_log((service), MLT_LOG_VERBOSE, (format), ##args)
-#define mlt_log_timings(service, format, args...) \
-    mlt_log((service), MLT_LOG_TIMINGS, (format), ##args)
-#define mlt_log_debug(service, format, args...) mlt_log((service), MLT_LOG_DEBUG, (format), ##args)
+#ifdef _MSC_VER
 
-void mlt_vlog(void *service, int level, const char *fmt, va_list);
-int mlt_log_get_level(void);
-void mlt_log_set_level(int);
-void mlt_log_set_callback(void (*)(void *, int, const char *, va_list));
+// 可变参数宏安全展开：允许没有 __VA_ARGS__ 的情况
+#define MLT_LOG_EXPAND_ARGS(...) , ##__VA_ARGS__
+
+#define mlt_log_panic(service, format, ...)   mlt_log((service), MLT_LOG_PANIC,   format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_fatal(service, format, ...)   mlt_log((service), MLT_LOG_FATAL,   format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_error(service, format, ...)   mlt_log((service), MLT_LOG_ERROR,   format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_warning(service, format, ...) mlt_log((service), MLT_LOG_WARNING, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_info(service, format, ...)    mlt_log((service), MLT_LOG_INFO,    format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_verbose(service, format, ...) mlt_log((service), MLT_LOG_VERBOSE, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_timings(service, format, ...) mlt_log((service), MLT_LOG_TIMINGS, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_debug(service, format, ...)   mlt_log((service), MLT_LOG_DEBUG,   format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+
+#else
+
+// GCC / Clang 使用 ##args 规避空参数逗号问题
+#define mlt_log_panic(service, format, args...)   mlt_log((service), MLT_LOG_PANIC,   format, ##args)
+#define mlt_log_fatal(service, format, args...)   mlt_log((service), MLT_LOG_FATAL,   format, ##args)
+#define mlt_log_error(service, format, args...)   mlt_log((service), MLT_LOG_ERROR,   format, ##args)
+#define mlt_log_warning(service, format, args...) mlt_log((service), MLT_LOG_WARNING, format, ##args)
+#define mlt_log_info(service, format, args...)    mlt_log((service), MLT_LOG_INFO,    format, ##args)
+#define mlt_log_verbose(service, format, args...) mlt_log((service), MLT_LOG_VERBOSE, format, ##args)
+#define mlt_log_timings(service, format, args...) mlt_log((service), MLT_LOG_TIMINGS, format, ##args)
+#define mlt_log_debug(service, format, args...)   mlt_log((service), MLT_LOG_DEBUG,   format, ##args)
+
+#endif
+
+
+MLT_API void mlt_vlog(void *service, int level, const char *fmt, va_list);
+MLT_API int mlt_log_get_level(void);
+MLT_API void mlt_log_set_level(int);
+MLT_API void mlt_log_set_callback(void (*)(void *, int, const char *, va_list));
 
 #define mlt_log_timings_begin() \
     { \
@@ -111,6 +128,6 @@ void mlt_log_set_callback(void (*)(void *, int, const char *, va_list));
                     _mlt_log_timings_end - _mlt_log_timings_begin); \
     }
 
-int64_t mlt_log_timings_now(void);
+MLT_API int64_t mlt_log_timings_now(void);
 
 #endif /* MLT_LOG_H */

--- a/src/framework/mlt_luma_map.h
+++ b/src/framework/mlt_luma_map.h
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include "mlt_api.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,11 +52,11 @@ struct mlt_luma_map_s
 
 typedef struct mlt_luma_map_s *mlt_luma_map;
 
-extern void mlt_luma_map_init(mlt_luma_map self);
-extern mlt_luma_map mlt_luma_map_new(const char *path);
-extern uint16_t *mlt_luma_map_render(mlt_luma_map self);
-extern int mlt_luma_map_from_pgm(const char *filename, uint16_t **map, int *width, int *height);
-extern void mlt_luma_map_from_yuv422(uint8_t *image, uint16_t **map, int width, int height);
+MLT_API extern void mlt_luma_map_init(mlt_luma_map self);
+MLT_API extern mlt_luma_map mlt_luma_map_new(const char *path);
+MLT_API extern uint16_t *mlt_luma_map_render(mlt_luma_map self);
+MLT_API extern int mlt_luma_map_from_pgm(const char *filename, uint16_t **map, int *width, int *height);
+MLT_API extern void mlt_luma_map_from_yuv422(uint8_t *image, uint16_t **map, int width, int height);
 
 #ifdef __cplusplus
 }

--- a/src/framework/mlt_multitrack.h
+++ b/src/framework/mlt_multitrack.h
@@ -24,7 +24,7 @@
 #define MLT_MULITRACK_H
 
 #include "mlt_producer.h"
-
+#include "mlt_api.h"
 /** \brief Track class used by mlt_multitrack_s
  */
 
@@ -58,17 +58,17 @@ struct mlt_multitrack_s
 #define MLT_MULTITRACK_PROPERTIES(multitrack) \
     MLT_SERVICE_PROPERTIES(MLT_MULTITRACK_SERVICE(multitrack))
 
-extern mlt_multitrack mlt_multitrack_init();
-extern mlt_producer mlt_multitrack_producer(mlt_multitrack self);
-extern mlt_service mlt_multitrack_service(mlt_multitrack self);
-extern mlt_properties mlt_multitrack_properties(mlt_multitrack self);
-extern int mlt_multitrack_connect(mlt_multitrack self, mlt_producer producer, int track);
-extern int mlt_multitrack_insert(mlt_multitrack self, mlt_producer producer, int track);
-extern int mlt_multitrack_disconnect(mlt_multitrack self, int track);
-extern mlt_position mlt_multitrack_clip(mlt_multitrack self, mlt_whence whence, int index);
-extern void mlt_multitrack_close(mlt_multitrack self);
-extern int mlt_multitrack_count(mlt_multitrack self);
-extern void mlt_multitrack_refresh(mlt_multitrack self);
-extern mlt_producer mlt_multitrack_track(mlt_multitrack self, int track);
+MLT_API extern mlt_multitrack mlt_multitrack_init();
+MLT_API extern mlt_producer mlt_multitrack_producer(mlt_multitrack self);
+MLT_API extern mlt_service mlt_multitrack_service(mlt_multitrack self);
+MLT_API extern mlt_properties mlt_multitrack_properties(mlt_multitrack self);
+MLT_API extern int mlt_multitrack_connect(mlt_multitrack self, mlt_producer producer, int track);
+MLT_API extern int mlt_multitrack_insert(mlt_multitrack self, mlt_producer producer, int track);
+MLT_API extern int mlt_multitrack_disconnect(mlt_multitrack self, int track);
+MLT_API extern mlt_position mlt_multitrack_clip(mlt_multitrack self, mlt_whence whence, int index);
+MLT_API extern void mlt_multitrack_close(mlt_multitrack self);
+MLT_API extern int mlt_multitrack_count(mlt_multitrack self);
+MLT_API extern void mlt_multitrack_refresh(mlt_multitrack self);
+MLT_API extern mlt_producer mlt_multitrack_track(mlt_multitrack self, int track);
 
 #endif

--- a/src/framework/mlt_parser.h
+++ b/src/framework/mlt_parser.h
@@ -24,6 +24,7 @@
 #define MLT_PARSER_H
 
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /** \brief Parser class
  *
@@ -55,9 +56,9 @@ struct mlt_parser_s
     int (*on_end_link)(mlt_parser self, mlt_link object);
 };
 
-extern mlt_parser mlt_parser_new();
-extern mlt_properties mlt_parser_properties(mlt_parser self);
-extern int mlt_parser_start(mlt_parser self, mlt_service object);
-extern void mlt_parser_close(mlt_parser self);
+MLT_API extern mlt_parser mlt_parser_new();
+MLT_API extern mlt_properties mlt_parser_properties(mlt_parser self);
+MLT_API extern int mlt_parser_start(mlt_parser self, mlt_service object);
+MLT_API extern void mlt_parser_close(mlt_parser self);
 
 #endif

--- a/src/framework/mlt_playlist.h
+++ b/src/framework/mlt_playlist.h
@@ -24,7 +24,7 @@
 #define MLT_PLAYLIST_H
 
 #include "mlt_producer.h"
-
+#include "mlt_api.h"
 /** \brief structure for returning clip information from a playlist entry
  */
 
@@ -82,56 +82,56 @@ struct mlt_playlist_s
 #define MLT_PLAYLIST_SERVICE(playlist) MLT_PRODUCER_SERVICE(MLT_PLAYLIST_PRODUCER(playlist))
 #define MLT_PLAYLIST_PROPERTIES(playlist) MLT_SERVICE_PROPERTIES(MLT_PLAYLIST_SERVICE(playlist))
 
-extern mlt_playlist mlt_playlist_init();
-extern mlt_playlist mlt_playlist_new(mlt_profile profile);
-extern mlt_producer mlt_playlist_producer(mlt_playlist self);
-extern mlt_service mlt_playlist_service(mlt_playlist self);
-extern mlt_properties mlt_playlist_properties(mlt_playlist self);
-extern int mlt_playlist_count(mlt_playlist self);
-extern int mlt_playlist_clear(mlt_playlist self);
-extern int mlt_playlist_append(mlt_playlist self, mlt_producer producer);
-extern int mlt_playlist_append_io(mlt_playlist self,
+MLT_API extern mlt_playlist mlt_playlist_init();
+MLT_API extern mlt_playlist mlt_playlist_new(mlt_profile profile);
+MLT_API extern mlt_producer mlt_playlist_producer(mlt_playlist self);
+MLT_API extern mlt_service mlt_playlist_service(mlt_playlist self);
+MLT_API extern mlt_properties mlt_playlist_properties(mlt_playlist self);
+MLT_API extern int mlt_playlist_count(mlt_playlist self);
+MLT_API extern int mlt_playlist_clear(mlt_playlist self);
+MLT_API extern int mlt_playlist_append(mlt_playlist self, mlt_producer producer);
+MLT_API extern int mlt_playlist_append_io(mlt_playlist self,
                                   mlt_producer producer,
                                   mlt_position in,
                                   mlt_position out);
-extern int mlt_playlist_blank(mlt_playlist self, mlt_position out);
-extern int mlt_playlist_blank_time(mlt_playlist self, const char *length);
-extern mlt_position mlt_playlist_clip(mlt_playlist self, mlt_whence whence, int index);
-extern int mlt_playlist_current_clip(mlt_playlist self);
-extern mlt_producer mlt_playlist_current(mlt_playlist self);
-extern int mlt_playlist_get_clip_info(mlt_playlist self, mlt_playlist_clip_info *info, int index);
-extern int mlt_playlist_insert(
+MLT_API extern int mlt_playlist_blank(mlt_playlist self, mlt_position out);
+MLT_API extern int mlt_playlist_blank_time(mlt_playlist self, const char *length);
+MLT_API extern mlt_position mlt_playlist_clip(mlt_playlist self, mlt_whence whence, int index);
+MLT_API extern int mlt_playlist_current_clip(mlt_playlist self);
+MLT_API extern mlt_producer mlt_playlist_current(mlt_playlist self);
+MLT_API extern int mlt_playlist_get_clip_info(mlt_playlist self, mlt_playlist_clip_info *info, int index);
+MLT_API extern int mlt_playlist_insert(
     mlt_playlist self, mlt_producer producer, int where, mlt_position in, mlt_position out);
-extern int mlt_playlist_remove(mlt_playlist self, int where);
-extern int mlt_playlist_move(mlt_playlist self, int from, int to);
-extern int mlt_playlist_reorder(mlt_playlist self, const int *indices);
-extern int mlt_playlist_resize_clip(mlt_playlist self, int clip, mlt_position in, mlt_position out);
-extern int mlt_playlist_repeat_clip(mlt_playlist self, int clip, int repeat);
-extern int mlt_playlist_split(mlt_playlist self, int clip, mlt_position position);
-extern int mlt_playlist_split_at(mlt_playlist self, mlt_position position, int left);
-extern int mlt_playlist_join(mlt_playlist self, int clip, int count, int merge);
-extern int mlt_playlist_mix(mlt_playlist self, int clip, int length, mlt_transition transition);
-extern int mlt_playlist_mix_in(mlt_playlist self, int clip, int length);
-extern int mlt_playlist_mix_out(mlt_playlist self, int clip, int length);
-extern int mlt_playlist_mix_add(mlt_playlist self, int clip, mlt_transition transition);
-extern mlt_producer mlt_playlist_get_clip(mlt_playlist self, int clip);
-extern mlt_producer mlt_playlist_get_clip_at(mlt_playlist self, mlt_position position);
-extern int mlt_playlist_get_clip_index_at(mlt_playlist self, mlt_position position);
-extern int mlt_playlist_clip_is_mix(mlt_playlist self, int clip);
-extern void mlt_playlist_consolidate_blanks(mlt_playlist self, int keep_length);
-extern int mlt_playlist_is_blank(mlt_playlist self, int clip);
-extern int mlt_playlist_is_blank_at(mlt_playlist self, mlt_position position);
-extern void mlt_playlist_insert_blank(mlt_playlist self, int clip, int out);
-extern void mlt_playlist_pad_blanks(mlt_playlist self, mlt_position position, int length, int find);
-extern mlt_producer mlt_playlist_replace_with_blank(mlt_playlist self, int clip);
-extern int mlt_playlist_insert_at(mlt_playlist self,
+MLT_API extern int mlt_playlist_remove(mlt_playlist self, int where);
+MLT_API extern int mlt_playlist_move(mlt_playlist self, int from, int to);
+MLT_API extern int mlt_playlist_reorder(mlt_playlist self, const int *indices);
+MLT_API extern int mlt_playlist_resize_clip(mlt_playlist self, int clip, mlt_position in, mlt_position out);
+MLT_API extern int mlt_playlist_repeat_clip(mlt_playlist self, int clip, int repeat);
+MLT_API extern int mlt_playlist_split(mlt_playlist self, int clip, mlt_position position);
+MLT_API extern int mlt_playlist_split_at(mlt_playlist self, mlt_position position, int left);
+MLT_API extern int mlt_playlist_join(mlt_playlist self, int clip, int count, int merge);
+MLT_API extern int mlt_playlist_mix(mlt_playlist self, int clip, int length, mlt_transition transition);
+MLT_API extern int mlt_playlist_mix_in(mlt_playlist self, int clip, int length);
+MLT_API extern int mlt_playlist_mix_out(mlt_playlist self, int clip, int length);
+MLT_API extern int mlt_playlist_mix_add(mlt_playlist self, int clip, mlt_transition transition);
+MLT_API extern mlt_producer mlt_playlist_get_clip(mlt_playlist self, int clip);
+MLT_API extern mlt_producer mlt_playlist_get_clip_at(mlt_playlist self, mlt_position position);
+MLT_API extern int mlt_playlist_get_clip_index_at(mlt_playlist self, mlt_position position);
+MLT_API extern int mlt_playlist_clip_is_mix(mlt_playlist self, int clip);
+MLT_API extern void mlt_playlist_consolidate_blanks(mlt_playlist self, int keep_length);
+MLT_API extern int mlt_playlist_is_blank(mlt_playlist self, int clip);
+MLT_API extern int mlt_playlist_is_blank_at(mlt_playlist self, mlt_position position);
+MLT_API extern void mlt_playlist_insert_blank(mlt_playlist self, int clip, int out);
+MLT_API extern void mlt_playlist_pad_blanks(mlt_playlist self, mlt_position position, int length, int find);
+MLT_API extern mlt_producer mlt_playlist_replace_with_blank(mlt_playlist self, int clip);
+MLT_API extern int mlt_playlist_insert_at(mlt_playlist self,
                                   mlt_position position,
                                   mlt_producer producer,
                                   int mode);
-extern int mlt_playlist_clip_start(mlt_playlist self, int clip);
-extern int mlt_playlist_clip_length(mlt_playlist self, int clip);
-extern int mlt_playlist_blanks_from(mlt_playlist self, int clip, int bounded);
-extern int mlt_playlist_remove_region(mlt_playlist self, mlt_position position, int length);
-extern void mlt_playlist_close(mlt_playlist self);
+MLT_API extern int mlt_playlist_clip_start(mlt_playlist self, int clip);
+MLT_API extern int mlt_playlist_clip_length(mlt_playlist self, int clip);
+MLT_API extern int mlt_playlist_blanks_from(mlt_playlist self, int clip, int bounded);
+MLT_API extern int mlt_playlist_remove_region(mlt_playlist self, mlt_position position, int length);
+MLT_API extern void mlt_playlist_close(mlt_playlist self);
 
 #endif

--- a/src/framework/mlt_pool.c
+++ b/src/framework/mlt_pool.c
@@ -95,11 +95,28 @@ typedef struct mlt_pool_s
  * optimized libraries (sse/altivec).
  */
 
+#if defined(__GNUC__) || defined(__clang__)
+// GCC 和 Clang 的语法
 typedef struct __attribute__((aligned(16))) mlt_release_s
 {
     mlt_pool pool;
     int references;
 } * mlt_release;
+#elif defined(_MSC_VER)
+// MSVC 的语法
+typedef __declspec(align(16)) struct mlt_release_s
+{
+    mlt_pool pool;
+    int references;
+} * mlt_release;
+#else
+// 其他未知编译器的备用方案（无对齐）
+typedef struct mlt_release_s
+{
+    mlt_pool pool;
+    int references;
+} * mlt_release;
+#endif
 
 /** Create a pool.
  *

--- a/src/framework/mlt_pool.h
+++ b/src/framework/mlt_pool.h
@@ -22,13 +22,14 @@
 
 #ifndef MLT_POOL_H
 #define MLT_POOL_H
+#include "mlt_api.h"
 
-extern void mlt_pool_init();
-extern void *mlt_pool_alloc(int size);
-extern void *mlt_pool_realloc(void *ptr, int size);
-extern void mlt_pool_release(void *release);
-extern void mlt_pool_purge();
-extern void mlt_pool_close();
-extern void mlt_pool_stat();
+MLT_API extern void mlt_pool_init();
+MLT_API extern void *mlt_pool_alloc(int size);
+MLT_API extern void *mlt_pool_realloc(void *ptr, int size);
+MLT_API extern void mlt_pool_release(void *release);
+MLT_API extern void mlt_pool_purge();
+MLT_API extern void mlt_pool_close();
+MLT_API extern void mlt_pool_stat();
 
 #endif

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -33,7 +33,9 @@
 #include <sys/stat.h>  // for stat()
 #include <sys/types.h> // for stat()
 #include <time.h>      // for strftime() and gtime()
-#include <unistd.h>    // for stat()
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif    // for stat()
 
 /* Forward references. */
 

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -26,7 +26,7 @@
 #include "mlt_filter.h"
 #include "mlt_profile.h"
 #include "mlt_service.h"
-
+#include "mlt_api.h"
 /** \brief Producer abstract service class
  *
  * A producer is a service that generates audio, video, and metadata.
@@ -112,38 +112,38 @@ struct mlt_producer_s
 #define MLT_PRODUCER_SERVICE(producer) (&(producer)->parent)
 #define MLT_PRODUCER_PROPERTIES(producer) MLT_SERVICE_PROPERTIES(MLT_PRODUCER_SERVICE(producer))
 
-extern int mlt_producer_init(mlt_producer self, void *child);
-extern mlt_producer mlt_producer_new(mlt_profile);
-extern mlt_service mlt_producer_service(mlt_producer self);
-extern mlt_properties mlt_producer_properties(mlt_producer self);
-extern int mlt_producer_seek(mlt_producer self, mlt_position position);
-extern int mlt_producer_seek_time(mlt_producer self, const char *time);
-extern mlt_position mlt_producer_position(mlt_producer self);
-extern mlt_position mlt_producer_frame(mlt_producer self);
-char *mlt_producer_frame_time(mlt_producer self, mlt_time_format);
-extern int mlt_producer_set_speed(mlt_producer self, double speed);
-extern double mlt_producer_get_speed(mlt_producer self);
-extern double mlt_producer_get_fps(mlt_producer self);
-extern int mlt_producer_set_in_and_out(mlt_producer self, mlt_position in, mlt_position out);
-extern int mlt_producer_clear(mlt_producer self);
-extern mlt_position mlt_producer_get_in(mlt_producer self);
-extern mlt_position mlt_producer_get_out(mlt_producer self);
-extern mlt_position mlt_producer_get_playtime(mlt_producer self);
-extern mlt_position mlt_producer_get_length(mlt_producer self);
-extern char *mlt_producer_get_length_time(mlt_producer self, mlt_time_format);
-extern void mlt_producer_prepare_next(mlt_producer self);
-extern int mlt_producer_attach(mlt_producer self, mlt_filter filter);
-extern int mlt_producer_detach(mlt_producer self, mlt_filter filter);
-extern mlt_filter mlt_producer_filter(mlt_producer self, int index);
-extern mlt_producer mlt_producer_cut(mlt_producer self, int in, int out);
-extern int mlt_producer_is_cut(mlt_producer self);
-extern int mlt_producer_is_mix(mlt_producer self);
-extern int mlt_producer_is_blank(mlt_producer self);
-extern mlt_producer mlt_producer_cut_parent(mlt_producer self);
-extern int mlt_producer_optimise(mlt_producer self);
-extern void mlt_producer_close(mlt_producer self);
-int64_t mlt_producer_get_creation_time(mlt_producer self);
-void mlt_producer_set_creation_time(mlt_producer self, int64_t creation_time);
-extern int mlt_producer_probe(mlt_producer self);
+MLT_API extern int mlt_producer_init(mlt_producer self, void *child);
+MLT_API extern mlt_producer mlt_producer_new(mlt_profile);
+MLT_API extern mlt_service mlt_producer_service(mlt_producer self);
+MLT_API extern mlt_properties mlt_producer_properties(mlt_producer self);
+MLT_API extern int mlt_producer_seek(mlt_producer self, mlt_position position);
+MLT_API extern int mlt_producer_seek_time(mlt_producer self, const char *time);
+MLT_API extern mlt_position mlt_producer_position(mlt_producer self);
+MLT_API extern mlt_position mlt_producer_frame(mlt_producer self);
+MLT_API char *mlt_producer_frame_time(mlt_producer self, mlt_time_format);
+MLT_API extern int mlt_producer_set_speed(mlt_producer self, double speed);
+MLT_API extern double mlt_producer_get_speed(mlt_producer self);
+MLT_API extern double mlt_producer_get_fps(mlt_producer self);
+MLT_API extern int mlt_producer_set_in_and_out(mlt_producer self, mlt_position in, mlt_position out);
+MLT_API extern int mlt_producer_clear(mlt_producer self);
+MLT_API extern mlt_position mlt_producer_get_in(mlt_producer self);
+MLT_API extern mlt_position mlt_producer_get_out(mlt_producer self);
+MLT_API extern mlt_position mlt_producer_get_playtime(mlt_producer self);
+MLT_API extern mlt_position mlt_producer_get_length(mlt_producer self);
+MLT_API extern char *mlt_producer_get_length_time(mlt_producer self, mlt_time_format);
+MLT_API extern void mlt_producer_prepare_next(mlt_producer self);
+MLT_API extern int mlt_producer_attach(mlt_producer self, mlt_filter filter);
+MLT_API extern int mlt_producer_detach(mlt_producer self, mlt_filter filter);
+MLT_API extern mlt_filter mlt_producer_filter(mlt_producer self, int index);
+MLT_API extern mlt_producer mlt_producer_cut(mlt_producer self, int in, int out);
+MLT_API extern int mlt_producer_is_cut(mlt_producer self);
+MLT_API extern int mlt_producer_is_mix(mlt_producer self);
+MLT_API extern int mlt_producer_is_blank(mlt_producer self);
+MLT_API extern mlt_producer mlt_producer_cut_parent(mlt_producer self);
+MLT_API extern int mlt_producer_optimise(mlt_producer self);
+MLT_API extern void mlt_producer_close(mlt_producer self);
+MLT_API int64_t mlt_producer_get_creation_time(mlt_producer self);
+MLT_API void mlt_producer_set_creation_time(mlt_producer self, int64_t creation_time);
+MLT_API extern int mlt_producer_probe(mlt_producer self);
 
 #endif

--- a/src/framework/mlt_profile.c
+++ b/src/framework/mlt_profile.c
@@ -22,7 +22,40 @@
 
 #include "mlt.h"
 
-#include <libgen.h>
+#ifdef _MSC_VER
+    #include <string.h> // for strrchr
+
+    // 为 MSVC 提供一个简单的 basename 实现
+    // 注意：这个实现返回一个指向原始字符串内部的指针
+    static inline char *basename(char *path) {
+        if (path == NULL || *path == '\0') {
+            // 如果路径为空或空字符串，返回"."
+            return ".";
+        }
+
+        // 查找最后一个路径分隔符（'/' 或 '\'）
+        char *last_slash = strrchr(path, '/');
+        char *last_bslash = strrchr(path, '\\');
+
+        if (last_slash && last_bslash) {
+            // 如果两者都存在，取后面的那一个
+            last_slash = (last_slash > last_bslash) ? last_slash : last_bslash;
+        } else if (last_bslash) {
+            // 如果只有反斜杠
+            last_slash = last_bslash;
+        }
+
+        if (last_slash != NULL) {
+            // 如果找到了分隔符，返回它后面的字符
+            return last_slash + 1;
+        } else {
+            // 如果没有找到分隔符，整个字符串就是文件名
+            return path;
+        }
+    }
+#else
+    #include <libgen.h>
+#endif
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/framework/mlt_profile.h
+++ b/src/framework/mlt_profile.h
@@ -24,6 +24,7 @@
 #define MLT_PROFILE_H
 
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /** \brief Profile class
  *
@@ -47,18 +48,18 @@ struct mlt_profile_s
     int is_explicit; /**< used internally to indicate if the profile was requested explicitly or computed or defaulted */
 };
 
-extern mlt_profile mlt_profile_init(const char *name);
-extern mlt_profile mlt_profile_load_file(const char *file);
-extern mlt_profile mlt_profile_load_properties(mlt_properties properties);
-extern mlt_profile mlt_profile_load_string(const char *string);
-extern double mlt_profile_fps(mlt_profile profile);
-extern double mlt_profile_sar(mlt_profile profile);
-extern double mlt_profile_dar(mlt_profile profile);
-extern void mlt_profile_close(mlt_profile profile);
-extern mlt_profile mlt_profile_clone(mlt_profile profile);
-extern mlt_properties mlt_profile_list();
-extern void mlt_profile_from_producer(mlt_profile profile, mlt_producer producer);
-extern char *mlt_profile_lumas_dir(mlt_profile profile);
-extern double mlt_profile_scale_width(mlt_profile profile, int width);
-extern double mlt_profile_scale_height(mlt_profile profile, int height);
+MLT_API extern mlt_profile mlt_profile_init(const char *name);
+MLT_API extern mlt_profile mlt_profile_load_file(const char *file);
+MLT_API extern mlt_profile mlt_profile_load_properties(mlt_properties properties);
+MLT_API extern mlt_profile mlt_profile_load_string(const char *string);
+MLT_API extern double mlt_profile_fps(mlt_profile profile);
+MLT_API extern double mlt_profile_sar(mlt_profile profile);
+MLT_API extern double mlt_profile_dar(mlt_profile profile);
+MLT_API extern void mlt_profile_close(mlt_profile profile);
+MLT_API extern mlt_profile mlt_profile_clone(mlt_profile profile);
+MLT_API extern mlt_properties mlt_profile_list();
+MLT_API extern void mlt_profile_from_producer(mlt_profile profile, mlt_producer producer);
+MLT_API extern char *mlt_profile_lumas_dir(mlt_profile profile);
+MLT_API extern double mlt_profile_scale_width(mlt_profile profile, int width);
+MLT_API extern double mlt_profile_scale_height(mlt_profile profile, int height);
 #endif

--- a/src/framework/mlt_properties.h
+++ b/src/framework/mlt_properties.h
@@ -26,6 +26,7 @@
 #include "mlt_events.h"
 #include "mlt_types.h"
 #include <stdio.h>
+#include "mlt_api.h"
 
 /** \brief Properties class
  *
@@ -46,129 +47,129 @@ struct mlt_properties_s
     void *close_object; /**< the object supplied to the close virtual function */
 };
 
-extern int mlt_properties_init(mlt_properties, void *child);
-extern mlt_properties mlt_properties_new();
-extern int mlt_properties_set_lcnumeric(mlt_properties, const char *locale);
-extern const char *mlt_properties_get_lcnumeric(mlt_properties self);
-extern mlt_properties mlt_properties_load(const char *file);
-extern int mlt_properties_preset(mlt_properties self, const char *name);
-extern int mlt_properties_inc_ref(mlt_properties self);
-extern int mlt_properties_dec_ref(mlt_properties self);
-extern int mlt_properties_ref_count(mlt_properties self);
-extern void mlt_properties_mirror(mlt_properties self, mlt_properties that);
-extern int mlt_properties_inherit(mlt_properties self, mlt_properties that);
-extern int mlt_properties_copy(mlt_properties self, mlt_properties that, const char *prefix);
-extern int mlt_properties_pass(mlt_properties self, mlt_properties that, const char *prefix);
-extern void mlt_properties_pass_property(mlt_properties self, mlt_properties that, const char *name);
-extern int mlt_properties_pass_list(mlt_properties self, mlt_properties that, const char *list);
-extern int mlt_properties_set(mlt_properties self, const char *name, const char *value);
-extern int mlt_properties_set_or_default(mlt_properties self,
+MLT_API extern int mlt_properties_init(mlt_properties, void *child);
+MLT_API extern mlt_properties mlt_properties_new();
+MLT_API extern int mlt_properties_set_lcnumeric(mlt_properties, const char *locale);
+MLT_API extern const char *mlt_properties_get_lcnumeric(mlt_properties self);
+MLT_API extern mlt_properties mlt_properties_load(const char *file);
+MLT_API extern int mlt_properties_preset(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_inc_ref(mlt_properties self);
+MLT_API extern int mlt_properties_dec_ref(mlt_properties self);
+MLT_API extern int mlt_properties_ref_count(mlt_properties self);
+MLT_API extern void mlt_properties_mirror(mlt_properties self, mlt_properties that);
+MLT_API extern int mlt_properties_inherit(mlt_properties self, mlt_properties that);
+MLT_API extern int mlt_properties_copy(mlt_properties self, mlt_properties that, const char *prefix);
+MLT_API extern int mlt_properties_pass(mlt_properties self, mlt_properties that, const char *prefix);
+MLT_API extern void mlt_properties_pass_property(mlt_properties self, mlt_properties that, const char *name);
+MLT_API extern int mlt_properties_pass_list(mlt_properties self, mlt_properties that, const char *list);
+MLT_API extern int mlt_properties_set(mlt_properties self, const char *name, const char *value);
+MLT_API extern int mlt_properties_set_or_default(mlt_properties self,
                                          const char *name,
                                          const char *value,
                                          const char *def);
-extern int mlt_properties_set_string(mlt_properties self, const char *name, const char *value);
-extern int mlt_properties_parse(mlt_properties self, const char *namevalue);
-extern char *mlt_properties_get(mlt_properties self, const char *name);
-extern char *mlt_properties_get_name(mlt_properties self, int index);
-extern char *mlt_properties_get_value_tf(mlt_properties self, int index, mlt_time_format);
-extern char *mlt_properties_get_value(mlt_properties self, int index);
-extern void *mlt_properties_get_data_at(mlt_properties self, int index, int *size);
-extern int mlt_properties_get_int(mlt_properties self, const char *name);
-extern int mlt_properties_set_int(mlt_properties self, const char *name, int value);
-extern int64_t mlt_properties_get_int64(mlt_properties self, const char *name);
-extern int mlt_properties_set_int64(mlt_properties self, const char *name, int64_t value);
-extern double mlt_properties_get_double(mlt_properties self, const char *name);
-extern int mlt_properties_set_double(mlt_properties self, const char *name, double value);
-extern mlt_position mlt_properties_get_position(mlt_properties self, const char *name);
-extern int mlt_properties_set_position(mlt_properties self, const char *name, mlt_position value);
-extern int mlt_properties_set_data(
+MLT_API extern int mlt_properties_set_string(mlt_properties self, const char *name, const char *value);
+MLT_API extern int mlt_properties_parse(mlt_properties self, const char *namevalue);
+MLT_API extern char *mlt_properties_get(mlt_properties self, const char *name);
+MLT_API extern char *mlt_properties_get_name(mlt_properties self, int index);
+MLT_API extern char *mlt_properties_get_value_tf(mlt_properties self, int index, mlt_time_format);
+MLT_API extern char *mlt_properties_get_value(mlt_properties self, int index);
+MLT_API extern void *mlt_properties_get_data_at(mlt_properties self, int index, int *size);
+MLT_API extern int mlt_properties_get_int(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_set_int(mlt_properties self, const char *name, int value);
+MLT_API extern int64_t mlt_properties_get_int64(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_set_int64(mlt_properties self, const char *name, int64_t value);
+MLT_API extern double mlt_properties_get_double(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_set_double(mlt_properties self, const char *name, double value);
+MLT_API extern mlt_position mlt_properties_get_position(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_set_position(mlt_properties self, const char *name, mlt_position value);
+MLT_API extern int mlt_properties_set_data(
     mlt_properties self, const char *name, void *value, int length, mlt_destructor, mlt_serialiser);
-extern void *mlt_properties_get_data(mlt_properties self, const char *name, int *length);
-extern int mlt_properties_rename(mlt_properties self, const char *source, const char *dest);
-extern int mlt_properties_count(mlt_properties self);
-extern void mlt_properties_dump(mlt_properties self, FILE *output);
-extern void mlt_properties_debug(mlt_properties self, const char *title, FILE *output);
-extern int mlt_properties_save(mlt_properties, const char *);
-extern int mlt_properties_dir_list(mlt_properties, const char *, const char *, int);
-extern void mlt_properties_close(mlt_properties self);
-extern int mlt_properties_is_sequence(mlt_properties self);
-extern mlt_properties mlt_properties_parse_yaml(const char *file);
-extern char *mlt_properties_serialise_yaml(mlt_properties self);
-extern void mlt_properties_lock(mlt_properties self);
-extern void mlt_properties_unlock(mlt_properties self);
-extern void mlt_properties_clear(mlt_properties self, const char *name);
-extern int mlt_properties_exists(mlt_properties self, const char *name);
+MLT_API extern void *mlt_properties_get_data(mlt_properties self, const char *name, int *length);
+MLT_API extern int mlt_properties_rename(mlt_properties self, const char *source, const char *dest);
+MLT_API extern int mlt_properties_count(mlt_properties self);
+MLT_API extern void mlt_properties_dump(mlt_properties self, FILE *output);
+MLT_API extern void mlt_properties_debug(mlt_properties self, const char *title, FILE *output);
+MLT_API extern int mlt_properties_save(mlt_properties, const char *);
+MLT_API extern int mlt_properties_dir_list(mlt_properties, const char *, const char *, int);
+MLT_API extern void mlt_properties_close(mlt_properties self);
+MLT_API extern int mlt_properties_is_sequence(mlt_properties self);
+MLT_API extern mlt_properties mlt_properties_parse_yaml(const char *file);
+MLT_API extern char *mlt_properties_serialise_yaml(mlt_properties self);
+MLT_API extern void mlt_properties_lock(mlt_properties self);
+MLT_API extern void mlt_properties_unlock(mlt_properties self);
+MLT_API extern void mlt_properties_clear(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_exists(mlt_properties self, const char *name);
 
-extern char *mlt_properties_get_time(mlt_properties, const char *name, mlt_time_format);
-extern char *mlt_properties_frames_to_time(mlt_properties, mlt_position, mlt_time_format);
-extern mlt_position mlt_properties_time_to_frames(mlt_properties, const char *time);
+MLT_API extern char *mlt_properties_get_time(mlt_properties, const char *name, mlt_time_format);
+MLT_API extern char *mlt_properties_frames_to_time(mlt_properties, mlt_position, mlt_time_format);
+MLT_API extern mlt_position mlt_properties_time_to_frames(mlt_properties, const char *time);
 
-extern int mlt_properties_set_color(mlt_properties, const char *name, mlt_color value);
-extern mlt_color mlt_properties_get_color(mlt_properties, const char *name);
-extern int mlt_properties_anim_set_color(mlt_properties self,
+MLT_API extern int mlt_properties_set_color(mlt_properties, const char *name, mlt_color value);
+MLT_API extern mlt_color mlt_properties_get_color(mlt_properties, const char *name);
+MLT_API extern int mlt_properties_anim_set_color(mlt_properties self,
                                          const char *name,
                                          mlt_color value,
                                          int position,
                                          int length,
                                          mlt_keyframe_type keyframe_type);
-extern mlt_color mlt_properties_anim_get_color(mlt_properties self,
+MLT_API extern mlt_color mlt_properties_anim_get_color(mlt_properties self,
                                                const char *name,
                                                int position,
                                                int length);
 
-extern char *mlt_properties_anim_get(mlt_properties self,
+MLT_API extern char *mlt_properties_anim_get(mlt_properties self,
                                      const char *name,
                                      int position,
                                      int length);
-extern int mlt_properties_anim_set(
+MLT_API extern int mlt_properties_anim_set(
     mlt_properties self, const char *name, const char *value, int position, int length);
-extern int mlt_properties_anim_get_int(mlt_properties self,
+MLT_API extern int mlt_properties_anim_get_int(mlt_properties self,
                                        const char *name,
                                        int position,
                                        int length);
-extern int mlt_properties_anim_set_int(mlt_properties self,
+MLT_API extern int mlt_properties_anim_set_int(mlt_properties self,
                                        const char *name,
                                        int value,
                                        int position,
                                        int length,
                                        mlt_keyframe_type keyframe_type);
-extern double mlt_properties_anim_get_double(mlt_properties self,
+MLT_API extern double mlt_properties_anim_get_double(mlt_properties self,
                                              const char *name,
                                              int position,
                                              int length);
-extern int mlt_properties_anim_set_double(mlt_properties self,
+MLT_API extern int mlt_properties_anim_set_double(mlt_properties self,
                                           const char *name,
                                           double value,
                                           int position,
                                           int length,
                                           mlt_keyframe_type keyframe_type);
-extern mlt_animation mlt_properties_get_animation(mlt_properties self, const char *name);
-extern int mlt_properties_is_anim(mlt_properties self, const char *name);
+MLT_API extern mlt_animation mlt_properties_get_animation(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_is_anim(mlt_properties self, const char *name);
 
-extern int mlt_properties_set_rect(mlt_properties self, const char *name, mlt_rect value);
-extern mlt_rect mlt_properties_get_rect(mlt_properties self, const char *name);
-extern int mlt_properties_anim_set_rect(mlt_properties self,
+MLT_API extern int mlt_properties_set_rect(mlt_properties self, const char *name, mlt_rect value);
+MLT_API extern mlt_rect mlt_properties_get_rect(mlt_properties self, const char *name);
+MLT_API extern int mlt_properties_anim_set_rect(mlt_properties self,
                                         const char *name,
                                         mlt_rect value,
                                         int position,
                                         int length,
                                         mlt_keyframe_type keyframe_type);
-extern mlt_rect mlt_properties_anim_get_rect(mlt_properties self,
+MLT_API extern mlt_rect mlt_properties_anim_get_rect(mlt_properties self,
                                              const char *name,
                                              int position,
                                              int length);
 
-extern int mlt_properties_from_utf8(mlt_properties properties,
+MLT_API extern int mlt_properties_from_utf8(mlt_properties properties,
                                     const char *name_from,
                                     const char *name_to);
-extern int mlt_properties_to_utf8(mlt_properties properties,
+MLT_API extern int mlt_properties_to_utf8(mlt_properties properties,
                                   const char *name_from,
                                   const char *name_to);
 
-extern int mlt_properties_set_properties(mlt_properties self,
+MLT_API extern int mlt_properties_set_properties(mlt_properties self,
                                          const char *name,
                                          mlt_properties properties);
-extern mlt_properties mlt_properties_get_properties(mlt_properties self, const char *name);
-extern mlt_properties mlt_properties_get_properties_at(mlt_properties self, int index);
+MLT_API extern mlt_properties mlt_properties_get_properties(mlt_properties self, const char *name);
+MLT_API extern mlt_properties mlt_properties_get_properties_at(mlt_properties self, int index);
 
 #endif

--- a/src/framework/mlt_property.h
+++ b/src/framework/mlt_property.h
@@ -24,6 +24,7 @@
 #define MLT_PROPERTY_H
 
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 #if defined(__FreeBSD__)
 /* This header has existed since 1994 and defines __FreeBSD_version below. */
@@ -45,91 +46,91 @@ struct mlt_locale_t;
 typedef char *mlt_locale_t;
 #endif
 
-extern mlt_property mlt_property_init();
-extern void mlt_property_clear(mlt_property self);
-extern int mlt_property_is_clear(mlt_property self);
-extern int mlt_property_set_int(mlt_property self, int value);
-extern int mlt_property_set_double(mlt_property self, double value);
-extern int mlt_property_set_position(mlt_property self, mlt_position value);
-extern int mlt_property_set_int64(mlt_property self, int64_t value);
-extern int mlt_property_set_string(mlt_property self, const char *value);
-extern int mlt_property_set_data(mlt_property self,
+MLT_API extern mlt_property mlt_property_init();
+MLT_API extern void mlt_property_clear(mlt_property self);
+MLT_API extern int mlt_property_is_clear(mlt_property self);
+MLT_API extern int mlt_property_set_int(mlt_property self, int value);
+MLT_API extern int mlt_property_set_double(mlt_property self, double value);
+MLT_API extern int mlt_property_set_position(mlt_property self, mlt_position value);
+MLT_API extern int mlt_property_set_int64(mlt_property self, int64_t value);
+MLT_API extern int mlt_property_set_string(mlt_property self, const char *value);
+MLT_API extern int mlt_property_set_data(mlt_property self,
                                  void *value,
                                  int length,
                                  mlt_destructor destructor,
                                  mlt_serialiser serialiser);
-extern int mlt_property_get_int(mlt_property self, double fps, mlt_locale_t);
-extern double mlt_property_get_double(mlt_property self, double fps, mlt_locale_t);
-extern mlt_position mlt_property_get_position(mlt_property self, double fps, mlt_locale_t);
-extern int64_t mlt_property_get_int64(mlt_property self);
-extern char *mlt_property_get_string_tf(mlt_property self, mlt_time_format);
-extern char *mlt_property_get_string(mlt_property self);
-extern char *mlt_property_get_string_l_tf(mlt_property self, mlt_locale_t, mlt_time_format);
-extern char *mlt_property_get_string_l(mlt_property self, mlt_locale_t);
-extern void *mlt_property_get_data(mlt_property self, int *length);
-extern void mlt_property_close(mlt_property self);
-extern void mlt_property_pass(mlt_property self, mlt_property that);
-extern char *mlt_property_get_time(mlt_property self, mlt_time_format, double fps, mlt_locale_t);
+MLT_API extern int mlt_property_get_int(mlt_property self, double fps, mlt_locale_t);
+MLT_API extern double mlt_property_get_double(mlt_property self, double fps, mlt_locale_t);
+MLT_API extern mlt_position mlt_property_get_position(mlt_property self, double fps, mlt_locale_t);
+MLT_API extern int64_t mlt_property_get_int64(mlt_property self);
+MLT_API extern char *mlt_property_get_string_tf(mlt_property self, mlt_time_format);
+MLT_API extern char *mlt_property_get_string(mlt_property self);
+MLT_API extern char *mlt_property_get_string_l_tf(mlt_property self, mlt_locale_t, mlt_time_format);
+MLT_API extern char *mlt_property_get_string_l(mlt_property self, mlt_locale_t);
+MLT_API extern void *mlt_property_get_data(mlt_property self, int *length);
+MLT_API extern void mlt_property_close(mlt_property self);
+MLT_API extern void mlt_property_pass(mlt_property self, mlt_property that);
+MLT_API extern char *mlt_property_get_time(mlt_property self, mlt_time_format, double fps, mlt_locale_t);
 
-extern int mlt_property_interpolate(mlt_property self,
+MLT_API extern int mlt_property_interpolate(mlt_property self,
                                     mlt_property points[],
                                     double progress,
                                     double fps,
                                     mlt_locale_t locale,
                                     mlt_keyframe_type interp);
-extern double mlt_property_anim_get_double(
+MLT_API extern double mlt_property_anim_get_double(
     mlt_property self, double fps, mlt_locale_t locale, int position, int length);
-extern int mlt_property_anim_get_int(
+MLT_API extern int mlt_property_anim_get_int(
     mlt_property self, double fps, mlt_locale_t locale, int position, int length);
-extern char *mlt_property_anim_get_string(
+MLT_API extern char *mlt_property_anim_get_string(
     mlt_property self, double fps, mlt_locale_t locale, int position, int length);
-extern int mlt_property_anim_set_double(mlt_property self,
+MLT_API extern int mlt_property_anim_set_double(mlt_property self,
                                         double value,
                                         double fps,
                                         mlt_locale_t locale,
                                         int position,
                                         int length,
                                         mlt_keyframe_type keyframe_type);
-extern int mlt_property_anim_set_int(mlt_property self,
+MLT_API extern int mlt_property_anim_set_int(mlt_property self,
                                      int value,
                                      double fps,
                                      mlt_locale_t locale,
                                      int position,
                                      int length,
                                      mlt_keyframe_type keyframe_type);
-extern int mlt_property_anim_set_string(
+MLT_API extern int mlt_property_anim_set_string(
     mlt_property self, const char *value, double fps, mlt_locale_t locale, int position, int length);
-extern mlt_animation mlt_property_get_animation(mlt_property self);
-extern int mlt_property_is_anim(mlt_property self);
+MLT_API extern mlt_animation mlt_property_get_animation(mlt_property self);
+MLT_API extern int mlt_property_is_anim(mlt_property self);
 
-extern int mlt_property_set_color(mlt_property self, mlt_color value);
-extern mlt_color mlt_property_get_color(mlt_property self, double fps, mlt_locale_t locale);
-extern int mlt_property_anim_set_color(mlt_property self,
+MLT_API extern int mlt_property_set_color(mlt_property self, mlt_color value);
+MLT_API extern mlt_color mlt_property_get_color(mlt_property self, double fps, mlt_locale_t locale);
+MLT_API extern int mlt_property_anim_set_color(mlt_property self,
                                        mlt_color value,
                                        double fps,
                                        mlt_locale_t locale,
                                        int position,
                                        int length,
                                        mlt_keyframe_type keyframe_type);
-extern mlt_color mlt_property_anim_get_color(
+MLT_API extern mlt_color mlt_property_anim_get_color(
     mlt_property self, double fps, mlt_locale_t locale, int position, int length);
 
-extern int mlt_property_set_rect(mlt_property self, mlt_rect value);
-extern mlt_rect mlt_property_get_rect(mlt_property self, mlt_locale_t locale);
-extern int mlt_property_anim_set_rect(mlt_property self,
+MLT_API extern int mlt_property_set_rect(mlt_property self, mlt_rect value);
+MLT_API extern mlt_rect mlt_property_get_rect(mlt_property self, mlt_locale_t locale);
+MLT_API extern int mlt_property_anim_set_rect(mlt_property self,
                                       mlt_rect value,
                                       double fps,
                                       mlt_locale_t locale,
                                       int position,
                                       int length,
                                       mlt_keyframe_type keyframe_type);
-extern mlt_rect mlt_property_anim_get_rect(
+MLT_API extern mlt_rect mlt_property_anim_get_rect(
     mlt_property self, double fps, mlt_locale_t locale, int position, int length);
 
-extern int mlt_property_set_properties(mlt_property self, mlt_properties properties);
-extern mlt_properties mlt_property_get_properties(mlt_property self);
-extern int mlt_property_is_color(mlt_property self);
-extern int mlt_property_is_numeric(mlt_property self, mlt_locale_t locale);
-extern int mlt_property_is_rect(mlt_property self);
+MLT_API extern int mlt_property_set_properties(mlt_property self, mlt_properties properties);
+MLT_API extern mlt_properties mlt_property_get_properties(mlt_property self);
+MLT_API extern int mlt_property_is_color(mlt_property self);
+MLT_API extern int mlt_property_is_numeric(mlt_property self, mlt_locale_t locale);
+MLT_API extern int mlt_property_is_rect(mlt_property self);
 
 #endif

--- a/src/framework/mlt_repository.h
+++ b/src/framework/mlt_repository.h
@@ -25,6 +25,7 @@
 
 #include "mlt_profile.h"
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /** This callback is the main entry point into a module, which must be exported
  *  with the symbol "mlt_register".
@@ -64,31 +65,31 @@ typedef mlt_properties (*mlt_metadata_callback)(mlt_service_type,
                                       (mlt_metadata_callback) (callback), \
                                       (data)))
 
-extern mlt_repository mlt_repository_init(const char *directory);
-extern void mlt_repository_register(mlt_repository self,
+MLT_API extern mlt_repository mlt_repository_init(const char *directory);
+MLT_API extern void mlt_repository_register(mlt_repository self,
                                     mlt_service_type service_type,
                                     const char *service,
                                     mlt_register_callback);
-extern void *mlt_repository_create(mlt_repository self,
+MLT_API extern void *mlt_repository_create(mlt_repository self,
                                    mlt_profile profile,
                                    mlt_service_type type,
                                    const char *service,
                                    const void *arg);
-extern void mlt_repository_close(mlt_repository self);
-extern mlt_properties mlt_repository_consumers(mlt_repository self);
-extern mlt_properties mlt_repository_filters(mlt_repository self);
-extern mlt_properties mlt_repository_links(mlt_repository self);
-extern mlt_properties mlt_repository_producers(mlt_repository self);
-extern mlt_properties mlt_repository_transitions(mlt_repository self);
-extern void mlt_repository_register_metadata(mlt_repository self,
+MLT_API extern void mlt_repository_close(mlt_repository self);
+MLT_API extern mlt_properties mlt_repository_consumers(mlt_repository self);
+MLT_API extern mlt_properties mlt_repository_filters(mlt_repository self);
+MLT_API extern mlt_properties mlt_repository_links(mlt_repository self);
+MLT_API extern mlt_properties mlt_repository_producers(mlt_repository self);
+MLT_API extern mlt_properties mlt_repository_transitions(mlt_repository self);
+MLT_API extern void mlt_repository_register_metadata(mlt_repository self,
                                              mlt_service_type type,
                                              const char *service,
                                              mlt_metadata_callback,
                                              void *callback_data);
-extern mlt_properties mlt_repository_metadata(mlt_repository self,
+MLT_API extern mlt_properties mlt_repository_metadata(mlt_repository self,
                                               mlt_service_type type,
                                               const char *service);
-extern mlt_properties mlt_repository_languages(mlt_repository self);
-extern mlt_properties mlt_repository_presets();
+MLT_API extern mlt_properties mlt_repository_languages(mlt_repository self);
+MLT_API extern mlt_properties mlt_repository_presets();
 
 #endif

--- a/src/framework/mlt_service.h
+++ b/src/framework/mlt_service.h
@@ -25,6 +25,7 @@
 
 #include "mlt_properties.h"
 #include "mlt_types.h"
+#include "mlt_api.h"
 
 /** \brief Service abstract base class
  *
@@ -77,35 +78,35 @@ struct mlt_service_s
 
 #define MLT_SERVICE_PROPERTIES(service) (&(service)->parent)
 
-extern int mlt_service_init(mlt_service self, void *child);
-extern void mlt_service_lock(mlt_service self);
-extern void mlt_service_unlock(mlt_service self);
-extern mlt_service_type mlt_service_identify(mlt_service self);
-extern int mlt_service_connect_producer(mlt_service self, mlt_service producer, int index);
-extern int mlt_service_insert_producer(mlt_service self, mlt_service producer, int index);
-extern int mlt_service_disconnect_producer(mlt_service self, int index);
-extern int mlt_service_disconnect_all_producers(mlt_service self);
-extern mlt_service mlt_service_get_producer(mlt_service self);
-extern int mlt_service_get_frame(mlt_service self, mlt_frame_ptr frame, int index);
-extern mlt_properties mlt_service_properties(mlt_service self);
-extern void mlt_service_set_consumer(mlt_service self, mlt_service consumer);
-extern mlt_service mlt_service_consumer(mlt_service self);
-extern mlt_service mlt_service_producer(mlt_service self);
-extern int mlt_service_attach(mlt_service self, mlt_filter filter);
-extern int mlt_service_detach(mlt_service self, mlt_filter filter);
-extern void mlt_service_apply_filters(mlt_service self, mlt_frame frame, int index);
-extern int mlt_service_filter_count(mlt_service self);
-extern int mlt_service_move_filter(mlt_service self, int from, int to);
-extern mlt_filter mlt_service_filter(mlt_service self, int index);
-extern mlt_profile mlt_service_profile(mlt_service self);
-extern void mlt_service_set_profile(mlt_service self, mlt_profile profile);
-extern void mlt_service_close(mlt_service self);
+MLT_API extern int mlt_service_init(mlt_service self, void *child);
+MLT_API extern void mlt_service_lock(mlt_service self);
+MLT_API extern void mlt_service_unlock(mlt_service self);
+MLT_API extern mlt_service_type mlt_service_identify(mlt_service self);
+MLT_API extern int mlt_service_connect_producer(mlt_service self, mlt_service producer, int index);
+MLT_API extern int mlt_service_insert_producer(mlt_service self, mlt_service producer, int index);
+MLT_API extern int mlt_service_disconnect_producer(mlt_service self, int index);
+MLT_API extern int mlt_service_disconnect_all_producers(mlt_service self);
+MLT_API extern mlt_service mlt_service_get_producer(mlt_service self);
+MLT_API extern int mlt_service_get_frame(mlt_service self, mlt_frame_ptr frame, int index);
+MLT_API extern mlt_properties mlt_service_properties(mlt_service self);
+MLT_API extern void mlt_service_set_consumer(mlt_service self, mlt_service consumer);
+MLT_API extern mlt_service mlt_service_consumer(mlt_service self);
+MLT_API extern mlt_service mlt_service_producer(mlt_service self);
+MLT_API extern int mlt_service_attach(mlt_service self, mlt_filter filter);
+MLT_API extern int mlt_service_detach(mlt_service self, mlt_filter filter);
+MLT_API extern void mlt_service_apply_filters(mlt_service self, mlt_frame frame, int index);
+MLT_API extern int mlt_service_filter_count(mlt_service self);
+MLT_API extern int mlt_service_move_filter(mlt_service self, int from, int to);
+MLT_API extern mlt_filter mlt_service_filter(mlt_service self, int index);
+MLT_API extern mlt_profile mlt_service_profile(mlt_service self);
+MLT_API extern void mlt_service_set_profile(mlt_service self, mlt_profile profile);
+MLT_API extern void mlt_service_close(mlt_service self);
 
-extern void mlt_service_cache_put(
+MLT_API extern void mlt_service_cache_put(
     mlt_service self, const char *name, void *data, int size, mlt_destructor destructor);
-extern mlt_cache_item mlt_service_cache_get(mlt_service self, const char *name);
-extern void mlt_service_cache_set_size(mlt_service self, const char *name, int size);
-extern int mlt_service_cache_get_size(mlt_service self, const char *name);
-extern void mlt_service_cache_purge(mlt_service self);
+MLT_API extern mlt_cache_item mlt_service_cache_get(mlt_service self, const char *name);
+MLT_API extern void mlt_service_cache_set_size(mlt_service self, const char *name, int size);
+MLT_API extern int mlt_service_cache_get_size(mlt_service self, const char *name);
+MLT_API extern void mlt_service_cache_purge(mlt_service self);
 
 #endif

--- a/src/framework/mlt_slices.c
+++ b/src/framework/mlt_slices.c
@@ -28,7 +28,9 @@
 #include <pthread.h>
 #include <sched.h>
 #include <stdlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #ifdef _WIN32
 #include <windows.h>
 #endif

--- a/src/framework/mlt_slices.h
+++ b/src/framework/mlt_slices.h
@@ -24,7 +24,7 @@
 #define MLT_SLICES_H
 
 #include "mlt_types.h"
-
+#include "mlt_api.h"
 /**
  * \envvar \em MLT_SLICES_COUNT Set the number of slices to use, which
  * defaults to number of CPUs found.
@@ -34,18 +34,18 @@ struct mlt_slices_s;
 
 typedef int (*mlt_slices_proc)(int id, int idx, int jobs, void *cookie);
 
-extern int mlt_slices_count_normal();
+MLT_API extern int mlt_slices_count_normal();
 
-extern int mlt_slices_count_rr();
+MLT_API extern int mlt_slices_count_rr();
 
-extern int mlt_slices_count_fifo();
+MLT_API extern int mlt_slices_count_fifo();
 
-extern void mlt_slices_run_normal(int jobs, mlt_slices_proc proc, void *cookie);
+MLT_API extern void mlt_slices_run_normal(int jobs, mlt_slices_proc proc, void *cookie);
 
-extern void mlt_slices_run_rr(int jobs, mlt_slices_proc proc, void *cookie);
+MLT_API extern void mlt_slices_run_rr(int jobs, mlt_slices_proc proc, void *cookie);
 
-extern void mlt_slices_run_fifo(int jobs, mlt_slices_proc proc, void *cookie);
+MLT_API extern void mlt_slices_run_fifo(int jobs, mlt_slices_proc proc, void *cookie);
 
-extern int mlt_slices_size_slice(int jobs, int index, int input_size, int *start);
+MLT_API extern int mlt_slices_size_slice(int jobs, int index, int input_size, int *start);
 
 #endif

--- a/src/framework/mlt_tokeniser.h
+++ b/src/framework/mlt_tokeniser.h
@@ -22,7 +22,7 @@
 
 #ifndef MLT_TOKENISER_H
 #define MLT_TOKENISER_H
-
+#include "mlt_api.h"
 /** \brief Tokeniser class
  *
  */
@@ -38,11 +38,11 @@ typedef struct
 /* Remote parser API.
 */
 
-extern mlt_tokeniser mlt_tokeniser_init();
-extern int mlt_tokeniser_parse_new(mlt_tokeniser tokeniser, char *text, const char *delimiter);
-extern char *mlt_tokeniser_get_input(mlt_tokeniser tokeniser);
-extern int mlt_tokeniser_count(mlt_tokeniser tokeniser);
-extern char *mlt_tokeniser_get_string(mlt_tokeniser tokeniser, int index);
-extern void mlt_tokeniser_close(mlt_tokeniser tokeniser);
+MLT_API extern mlt_tokeniser mlt_tokeniser_init();
+MLT_API extern int mlt_tokeniser_parse_new(mlt_tokeniser tokeniser, char *text, const char *delimiter);
+MLT_API extern char *mlt_tokeniser_get_input(mlt_tokeniser tokeniser);
+MLT_API extern int mlt_tokeniser_count(mlt_tokeniser tokeniser);
+MLT_API extern char *mlt_tokeniser_get_string(mlt_tokeniser tokeniser, int index);
+MLT_API extern void mlt_tokeniser_close(mlt_tokeniser tokeniser);
 
 #endif

--- a/src/framework/mlt_tractor.h
+++ b/src/framework/mlt_tractor.h
@@ -24,7 +24,7 @@
 #define MLT_TRACTOR_H
 
 #include "mlt_producer.h"
-
+#include "mlt_api.h"
 /** \brief Tractor class
  *
  * The tractor is a convenience class that works with the field class
@@ -46,19 +46,19 @@ struct mlt_tractor_s
 #define MLT_TRACTOR_SERVICE(tractor) MLT_PRODUCER_SERVICE(MLT_TRACTOR_PRODUCER(tractor))
 #define MLT_TRACTOR_PROPERTIES(tractor) MLT_SERVICE_PROPERTIES(MLT_TRACTOR_SERVICE(tractor))
 
-extern mlt_tractor mlt_tractor_init();
-extern mlt_tractor mlt_tractor_new();
-extern mlt_service mlt_tractor_service(mlt_tractor self);
-extern mlt_producer mlt_tractor_producer(mlt_tractor self);
-extern mlt_properties mlt_tractor_properties(mlt_tractor self);
-extern mlt_field mlt_tractor_field(mlt_tractor self);
-extern mlt_multitrack mlt_tractor_multitrack(mlt_tractor self);
-extern int mlt_tractor_connect(mlt_tractor self, mlt_service service);
-extern void mlt_tractor_refresh(mlt_tractor self);
-extern int mlt_tractor_set_track(mlt_tractor self, mlt_producer producer, int index);
-extern int mlt_tractor_insert_track(mlt_tractor self, mlt_producer producer, int index);
-extern int mlt_tractor_remove_track(mlt_tractor self, int index);
-extern mlt_producer mlt_tractor_get_track(mlt_tractor self, int index);
-extern void mlt_tractor_close(mlt_tractor self);
+MLT_API extern mlt_tractor mlt_tractor_init();
+MLT_API extern mlt_tractor mlt_tractor_new();
+MLT_API extern mlt_service mlt_tractor_service(mlt_tractor self);
+MLT_API extern mlt_producer mlt_tractor_producer(mlt_tractor self);
+MLT_API extern mlt_properties mlt_tractor_properties(mlt_tractor self);
+MLT_API extern mlt_field mlt_tractor_field(mlt_tractor self);
+MLT_API extern mlt_multitrack mlt_tractor_multitrack(mlt_tractor self);
+MLT_API extern int mlt_tractor_connect(mlt_tractor self, mlt_service service);
+MLT_API extern void mlt_tractor_refresh(mlt_tractor self);
+MLT_API extern int mlt_tractor_set_track(mlt_tractor self, mlt_producer producer, int index);
+MLT_API extern int mlt_tractor_insert_track(mlt_tractor self, mlt_producer producer, int index);
+MLT_API extern int mlt_tractor_remove_track(mlt_tractor self, int index);
+MLT_API extern mlt_producer mlt_tractor_get_track(mlt_tractor self, int index);
+MLT_API extern void mlt_tractor_close(mlt_tractor self);
 
 #endif

--- a/src/framework/mlt_transition.h
+++ b/src/framework/mlt_transition.h
@@ -24,6 +24,7 @@
 #define MLT_TRANSITION_H
 
 #include "mlt_service.h"
+#include "mlt_api.h"
 #include <pthread.h>
 
 /** \brief Transition abstract service class
@@ -66,25 +67,25 @@ struct mlt_transition_s
 #define MLT_TRANSITION_PROPERTIES(transition) \
     MLT_SERVICE_PROPERTIES(MLT_TRANSITION_SERVICE(transition))
 
-extern int mlt_transition_init(mlt_transition self, void *child);
-extern mlt_transition mlt_transition_new();
-extern mlt_service mlt_transition_service(mlt_transition self);
-extern mlt_properties mlt_transition_properties(mlt_transition self);
-extern int mlt_transition_connect(mlt_transition self,
+MLT_API extern int mlt_transition_init(mlt_transition self, void *child);
+MLT_API extern mlt_transition mlt_transition_new();
+MLT_API extern mlt_service mlt_transition_service(mlt_transition self);
+MLT_API extern mlt_properties mlt_transition_properties(mlt_transition self);
+MLT_API extern int mlt_transition_connect(mlt_transition self,
                                   mlt_service producer,
                                   int a_track,
                                   int b_track);
-extern void mlt_transition_set_in_and_out(mlt_transition self, mlt_position in, mlt_position out);
-extern void mlt_transition_set_tracks(mlt_transition self, int a_track, int b_track);
-extern int mlt_transition_get_a_track(mlt_transition self);
-extern int mlt_transition_get_b_track(mlt_transition self);
-extern mlt_position mlt_transition_get_in(mlt_transition self);
-extern mlt_position mlt_transition_get_out(mlt_transition self);
-extern mlt_position mlt_transition_get_length(mlt_transition self);
-extern mlt_position mlt_transition_get_position(mlt_transition self, mlt_frame frame);
-extern double mlt_transition_get_progress(mlt_transition self, mlt_frame frame);
-extern double mlt_transition_get_progress_delta(mlt_transition self, mlt_frame frame);
-extern mlt_frame mlt_transition_process(mlt_transition self, mlt_frame a_frame, mlt_frame b_frame);
-extern void mlt_transition_close(mlt_transition self);
+MLT_API extern void mlt_transition_set_in_and_out(mlt_transition self, mlt_position in, mlt_position out);
+MLT_API extern void mlt_transition_set_tracks(mlt_transition self, int a_track, int b_track);
+MLT_API extern int mlt_transition_get_a_track(mlt_transition self);
+MLT_API extern int mlt_transition_get_b_track(mlt_transition self);
+MLT_API extern mlt_position mlt_transition_get_in(mlt_transition self);
+MLT_API extern mlt_position mlt_transition_get_out(mlt_transition self);
+MLT_API extern mlt_position mlt_transition_get_length(mlt_transition self);
+MLT_API extern mlt_position mlt_transition_get_position(mlt_transition self, mlt_frame frame);
+MLT_API extern double mlt_transition_get_progress(mlt_transition self, mlt_frame frame);
+MLT_API extern double mlt_transition_get_progress_delta(mlt_transition self, mlt_frame frame);
+MLT_API extern mlt_frame mlt_transition_process(mlt_transition self, mlt_frame a_frame, mlt_frame b_frame);
+MLT_API extern void mlt_transition_close(mlt_transition self);
 
 #endif

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -30,7 +30,7 @@ extern "C" {
 #include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
-
+#include "mlt_api.h"
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
@@ -292,19 +292,19 @@ typedef void *(*mlt_thread_function_t)(void *);      /**< generic thread functio
 #include <pthread.h>
 /* Win32 compatibility function declarations */
 #if !defined(__MINGW32__)
-extern int usleep(unsigned int useconds);
+MLT_API extern int usleep(unsigned int useconds);
 #endif
 #ifndef WIN_PTHREADS_TIME_H
-extern int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
+MLT_API extern int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
 #endif
-extern int setenv(const char *name, const char *value, int overwrite);
-extern char *getlocale();
-extern FILE *win32_fopen(const char *filename_utf8, const char *mode_utf8);
+MLT_API extern int setenv(const char *name, const char *value, int overwrite);
+MLT_API extern char *getlocale();
+MLT_API extern FILE *win32_fopen(const char *filename_utf8, const char *mode_utf8);
 #include <sys/stat.h>
 #include <sys/types.h>
-extern int win32_stat(const char *filename_utf8, struct stat *buffer);
+MLT_API extern int win32_stat(const char *filename_utf8, struct stat *buffer);
 #include <time.h>
-extern char *strptime(const char *buf, const char *fmt, struct tm *tm);
+MLT_API extern char *strptime(const char *buf, const char *fmt, struct tm *tm);
 #define mlt_fopen win32_fopen
 #define mlt_stat win32_stat
 #define MLT_DIRLIST_DELIMITER ";"
@@ -314,8 +314,8 @@ extern char *strptime(const char *buf, const char *fmt, struct tm *tm);
 #define MLT_DIRLIST_DELIMITER ":"
 #endif /* ifdef _WIN32 */
 
-extern const char *mlt_deinterlacer_name(mlt_deinterlacer method);
-extern mlt_deinterlacer mlt_deinterlacer_id(const char *name);
+MLT_API extern const char *mlt_deinterlacer_name(mlt_deinterlacer method);
+MLT_API extern mlt_deinterlacer mlt_deinterlacer_id(const char *name);
 
 #ifdef __cplusplus
 }

--- a/src/framework/mlt_version.h
+++ b/src/framework/mlt_version.h
@@ -33,11 +33,11 @@
     ((LIBMLT_VERSION_MAJOR << 16) + (LIBMLT_VERSION_MINOR << 8) + LIBMLT_VERSION_REVISION)
 #define LIBMLT_VERSION \
     MLT_STRINGIZE(LIBMLT_VERSION_MAJOR.LIBMLT_VERSION_MINOR.LIBMLT_VERSION_REVISION)
-
-extern int mlt_version_get_int();
-extern int mlt_version_get_major();
-extern int mlt_version_get_minor();
-extern int mlt_version_get_revision();
-extern char *mlt_version_get_string();
+#include "mlt_api.h"
+MLT_API extern int mlt_version_get_int();
+MLT_API extern int mlt_version_get_major();
+MLT_API extern int mlt_version_get_minor();
+MLT_API extern int mlt_version_get_revision();
+MLT_API extern char *mlt_version_get_string();
 
 #endif

--- a/src/framework/msvc_posix_compat.h
+++ b/src/framework/msvc_posix_compat.h
@@ -1,0 +1,44 @@
+#ifndef MSVC_COMPAT_H
+#define MSVC_COMPAT_H
+
+#ifdef _MSC_VER // 只在 MSVC 编译器下生效
+
+// ------------------------------------------------------------------
+// 关键部分：建立一个干净且完整的 Windows/Winsock 环境
+// ------------------------------------------------------------------
+
+// 1. 定义 WIN32_LEAN_AND_MEAN 来减少不必要的包含，避免冲突
+//    但是，对于 COM，我们可能需要完整的 windows.h，所以可以暂时注释掉它来测试
+// #ifndef WIN32_LEAN_AND_MEAN
+// #define WIN32_LEAN_AND_MEAN
+// #endif
+
+// 2. 确保 Winsock2 在最前面，解决 sockaddr 重定义问题
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+// 3. 包含完整的 Windows 头文件，它会定义 'interface' 等 COM 关键字
+//    这一步是解决当前问题的关键
+#include <windows.h>
+
+// 4. 包含其他 COM 核心头文件，确保万无一失
+#include <objbase.h>
+
+
+// ------------------------------------------------------------------
+// POSIX 兼容性定义
+// ------------------------------------------------------------------
+#include <BaseTsd.h>
+#include <io.h>
+#include <string.h>
+
+typedef SSIZE_T ssize_t;
+#define STDIN_FILENO  _fileno(stdin)
+#define STDOUT_FILENO _fileno(stdout)
+#define STDERR_FILENO _fileno(stderr)
+#define strcasecmp  _stricmp
+#define strncasecmp _strnicmp
+
+#endif // _MSC_VER
+
+#endif // MSVC_COMPAT_H

--- a/src/melt/CMakeLists.txt
+++ b/src/melt/CMakeLists.txt
@@ -1,5 +1,13 @@
-add_executable(melt melt.c io.c io.h)
-
+add_executable(melt
+        ${CMAKE_CURRENT_SOURCE_DIR}/melt.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/io.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/io.h
+)
+set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/melt.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/io.c
+        PROPERTIES LANGUAGE C
+)
 target_compile_options(melt PRIVATE ${MLT_COMPILE_OPTIONS})
 
 target_link_libraries(melt PRIVATE mlt Threads::Threads)

--- a/src/melt/io.c
+++ b/src/melt/io.c
@@ -32,11 +32,22 @@
 // MinGW defines struct timespec in pthread.h
 #include <pthread.h>
 // for nanosleep()
+#ifdef _MSC_VER
+    // 在 Windows 上，确保 winsock2.h 在 windows.h 之前被包含
+    // 以防止 sockaddr 重定义错误
+    #include <winsock2.h>
+#endif
 #include <framework/mlt_types.h>
 #include <windows.h>
 #endif
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 /* Application header files */
 #include "io.h"

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -31,9 +31,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 // avformat header files
 #include <libavcodec/avcodec.h>
@@ -1427,8 +1433,9 @@ static int encode_audio(encode_ctx_t *ctx)
 
                         while (--s) {
                             memcpy(dest, src, ctx->sample_bytes);
-                            dest += current_channels * ctx->sample_bytes;
-                            src += ctx->channels * ctx->sample_bytes;
+                            // 修改后的正确代码
+                            dest = (char *)dest + current_channels * ctx->sample_bytes;
+                            src = (char *)src + ctx->channels * ctx->sample_bytes;
                         }
                     }
                 }

--- a/src/modules/avformat/link_avfilter.c
+++ b/src/modules/avformat/link_avfilter.c
@@ -819,26 +819,25 @@ static int link_get_audio(mlt_frame frame,
             break;
         }
 
+        int out_channels;
         // Sanity check the output frame
 #if HAVE_FFMPEG_CH_LAYOUT
+        out_channels = pdata->avoutframe->ch_layout.nb_channels;
         if (*channels != pdata->avoutframe->ch_layout.nb_channels
 #else
+        out_channels = pdata->avoutframe->channels;
         if (*channels != pdata->avoutframe->channels
 #endif
             || *samples != pdata->avoutframe->nb_samples
             || *frequency != pdata->avoutframe->sample_rate) {
             mlt_log_error(self,
-                          "Unexpected return format c %d->%d\tf %d->%d\tf %d->%d\n",
-                          *channels,
-#if HAVE_FFMPEG_CH_LAYOUT
-                          pdata->avoutframe->ch_layout.nb_channels,
-#else
-                          pdata->avoutframe->channels,
-#endif
-                          *samples,
-                          pdata->avoutframe->nb_samples,
-                          *frequency,
-                          pdata->avoutframe->sample_rate);
+              "Unexpected return format c %d->%d\tf %d->%d\tf %d->%d\n",
+              *channels,
+              out_channels, // <-- 使用临时变量
+              *samples,
+              pdata->avoutframe->nb_samples,
+              *frequency,
+              pdata->avoutframe->sample_rate);
             error = 1;
             break;
         }

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -3614,10 +3614,15 @@ static int producer_get_audio(mlt_frame frame,
                 size = self->audio_used[index] < *samples ? self->audio_used[index] : *samples;
                 memcpy(*buffer, src, size * *channels * sizeof_sample);
                 // supply the remaining requested samples as silence
-                if (*samples > self->audio_used[index])
-                    memset(*buffer + size * *channels * sizeof_sample,
+                if (*samples > self->audio_used[index]) {
+                    // 先将 void* 转换为 char*，以便进行字节级别的指针运算
+                    char *dest_ptr = (char *)(*buffer) + (size * *channels * sizeof_sample);
+
+                    // 然后将计算好的、类型正确的指针传递给 memset
+                    memset(dest_ptr,
                            silence,
                            (*samples - self->audio_used[index]) * *channels * sizeof_sample);
+                }
                 // reposition the samples within audio_buffer
                 self->audio_used[index] -= size;
                 memmove(src,

--- a/src/modules/core/consumer_multi.c
+++ b/src/modules/core/consumer_multi.c
@@ -22,7 +22,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 // Forward references
 static int start(mlt_consumer consumer);

--- a/src/modules/core/filter_audiochannels.c
+++ b/src/modules/core/filter_audiochannels.c
@@ -136,13 +136,19 @@ static int filter_get_audio(mlt_frame frame,
                 in += 6;
             }
         } else if (*format == mlt_audio_s32) {
-            int32_t *flin = *buffer;
-            int32_t *frin = *buffer + (*samples * sizeof(float));
-            int32_t *cin = *buffer + (2 * *samples * sizeof(float));
-            int32_t *slin = *buffer + (4 * *samples * sizeof(float));
-            int32_t *srin = *buffer + (5 * *samples * sizeof(float));
-            int32_t *lout = *buffer;
-            int32_t *rout = *buffer + (*samples * sizeof(float));
+            // 先将 void* 转换为 char*，以便进行字节级别的指针运算
+            char *buffer_start = (char*)(*buffer);
+
+            // flin 和 lout 指向缓冲区的起始位置
+            int32_t *flin = (int32_t*)buffer_start;
+            int32_t *lout = (int32_t*)buffer_start;
+
+            // 其他指针基于起始位置进行字节偏移
+            int32_t *frin = (int32_t*)(buffer_start + (*samples * sizeof(float)));
+            int32_t *cin  = (int32_t*)(buffer_start + (2 * *samples * sizeof(float)));
+            int32_t *slin = (int32_t*)(buffer_start + (4 * *samples * sizeof(float)));
+            int32_t *srin = (int32_t*)(buffer_start + (5 * *samples * sizeof(float)));
+            int32_t *rout = (int32_t*)(buffer_start + (*samples * sizeof(float)));
             int i;
             for (i = 0; i < *samples; i++) {
                 double fl = *flin++;
@@ -154,13 +160,19 @@ static int filter_get_audio(mlt_frame frame,
                 *rout++ = CLAMP(MIX(fr, c, sr), INT32_MIN, INT32_MAX);
             }
         } else if (*format == mlt_audio_float) {
-            float *flin = *buffer;
-            float *frin = *buffer + (*samples * sizeof(float));
-            float *cin = *buffer + (2 * *samples * sizeof(float));
-            float *slin = *buffer + (4 * *samples * sizeof(float));
-            float *srin = *buffer + (5 * *samples * sizeof(float));
-            float *lout = *buffer;
-            float *rout = *buffer + (*samples * sizeof(float));
+            // 同样，先将 void* 转换为 char*
+            char *buffer_start = (char*)(*buffer);
+
+            // flin 和 lout 指向缓冲区的起始位置
+            float *flin = (float*)buffer_start;
+            float *lout = (float*)buffer_start;
+
+            // 其他指针基于起始位置进行字节偏移
+            float *frin = (float*)(buffer_start + (*samples * sizeof(float)));
+            float *cin  = (float*)(buffer_start + (2 * *samples * sizeof(float)));
+            float *slin = (float*)(buffer_start + (4 * *samples * sizeof(float)));
+            float *srin = (float*)(buffer_start + (5 * *samples * sizeof(float)));
+            float *rout = (float*)(buffer_start + (*samples * sizeof(float)));
             int i;
             for (i = 0; i < *samples; i++) {
                 float fl = *flin++;

--- a/src/modules/core/filter_pillar_echo.c
+++ b/src/modules/core/filter_pillar_echo.c
@@ -71,7 +71,7 @@ static int scale_sliced_proc(int id, int index, int jobs, void *data)
     int slice_line_end = slice_line_start + slice_height;
     double srcScale = rect.h / (double) src->height;
     int linesize = src->width * 4;
-    uint8_t *d = dst->data + (slice_line_start * linesize);
+    uint8_t *d = (uint8_t *)((char *)(dst->data) + (slice_line_start * linesize));
     for (int y = slice_line_start; y < slice_line_end; y++) {
         double srcY = rect.y + (double) y * srcScale;
         int srcYindex = floor(srcY);
@@ -88,7 +88,7 @@ static int scale_sliced_proc(int id, int index, int jobs, void *data)
             double valueSum[] = {0.0, 0.0, 0.0, 0.0};
             double factorSum[] = {0.0, 0.0, 0.0, 0.0};
 
-            uint8_t *s = src->data + (srcYindex * linesize) + (srcXindex * 4);
+            uint8_t *s = (uint8_t *)((char *)(src->data) + (srcYindex * linesize) + (srcXindex * 4));
 
             // Top Left
             double ftl = ftop * fleft;
@@ -194,8 +194,8 @@ static void blit_rect(mlt_image src, mlt_image dst, mlt_rect rect)
     int blitHeight = rect.h;
     int blitWidth = rect.w * 4;
     int linesize = src->width * 4;
-    uint8_t *s = src->data + (int) rect.y * linesize + (int) rect.x * 4;
-    uint8_t *d = dst->data + (int) rect.y * linesize + (int) rect.x * 4;
+    uint8_t *s = (uint8_t *)((char *)(src->data) + (int) rect.y * linesize + (int) rect.x * 4);
+    uint8_t *d = (uint8_t *)((char *)(dst->data) + (int) rect.y * linesize + (int) rect.x * 4);
     while (blitHeight--) {
         memcpy(d, s, blitWidth);
         s += linesize;

--- a/src/modules/core/image_proc.c
+++ b/src/modules/core/image_proc.c
@@ -50,11 +50,11 @@ static int blur_h_proc_rgba(int id, int index, int jobs, void *data)
     double diameter = (radius * 2) + 1;
 
     for (y = slice_line_start; y < slice_line_end; y++) {
-        uint8_t *first = desc->src->data + (y * linesize);
+        uint8_t *first = (uint8_t *)((char *)(desc->src->data) + (y * linesize));
         uint8_t *last = first + linesize - step;
         uint8_t *s1 = first;
         uint8_t *s2 = first;
-        uint8_t *d = desc->dst->data + (y * linesize);
+        uint8_t *d = (uint8_t *)((char *)(desc->dst->data) + (y * linesize));
         accumulator[0] = first[0] * (radius + 1);
         accumulator[1] = first[1] * (radius + 1);
         accumulator[2] = first[2] * (radius + 1);
@@ -128,11 +128,11 @@ static int blur_v_proc_rgba(int id, int index, int jobs, void *data)
     double diameter = (radius * 2) + 1;
 
     for (x = slice_row_start; x < slice_row_end; x++) {
-        uint8_t *first = desc->src->data + (x * step);
+        uint8_t *first = (uint8_t *)((char *)(desc->src->data) + (x * step));
         uint8_t *last = first + (linesize * (desc->src->height - 1));
         uint8_t *s1 = first;
         uint8_t *s2 = first;
-        uint8_t *d = desc->dst->data + (x * step);
+        uint8_t *d = (uint8_t *)((char *)(desc->dst->data) + (x * step));
         accumulator[0] = first[0] * (radius + 1);
         accumulator[1] = first[1] * (radius + 1);
         accumulator[2] = first[2] * (radius + 1);
@@ -206,11 +206,11 @@ static int blur_h_proc_rgbx(int id, int index, int jobs, void *data)
     double diameter = (radius * 2) + 1;
 
     for (y = slice_line_start; y < slice_line_end; y++) {
-        uint8_t *first = desc->src->data + (y * linesize);
+        uint8_t *first = (uint8_t *)((char *)(desc->src->data) + (y * linesize));
         uint8_t *last = first + linesize - step;
         uint8_t *s1 = first;
         uint8_t *s2 = first;
-        uint8_t *d = desc->dst->data + (y * linesize);
+        uint8_t *d = (uint8_t *)((char *)(desc->dst->data) + (y * linesize));
         accumulator[0] = first[0] * (radius + 1);
         accumulator[1] = first[1] * (radius + 1);
         accumulator[2] = first[2] * (radius + 1);
@@ -276,11 +276,11 @@ static int blur_v_proc_rgbx(int id, int index, int jobs, void *data)
     double diameter = (radius * 2) + 1;
 
     for (x = slice_row_start; x < slice_row_end; x++) {
-        uint8_t *first = desc->src->data + (x * step);
+        uint8_t *first = (uint8_t *)((char *)(desc->src->data) + (x * step));
         uint8_t *last = first + (linesize * (desc->src->height - 1));
         uint8_t *s1 = first;
         uint8_t *s2 = first;
-        uint8_t *d = desc->dst->data + (x * step);
+        uint8_t *d = (uint8_t *)((char *)(desc->dst->data) + (x * step));
         accumulator[0] = first[0] * (radius + 1);
         accumulator[1] = first[1] * (radius + 1);
         accumulator[2] = first[2] * (radius + 1);

--- a/src/modules/core/link_timeremap.c
+++ b/src/modules/core/link_timeremap.c
@@ -362,7 +362,15 @@ static int link_get_image_blend(mlt_frame frame,
     double source_fps = mlt_properties_get_double(unique_properties, "source_fps");
 
     // Get pointers to all the images for this frame
-    uint8_t *images[MAX_BLEND_IMAGES];
+    uint8_t **images = (uint8_t **)malloc(MAX_BLEND_IMAGES * sizeof(uint8_t *));
+
+    // 重要：检查 malloc 是否成功
+    if (images == NULL) {
+        // 处理内存分配失败的情况，例如返回错误码或打印日志
+        return 1;
+        // return MLT_LC_FAIL; (或者类似的操作)
+    }
+
     int image_count = 0;
     mlt_position in_frame_pos = floor(source_time * source_fps);
     char key[19];
@@ -435,6 +443,9 @@ static int link_get_image_blend(mlt_frame frame,
                              MLT_FRAME_PROPERTIES(src_frame),
                              "colorspace color_primaries color_trc full_range");
 
+
+    free(images);
+    images = NULL; // 好习惯：防止野指针
     return 0;
 }
 

--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -11,8 +11,20 @@ add_custom_target(Other_decklink_Files SOURCES
 
 target_compile_options(mltdecklink PRIVATE ${MLT_COMPILE_OPTIONS})
 
-target_link_libraries(mltdecklink PRIVATE mlt Threads::Threads)
+if (NOT MSVC)
+  target_link_libraries(mltdecklink PRIVATE mlt Threads::Threads)
+else ()
+  # 手动寻找 gettimeofday.lib
+  find_library(GETTIMEOFDAY_LIBRARY
+          NAMES gettimeofday
+          # vcpkg 会自动把正确的搜索路径加进来
+  )
 
+  if (NOT GETTIMEOFDAY_LIBRARY)
+    message(FATAL_ERROR "Could not find gettimeofday.lib")
+  endif()
+  target_link_libraries(mltdecklink PRIVATE  ${GETTIMEOFDAY_LIBRARY} mlt PThreads4W::PThreads4W)
+endif ()
 if(WIN32)
   target_sources(mltdecklink PRIVATE win/DeckLinkAPI_i.cpp)
   target_include_directories(mltdecklink PRIVATE win)

--- a/src/modules/decklink/common.cpp
+++ b/src/modules/decklink/common.cpp
@@ -19,7 +19,9 @@
 
 #include "common.h"
 #include <stdlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #ifdef __APPLE__
 

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -18,14 +18,21 @@
  */
 
 #define __STDC_FORMAT_MACROS /* see inttypes.h */
+#include <framework/msvc_posix_compat.h>
 #include "common.h"
 #include <framework/mlt.h>
 #include <limits.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #define SWAB_SLICED_ALIGN_POW 5
 static int swab_sliced(int id, int idx, int jobs, void *cookie)

--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -17,14 +17,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "framework/msvc_posix_compat.h"
 #include "common.h"
 #include <framework/mlt.h>
 #include <limits.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+extern "C"{
+    #include <gettimeofday.h>
+    }
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <framework/mlt_slices.h>
 

--- a/src/modules/gdk/CMakeLists.txt
+++ b/src/modules/gdk/CMakeLists.txt
@@ -4,6 +4,9 @@ add_library(mltgdk MODULE
   pixops.c
   producer_pixbuf.c
 )
+if(MSVC)
+  target_link_options(mltgdk PRIVATE "/NODEFAULTLIB:m.lib")
+endif()
 
 file(GLOB YML "*.yml")
 add_custom_target(Other_gdk_Files SOURCES
@@ -11,7 +14,29 @@ add_custom_target(Other_gdk_Files SOURCES
 )
 
 target_compile_options(mltgdk PRIVATE ${MLT_COMPILE_OPTIONS})
+# =================== MSVC 链接修复程序 ===================
+if(MSVC)
+  # --- 修复 PkgConfig::GdkPixbuf ---
+  if(TARGET PkgConfig::GdkPixbuf)
+    # 获取它传递的链接库
+    get_target_property(GDK_LIBS PkgConfig::GdkPixbuf INTERFACE_LINK_LIBRARIES)
+    # 从列表中移除 'm'
+    list(REMOVE_ITEM GDK_LIBS "m")
+    # 将修改后的、干净的列表设置回去
+    set_target_properties(PkgConfig::GdkPixbuf PROPERTIES INTERFACE_LINK_LIBRARIES "${GDK_LIBS}")
+  endif()
 
+  # --- 修复 PkgConfig::libexif ---
+  if(TARGET PkgConfig::libexif)
+    get_target_property(EXIF_LIBS PkgConfig::libexif INTERFACE_LINK_LIBRARIES)
+    list(REMOVE_ITEM EXIF_LIBS "m")
+    set_target_properties(PkgConfig::libexif PROPERTIES INTERFACE_LINK_LIBRARIES "${EXIF_LIBS}")
+  endif()
+
+  # 对其他所有通过 pkg_check_modules 找到的目标也进行同样的操作
+  # 例如 Pango, fftw3, ebur128 等
+endif()
+# ==========================================================
 target_link_libraries(mltgdk PRIVATE mlt Threads::Threads PkgConfig::GdkPixbuf)
 if(NOT MSVC)
   target_link_libraries(mltgdk PRIVATE m)

--- a/src/modules/gdk/producer_pixbuf.c
+++ b/src/modules/gdk/producer_pixbuf.c
@@ -37,7 +37,31 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
+#ifdef _MSC_VER
+    #include <io.h>      // For _close, _write
+    #include <stdio.h>
+    #include <BaseTsd.h> // For SSIZE_T
+
+    // Define ssize_t for MSVC
+    typedef SSIZE_T ssize_t;
+
+// --- 使用函数包装器来避免与结构体成员冲突 ---
+
+// close 的包装器
+static inline int close(int fd)
+{
+    return _close(fd);
+}
+
+// write 的包装器
+static inline int write(int fd, const void *buffer, unsigned int count)
+{
+    return _write(fd, buffer, count);
+}
+#endif
 
 // this protects concurrent access to gdk_pixbuf
 static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/modules/jackrack/consumer_jack.c
+++ b/src/modules/jackrack/consumer_jack.c
@@ -24,8 +24,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #define BUFFER_LEN (204800 * 6)
 

--- a/src/modules/jackrack/filter_jackrack.c
+++ b/src/modules/jackrack/filter_jackrack.c
@@ -22,7 +22,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <jack/jack.h>
 #include <jack/ringbuffer.h>

--- a/src/modules/jackrack/filter_ladspa.c
+++ b/src/modules/jackrack/filter_ladspa.c
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <pthread.h>
 #include <string.h>

--- a/src/modules/jackrack/filter_lv2.c
+++ b/src/modules/jackrack/filter_lv2.c
@@ -25,7 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <pthread.h>
 #include <string.h>

--- a/src/modules/jackrack/filter_vst2.c
+++ b/src/modules/jackrack/filter_vst2.c
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <pthread.h>
 #include <string.h>

--- a/src/modules/jackrack/jack_rack.c
+++ b/src/modules/jackrack/jack_rack.c
@@ -24,7 +24,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
+#ifndef _MSC_VER
+    #include <strings.h>
+#endif
 #include <string.h>
 #include <ctype.h>
 

--- a/src/modules/jackrack/lv2_context.c
+++ b/src/modules/jackrack/lv2_context.c
@@ -26,7 +26,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
+#ifndef _MSC_VER
+    #include <strings.h>
+#endif
 
 #include <ladspa.h>
 #include <libxml/parser.h>

--- a/src/modules/jackrack/lv2_process.c
+++ b/src/modules/jackrack/lv2_process.c
@@ -31,7 +31,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #include <time.h>
 
 #include "framework/mlt_log.h"

--- a/src/modules/jackrack/plugin_mgr.c
+++ b/src/modules/jackrack/plugin_mgr.c
@@ -31,10 +31,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
+#ifndef _MSC_VER
+    #include <strings.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "framework/mlt_factory.h"
 #include "framework/mlt_log.h"

--- a/src/modules/jackrack/process.c
+++ b/src/modules/jackrack/process.c
@@ -30,7 +30,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #include <time.h>
 #include <ctype.h>
 

--- a/src/modules/jackrack/producer_ladspa.c
+++ b/src/modules/jackrack/producer_ladspa.c
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <string.h>
 

--- a/src/modules/jackrack/producer_lv2.c
+++ b/src/modules/jackrack/producer_lv2.c
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <string.h>
 

--- a/src/modules/jackrack/producer_vst2.c
+++ b/src/modules/jackrack/producer_vst2.c
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <string.h>
 

--- a/src/modules/jackrack/vst2_context.c
+++ b/src/modules/jackrack/vst2_context.c
@@ -25,7 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
+#ifndef _MSC_VER
+    #include <strings.h>
+#endif
 
 #include <ladspa.h>
 #include <libxml/parser.h>

--- a/src/modules/jackrack/vst2_process.c
+++ b/src/modules/jackrack/vst2_process.c
@@ -31,7 +31,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #include <time.h>
 
 #include "framework/mlt_log.h"

--- a/src/modules/kdenlive/producer_framebuffer.c
+++ b/src/modules/kdenlive/producer_framebuffer.c
@@ -26,7 +26,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 // Forward references.
 static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int index);

--- a/src/modules/movit/consumer_xgl.c
+++ b/src/modules/movit/consumer_xgl.c
@@ -32,9 +32,15 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <framework/mlt.h>
 

--- a/src/modules/ndi/consumer_ndi.c
+++ b/src/modules/ndi/consumer_ndi.c
@@ -27,8 +27,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "factory.h"
 

--- a/src/modules/ndi/factory.c
+++ b/src/modules/ndi/factory.c
@@ -28,8 +28,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "factory.h"
 

--- a/src/modules/ndi/producer_ndi.c
+++ b/src/modules/ndi/producer_ndi.c
@@ -27,8 +27,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <framework/mlt.h>
 

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -29,7 +29,9 @@
 #include <opencv2/tracking/tracking_legacy.hpp>
 #include <sys/stat.h>  // for stat()
 #include <sys/types.h> // for stat()
-#include <unistd.h>    // for stat()
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif    // for stat()
 #endif
 
 typedef struct

--- a/src/modules/plus/CMakeLists.txt
+++ b/src/modules/plus/CMakeLists.txt
@@ -41,10 +41,37 @@ add_custom_target(Other_plus_Files SOURCES
 
 target_compile_options(mltplus PRIVATE ${MLT_COMPILE_OPTIONS})
 
-target_link_libraries(mltplus PRIVATE mlt Threads::Threads)
+
 if(NOT MSVC)
+  target_link_libraries(mltplus PRIVATE mlt Threads::Threads)
   target_link_libraries(mltplus PRIVATE m)
+else ()
+  target_link_libraries(mltplus PRIVATE mlt PThreads4W::PThreads4W)
 endif()
+
+# =================== MSVC 链接修复程序 (for mltplus) ===================
+if(MSVC)
+  # --- 修复 PkgConfig::FFTW 传递的 -lm 依赖 ---
+  if(TARGET PkgConfig::FFTW)
+    # 获取它传递的链接库
+    get_target_property(FFTW_LIBS PkgConfig::FFTW INTERFACE_LINK_LIBRARIES)
+    # 从列表中移除 'm'
+    list(REMOVE_ITEM FFTW_LIBS "m")
+    # 将修改后的、干净的列表设置回去
+    set_target_properties(PkgConfig::FFTW PROPERTIES INTERFACE_LINK_LIBRARIES "${FFTW_LIBS}")
+  endif()
+
+  # --- 修复 PkgConfig::libebur128 传递的 -lm 依赖 ---
+  if(TARGET PkgConfig::libebur128)
+    # 获取它传递的链接库
+    get_target_property(EBUR128_LIBS PkgConfig::libebur128 INTERFACE_LINK_LIBRARIES)
+    # 从列表中移除 'm'
+    list(REMOVE_ITEM EBUR128_LIBS "m")
+    # 将修改后的、干净的列表设置回去
+    set_target_properties(PkgConfig::libebur128 PROPERTIES INTERFACE_LINK_LIBRARIES "${EBUR128_LIBS}")
+  endif()
+endif()
+
 
 if(TARGET PkgConfig::FFTW)
   target_sources(mltplus PRIVATE filter_dance.c filter_fft.c)

--- a/src/modules/plus/filter_dynamictext.c
+++ b/src/modules/plus/filter_dynamictext.c
@@ -19,14 +19,49 @@
 
 #include <framework/mlt.h>
 
-#include <libgen.h> // for basename()
+#ifdef _MSC_VER
+    #include <string.h> // for strrchr
+
+    // 为 MSVC 提供一个简单的 basename 实现
+    // 注意：这个实现返回一个指向原始字符串内部的指针
+    static inline char *basename(char *path) {
+        if (path == NULL || *path == '\0') {
+            // 如果路径为空或空字符串，返回"."
+            return ".";
+        }
+
+        // 查找最后一个路径分隔符（'/' 或 '\'）
+        char *last_slash = strrchr(path, '/');
+        char *last_bslash = strrchr(path, '\\');
+
+        if (last_slash && last_bslash) {
+            // 如果两者都存在，取后面的那一个
+            last_slash = (last_slash > last_bslash) ? last_slash : last_bslash;
+        } else if (last_bslash) {
+            // 如果只有反斜杠
+            last_slash = last_bslash;
+        }
+
+        if (last_slash != NULL) {
+            // 如果找到了分隔符，返回它后面的字符
+            return last_slash + 1;
+        } else {
+            // 如果没有找到分隔符，整个字符串就是文件名
+            return path;
+        }
+    }
+#else
+    #include <libgen.h>
+#endif // for basename()
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>  // for stat()
 #include <sys/types.h> // for stat()
 #include <time.h>      // for strftime() and gtime()
-#include <unistd.h>    // for stat()
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif    // for stat()
 
 #define MAX_TEXT_LEN 512
 

--- a/src/modules/qt/CMakeLists.txt
+++ b/src/modules/qt/CMakeLists.txt
@@ -47,14 +47,26 @@ function(mlt_add_qt_module ARG_TARGET)
 
     target_compile_options(${ARG_TARGET} PRIVATE ${MLT_COMPILE_OPTIONS})
 
-    target_link_libraries(${ARG_TARGET} PRIVATE
-      mlt++
-      mlt
-      Threads::Threads
-      Qt${ARG_QT_VERSION}::Core
-      Qt${ARG_QT_VERSION}::Gui
-      Qt${ARG_QT_VERSION}::Xml
-    )
+    if (NOT MSVC)
+        target_link_libraries(${ARG_TARGET} PRIVATE
+                mlt++
+                mlt
+                Threads::Threads
+                Qt${ARG_QT_VERSION}::Core
+                Qt${ARG_QT_VERSION}::Gui
+                Qt${ARG_QT_VERSION}::Xml
+        )
+    else ()
+        target_link_libraries(${ARG_TARGET} PRIVATE
+                mlt++
+                mlt
+                PThreads4W::PThreads4W
+                Qt${ARG_QT_VERSION}::Core
+                Qt${ARG_QT_VERSION}::Gui
+                Qt${ARG_QT_VERSION}::Xml
+        )
+    endif ()
+
 
     if(NOT MSVC)
       target_link_libraries(${ARG_TARGET} PRIVATE m)
@@ -84,6 +96,28 @@ function(mlt_add_qt_module ARG_TARGET)
       install(FILES transition_vqm.yml DESTINATION ${MLT_INSTALL_DATA_DIR}/${ARG_DATADIR})
     endif()
 
+    # =================== MSVC 链接修复程序 (for Qt6 module) ===================
+    if(MSVC)
+        # --- 修复 PkgConfig::FFTW 传递的 -lm 依赖 ---
+        if(TARGET PkgConfig::FFTW)
+            get_target_property(FFTW_LIBS PkgConfig::FFTW INTERFACE_LINK_LIBRARIES)
+            list(REMOVE_ITEM FFTW_LIBS "m")
+            set_target_properties(PkgConfig::FFTW PROPERTIES INTERFACE_LINK_LIBRARIES "${FFTW_LIBS}")
+        endif()
+
+        # --- 修复 PkgConfig::libexif 传递的 -lm 依赖 ---
+        if(TARGET PkgConfig::libexif)
+            get_target_property(EXIF_LIBS PkgConfig::libexif INTERFACE_LINK_LIBRARIES)
+            list(REMOVE_ITEM EXIF_LIBS "m")
+            set_target_properties(PkgConfig::libexif PROPERTIES INTERFACE_LINK_LIBRARIES "${EXIF_LIBS}")
+        endif()
+    endif()
+
+    if (MSVC)
+        target_sources(${ARG_TARGET} PRIVATE
+                ${CMAKE_SOURCE_DIR}/src/win32/strptime.c
+        )
+    endif ()
     if(TARGET PkgConfig::FFTW)
       target_sources(${ARG_TARGET} PRIVATE filter_audiospectrum.cpp filter_lightshow.cpp)
       target_link_libraries(${ARG_TARGET} PRIVATE PkgConfig::FFTW)

--- a/src/modules/qt/producer_qimage.c
+++ b/src/modules/qt/producer_qimage.c
@@ -27,7 +27,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 static void load_filenames(producer_qimage self, mlt_properties producer_properties);
 static int producer_get_frame(mlt_producer parent, mlt_frame_ptr frame, int index);

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -42,7 +42,9 @@
 #include <cmath>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 extern "C" {
 

--- a/src/modules/rtaudio/CMakeLists.txt
+++ b/src/modules/rtaudio/CMakeLists.txt
@@ -9,9 +9,39 @@ add_custom_target(Other_rtaudio_Files SOURCES
 
 target_compile_options(mltrtaudio PRIVATE ${MLT_COMPILE_OPTIONS})
 
-target_link_libraries(mltrtaudio PRIVATE mlt Threads::Threads)
+if (MSVC)
+  target_link_libraries(mltrtaudio PRIVATE mlt PThreads4W::PThreads4W)
+
+  find_library(GETTIMEOFDAY_LIBRARY
+          NAMES gettimeofday
+          PATHS "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/debug/lib/manual-link"
+          NO_DEFAULT_PATH
+  )
+
+  message(STATUS ">> Linking with gettimeofday = ${GETTIMEOFDAY_LIBRARY}")
+
+  if (NOT GETTIMEOFDAY_LIBRARY)
+    message(FATAL_ERROR "Could not find debug gettimeofday.lib")
+  endif()
+
+  target_link_libraries(mltrtaudio PRIVATE ${GETTIMEOFDAY_LIBRARY})
+else ()
+  target_link_libraries(mltrtaudio PRIVATE mlt Threads::Threads)
+endif ()
+
 
 if(TARGET PkgConfig::rtaudio)
+  if(MSVC)
+    # --- 修复 rtaudio 传递的错误 pthread 依赖 ---
+    if(TARGET PkgConfig::rtaudio) # 假设 vcpkg 创建的 target 名是 rtaudio::rtaudio
+      # 获取它传递的链接库
+      get_target_property(RTAUDIO_LIBS PkgConfig::rtaudio INTERFACE_LINK_LIBRARIES)
+      # 从列表中移除 'pthread'
+      list(REMOVE_ITEM RTAUDIO_LIBS "pthread")
+      # 将修改后的、干净的列表设置回去
+      set_target_properties(PkgConfig::rtaudio PROPERTIES INTERFACE_LINK_LIBRARIES "${RTAUDIO_LIBS}")
+    endif()
+  endif()
   target_link_libraries(mltrtaudio PRIVATE PkgConfig::rtaudio)
 else()
   target_sources(mltrtaudio PRIVATE RtAudio.cpp RtAudio.h)

--- a/src/modules/rtaudio/RtAudio.cpp
+++ b/src/modules/rtaudio/RtAudio.cpp
@@ -937,7 +937,9 @@ unsigned int RtApi :: getStreamSampleRate( void )
 
 #if defined(__MACOSX_CORE__)
 
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 // The OS X CoreAudio API is designed to use a separate callback
 // procedure for each of its audio devices.  A single RtAudio duplex
@@ -2516,7 +2518,9 @@ const char* RtApiCore :: getErrorCode( OSStatus code )
 // devices are available (i.e., the JACK server is not running), a
 // stream cannot be opened.
 
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <cstdio>
 
 // A structure to hold various information related to the Jack API
@@ -7856,7 +7860,9 @@ static const char* getErrorString( int code )
 #if defined(__LINUX_ALSA__)
 
 #include <alsa/asoundlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
   // A structure to hold various information related to the ALSA API
   // implementation.
@@ -9877,9 +9883,13 @@ RtAudioErrorType RtApiPulse::abortStream( void )
 
 #if defined(__LINUX_OSS__)
 
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <sys/ioctl.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 #include <errno.h>
 #include <math.h>

--- a/src/modules/rtaudio/RtAudio.h
+++ b/src/modules/rtaudio/RtAudio.h
@@ -737,7 +737,11 @@ class S24 {
 #pragma pack(pop)
 
 #if defined( HAVE_GETTIMEOFDAY )
-  #include <sys/time.h>
+  #ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 #endif
 
 #include <sstream>

--- a/src/modules/rtaudio/consumer_rtaudio.cpp
+++ b/src/modules/rtaudio/consumer_rtaudio.cpp
@@ -21,7 +21,13 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+extern "C"{
+    #include <gettimeofday.h>
+}
+#else
+    #include <sys/time.h>
+#endif
 #ifdef USE_INTERNAL_RTAUDIO
 #include "RtAudio.h"
 #else

--- a/src/modules/sdl/consumer_sdl.c
+++ b/src/modules/sdl/consumer_sdl.c
@@ -30,7 +30,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 #include "consumer_sdl_osx.h"
 

--- a/src/modules/sdl/consumer_sdl_audio.c
+++ b/src/modules/sdl/consumer_sdl_audio.c
@@ -29,7 +29,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 extern pthread_mutex_t mlt_sdl_mutex;
 

--- a/src/modules/sdl/consumer_sdl_preview.c
+++ b/src/modules/sdl/consumer_sdl_preview.c
@@ -27,7 +27,11 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 extern pthread_mutex_t mlt_sdl_mutex;
 

--- a/src/modules/sdl/consumer_sdl_still.c
+++ b/src/modules/sdl/consumer_sdl_still.c
@@ -30,7 +30,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 #include "consumer_sdl_osx.h"
 

--- a/src/modules/sdl2/CMakeLists.txt
+++ b/src/modules/sdl2/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_target(Other_sdl2_Files SOURCES
   ${YML}
 )
 
-target_compile_options(mltsdl2 PRIVATE ${MLT_COMPILE_OPTIONS})
+target_compile_options(mltsdl2 PRIVATE   ${MLT_COMPILE_OPTIONS})
 
 target_link_libraries(mltsdl2 PRIVATE mlt Threads::Threads PkgConfig::sdl2)
 if(NOT MSVC)

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -31,11 +31,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+#include "framework/mlt_consumer.h"
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
 #undef MLT_IMAGE_FORMAT // only yuv422 working currently
 
-extern pthread_mutex_t mlt_sdl_mutex;
+
 
 /** This classes definition.
 */

--- a/src/modules/sdl2/consumer_sdl2_audio.c
+++ b/src/modules/sdl2/consumer_sdl2_audio.c
@@ -31,9 +31,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#ifdef _MSC_VER
+    #include "framework/mlt_consumer.h"
+    #include <gettimeofday.h>
+#else
+    #include <sys/time.h>
+#endif
 
-extern pthread_mutex_t mlt_sdl_mutex;
 
 /** This classes definition.
 */

--- a/src/modules/sdl2/sdl2_export.h
+++ b/src/modules/sdl2/sdl2_export.h
@@ -1,0 +1,14 @@
+#ifndef SDL2_EXPORT_H
+#define SDL2_EXPORT_H
+
+#ifdef _WIN32
+    #ifdef MLTSDL2_BUILD_DLL
+        #define MLTSDL2_API __declspec(dllexport)
+    #else
+        #define MLTSDL2_API __declspec(dllimport)
+    #endif
+#else
+    #define MLTSDL2_API
+#endif
+
+#endif // SDL2_EXPORT_H

--- a/src/modules/xine/xineutils.h
+++ b/src/modules/xine/xineutils.h
@@ -25,7 +25,9 @@
 extern "C" {
 #endif
 
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
@@ -34,7 +36,12 @@ extern "C" {
 #if HAVE_LIBGEN_H
 #  include <libgen.h>
 #endif
-
+#ifdef _MSC_VER
+#include <malloc.h>
+#define alloca _alloca // 为 MSVC 定义一个别名
+#else
+#include <alloca.h>
+#endif
 //#ifdef XINE_COMPILE
 #  include "attributes.h"
 //#  include "compat.h"
@@ -717,7 +724,7 @@ static inline char *_private_strsep(char **stringp, const char *delim) {
 #else
 static inline void _private_setenv(const char *name, const char *val, int _xx) {
   int  len  = strlen(name) + strlen(val) + 2;
-  char env[len];
+  char *env = (char *)alloca(len);;
 
   sprintf(env, "%s%c%s", name, '=', val);
   putenv(env);

--- a/src/modules/xml/consumer_xml.c
+++ b/src/modules/xml/consumer_xml.c
@@ -26,7 +26,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #define ID_SIZE 128
 #define TIME_PROPERTY "_consumer_xml"

--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -27,7 +27,9 @@
 #include <framework/mlt_log.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include <libxml/parser.h>
 #include <libxml/parserInternals.h> // for xmlCreateFileParserCtxt

--- a/src/win32/strptime.c
+++ b/src/win32/strptime.c
@@ -50,6 +50,15 @@ __RCSID("$NetBSD: strptime.c,v 1.36 2012/03/13 21:13:48 christos Exp $");
 __weak_alias(strptime,_strptime)
 #endif
 */
+
+#ifdef _MSC_VER
+	#include <string.h>
+
+	// 为 MSVC 提供 POSIX 函数的别名
+	#define strncasecmp _strnicmp
+	#define strcasecmp  _stricmp  // 如果将来需要 strcasecmp，也一并加上
+	#define tzname      _tzname
+#endif
 typedef unsigned char u_char;
 typedef unsigned int uint;
 typedef unsigned __int64 uint64_t;


### PR DESCRIPTION
- 修复了多个模块在 MSVC 环境下的链接错误，包括 mlt、mltdecklink、mltplus、mltrtaudio 等
- 添加了针对 MSVC 的特殊编译选项和库文件搜索路径
- 在多个文件中添加了对 MSVC 的条件编译判断，以确保代码兼容性
- 更新了 CMakeLists.txt 文件以支持 MSVC 编译