### PR TITLE
Define SDL_MAIN_HANDLED for melt to avoid conflict with main()

### DIFF
--- a/src/melt/melt.c
+++ b/src/melt/melt.c
@@ -32,6 +32,7 @@
 #include <framework/mlt.h>
 
 #if (defined(__APPLE__) || defined(_WIN32) || defined(HAVE_SDL2)) && !defined(MELT_NOSDL)
+#define SDL_MAIN_HANDLED
 #include <SDL.h>
 #endif
 


### PR DESCRIPTION
See https://wiki.libsdl.org/SDL2/SDL_SetMainReady

With MSVC this leads to "unresolved external symbol" errors