### PR TITLE
Fix freeze on image with a % in the name

### DIFF
--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -484,6 +484,9 @@ int load_sequence_sprintf(producer_qimage self, mlt_properties properties, const
         for (int gap = 0; gap < 100;) {
             QString full = QString::asprintf(filename, i++);
             if (QFile::exists(full)) {
+                if (full == filename) {
+                    break;
+                }
                 QString key = QString::asprintf("%d", keyvalue++);
                 mlt_properties_set(self->filenames,
                                    key.toLatin1().constData(),

--- a/src/modules/qt/qimage_wrapper.cpp
+++ b/src/modules/qt/qimage_wrapper.cpp
@@ -483,10 +483,10 @@ int load_sequence_sprintf(producer_qimage self, mlt_properties properties, const
 #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
         for (int gap = 0; gap < 100;) {
             QString full = QString::asprintf(filename, i++);
+            if (full == filename) {
+                break;
+            }
             if (QFile::exists(full)) {
-                if (full == filename) {
-                    break;
-                }
                 QString key = QString::asprintf("%d", keyvalue++);
                 mlt_properties_set(self->filenames,
                                    key.toLatin1().constData(),


### PR DESCRIPTION
Trying to play an image file named `hello % Hello.png` (The capital letter after the percent seems to matter here) freezed MLT. This was caused by the `QString::asprintf` command returning the original filename, and we entered an endless loop.
Kdenlive Bug 506017