### PR TITLE
Add mlt_image_rgba64 format

### DIFF
--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -442,6 +442,7 @@ static int generate_test_image(mlt_properties properties,
         case mlt_image_yuv422p16:
         case mlt_image_yuv420p10:
         case mlt_image_yuv444p10:
+        case mlt_image_rgba64:
             break;
         case mlt_image_none:
         case mlt_image_movit:
@@ -539,7 +540,7 @@ int mlt_frame_get_image(mlt_frame self,
 
 /** Get the alpha channel associated to the frame (without creating if it has not).
  *
- * This returns NULL if the frame's image format is \p mlt_image_rgba.
+ * This returns NULL if the frame's image format is \p mlt_image_rgba or mlt_image_rgba64.
  * \public \memberof mlt_frame_s
  * \param self a frame
  * \return the alpha channel or NULL
@@ -552,7 +553,7 @@ uint8_t *mlt_frame_get_alpha(mlt_frame self)
         alpha = mlt_properties_get_data(&self->parent, "alpha", NULL);
         if (alpha) {
             mlt_image_format format = mlt_properties_get_int(&self->parent, "format");
-            if (mlt_image_rgba == format) {
+            if (mlt_image_rgba == format || mlt_image_rgba64) {
                 alpha = NULL;
             }
         }
@@ -563,7 +564,7 @@ uint8_t *mlt_frame_get_alpha(mlt_frame self)
 /** Get the alpha channel associated to the frame and its size.
  *
  * This returns NULL and sets \p size to 0 if the frame's image format is
- * \p mlt_image_rgba.
+ * \p mlt_image_rgba or mlt_image_rgba64.
  *
  * \public \memberof mlt_frame_s
  * \param self a frame
@@ -577,7 +578,7 @@ uint8_t *mlt_frame_get_alpha_size(mlt_frame self, int *size)
         alpha = mlt_properties_get_data(&self->parent, "alpha", size);
         if (alpha) {
             mlt_image_format format = mlt_properties_get_int(&self->parent, "format");
-            if (mlt_image_rgba == format) {
+            if (mlt_image_rgba == format || mlt_image_rgba64 == format) {
                 alpha = NULL;
                 if (size) {
                     size = 0;

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -3,7 +3,7 @@
  * \brief interface for all frame classes
  * \see mlt_frame_s
  *
- * Copyright (C) 2003-2024 Meltytech, LLC
+ * Copyright (C) 2003-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -3,7 +3,7 @@
  * \brief Image class
  * \see mlt_mlt_image_s
  *
- * Copyright (C) 2020-2024 Meltytech, LLC
+ * Copyright (C) 2020-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -195,6 +195,8 @@ int mlt_image_calculate_size(mlt_image self)
         return self->width * self->height * 3;
     case mlt_image_yuv444p10:
         return self->width * self->height * 6;
+    case mlt_image_rgba64:
+        return self->width * self->height * 4 * 2;
     case mlt_image_none:
     case mlt_image_invalid:
         return 0;
@@ -232,6 +234,8 @@ const char *mlt_image_format_name(mlt_image_format format)
         return "yuv420p10";
     case mlt_image_yuv444p10:
         return "yuv444p10";
+    case mlt_image_rgba64:
+        return "rgba64";
     case mlt_image_invalid:
         return "invalid";
     }
@@ -276,7 +280,8 @@ void mlt_image_fill_black(mlt_image self)
     case mlt_image_opengl_texture:
         return;
     case mlt_image_rgb:
-    case mlt_image_rgba: {
+    case mlt_image_rgba:
+    case mlt_image_rgba64: {
         int size = mlt_image_calculate_size(self);
         memset(self->planes[0], 0, size);
         break;
@@ -432,6 +437,20 @@ void mlt_image_fill_checkerboard(mlt_image self, double sample_aspect_ratio)
         memset(self->planes[1], 128, self->height * self->strides[1] / 2);
         memset(self->planes[2], 128, self->height * self->strides[2] / 2);
     } break;
+    case mlt_image_rgba64: {
+        uint16_t *p = (uint16_t *) self->planes[0];
+        for (int i = 0; i < self->height; i++) {
+            for (int j = 0; j < self->width; j++) {
+                uint16_t color = ((((i + oy) / h) % 2) ^ (((j + ox) / w) % 2)) ? gray1 : gray2;
+                color *= 256;
+                p[0] = color;
+                p[1] = color;
+                p[2] = color;
+                p[3] = 0xffff;
+                p += 4;
+            }
+        }
+    } break;
     }
 }
 
@@ -454,7 +473,8 @@ void mlt_image_fill_white(mlt_image self, int full_range)
     case mlt_image_opengl_texture:
         return;
     case mlt_image_rgb:
-    case mlt_image_rgba: {
+    case mlt_image_rgba:
+    case mlt_image_rgba64: {
         int size = mlt_image_calculate_size(self);
         memset(self->planes[0], 255, size);
         break;
@@ -526,6 +546,14 @@ void mlt_image_fill_opaque(mlt_image self)
                 *pLine += 4;
             }
         }
+    } else if (self->format == mlt_image_rgba64 && self->planes[0] != NULL) {
+        for (int line = 0; line < self->height; line++) {
+            uint16_t *pLine = (uint16_t *) self->planes[0] + (self->strides[0] * line) + 3;
+            for (int pixel = 0; pixel < self->width; pixel++) {
+                *pLine = 0xffff;
+                *pLine += 4;
+            }
+        }
     } else if (self->planes[3] != NULL) {
         memset(self->planes[3], 255, self->height * self->strides[3]);
     }
@@ -576,6 +604,10 @@ int mlt_image_format_size(mlt_image_format format, int width, int height, int *b
         if (bpp)
             *bpp = 6;
         return 6 * height * width;
+    case mlt_image_rgba64:
+        if (bpp)
+            *bpp = 8;
+        return 8 * height * width;
     default:
         if (bpp)
             *bpp = 0;

--- a/src/framework/mlt_repository.c
+++ b/src/framework/mlt_repository.c
@@ -170,7 +170,7 @@ mlt_repository mlt_repository_init(const char *directory)
                                 __FUNCTION__,
                                 object_name,
                                 dlerror());
-                
+
                 dlclose(object);
             }
         } else if (strstr(object_name, "libmlt")) {

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -48,6 +48,7 @@ typedef enum {
     mlt_image_yuv422p16, /**< planar YUV 4:2:2, 32bpp, (1 Cr & Cb sample per 2x1 Y samples), little-endian */
     mlt_image_yuv420p10, /**< planar YUV 4:2:0, 15bpp, (1 Cr & Cb sample per 2x2 Y samples), little-endian */
     mlt_image_yuv444p10, /**< planar YUV 4:4:4, 30bpp, (1 Cr & Cb sample per 1x1 Y samples), little-endian */
+    mlt_image_rgba64, /**< 16-bit RGB with alpha channel */
     mlt_image_invalid
 } mlt_image_format;
 

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -314,6 +314,8 @@ int mlt_to_av_image_format(mlt_image_format format)
         return AV_PIX_FMT_YUV444P10LE;
     case mlt_image_yuv422p16:
         return AV_PIX_FMT_YUV422P16LE;
+    case mlt_image_rgba64:
+        return AV_PIX_FMT_RGBA64LE;
     case mlt_image_movit:
     case mlt_image_opengl_texture:
     case mlt_image_invalid:
@@ -347,6 +349,8 @@ mlt_image_format mlt_get_supported_image_format(mlt_image_format format)
         return mlt_image_yuv444p10;
     case mlt_image_yuv422p16:
         return mlt_image_yuv422p16;
+    case mlt_image_rgba64:
+        return mlt_image_rgba64;
     }
     mlt_log_error(NULL, "[filter_avfilter] Unknown image format requested: %d\n", format);
     return mlt_image_rgba;

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -652,6 +652,8 @@ static enum AVPixelFormat pick_pix_fmt(mlt_image_format img_fmt)
         return AV_PIX_FMT_YUV420P10LE;
     case mlt_image_yuv444p10:
         return AV_PIX_FMT_YUV444P10LE;
+    case mlt_image_rgba64:
+        return AV_PIX_FMT_RGBA64LE;
     default:
         return AV_PIX_FMT_YUYV422;
     }
@@ -2176,6 +2178,9 @@ static void *consumer_thread(void *arg)
                 } else if (strstr(pix_fmt_name, "yuv444p10le")) {
                     mlt_properties_set(properties, "mlt_image_format", "yuv444p10");
                     img_fmt = mlt_image_yuv444p10;
+                } else if (strstr(pix_fmt_name, "rgba64le")) {
+                    mlt_properties_set(properties, "mlt_image_format", "rgba64");
+                    img_fmt = mlt_image_rgba64;
                 }
             }
         }

--- a/src/modules/avformat/filter_avcolour_space.c
+++ b/src/modules/avformat/filter_avcolour_space.c
@@ -1,6 +1,6 @@
 /*
  * filter_avcolour_space.c -- Colour space filter
- * Copyright (C) 2004-2024 Meltytech, LLC
+ * Copyright (C) 2004-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -64,6 +64,14 @@ static int animatable_avoption(const AVOption *opt)
 }
 #endif
 
+int is_rgb(int format)
+{
+    if (format == mlt_image_rgb || format == mlt_image_rgba || format == mlt_image_rgba64) {
+        return 1;
+    }
+    return 0;
+}
+
 static void property_changed(mlt_service owner, mlt_filter filter, mlt_event_data event_data)
 {
     const char *name = mlt_event_data_to_string(event_data);
@@ -777,7 +785,7 @@ static int filter_get_image(mlt_frame frame,
 
     mlt_log_debug(MLT_FILTER_SERVICE(filter), "position %" PRId64 "\n", pos);
     if (mlt_properties_get_int(MLT_FILTER_PROPERTIES(filter), "_yuv_only")) {
-        if (*format == mlt_image_rgb || *format == mlt_image_rgba)
+        if (is_rgb(*format))
             *format = mlt_image_yuv422;
     } else {
         *format = mlt_get_supported_image_format(*format);
@@ -815,7 +823,7 @@ static int filter_get_image(mlt_frame frame,
         //                                     ? AVCOL_RANGE_JPEG
         //                                     : AVCOL_RANGE_MPEG;
 
-        if (*format == mlt_image_rgb || *format == mlt_image_rgba) {
+        if (is_rgb(*format)) {
             pdata->avinframe->colorspace = AVCOL_SPC_RGB;
         } else {
             switch (mlt_properties_get_int(frame_properties, "colorspace")) {

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -1,6 +1,6 @@
 /*
  * filter_avfilter.c -- provide various filters based on libavfilter
- * Copyright (C) 2016-2024 Meltytech, LLC
+ * Copyright (C) 2016-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/avformat/filter_swscale.c
+++ b/src/modules/avformat/filter_swscale.c
@@ -62,6 +62,9 @@ static inline int convert_mlt_to_av_cs(mlt_image_format format)
     case mlt_image_yuv422p16:
         value = AV_PIX_FMT_YUV422P16LE;
         break;
+    case mlt_image_rgba64:
+        value = AV_PIX_FMT_RGBA64LE;
+        break;
     default:
         mlt_log_error(NULL, "[filter swscale] Invalid format %s\n", mlt_image_format_name(format));
         break;

--- a/src/modules/avformat/filter_swscale.c
+++ b/src/modules/avformat/filter_swscale.c
@@ -1,6 +1,6 @@
 /*
  * filter_swscale.c -- image scaling filter
- * Copyright (C) 2008-2024 Meltytech, LLC
+ * Copyright (C) 2008-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/avformat/link_avdeinterlace.c
+++ b/src/modules/avformat/link_avdeinterlace.c
@@ -1,6 +1,6 @@
 /*
  * link_avdeinterlace.c
- * Copyright (C) 2023-2024 Meltytech, LLC
+ * Copyright (C) 2023-2025 Meltytech, LLC
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/modules/avformat/link_avdeinterlace.c
+++ b/src/modules/avformat/link_avdeinterlace.c
@@ -74,6 +74,7 @@ static mlt_image_format validate_format(mlt_image_format format)
     case mlt_image_yuv422p16:
     case mlt_image_yuv420p10:
     case mlt_image_yuv444p10:
+    case mlt_image_rgba64:
         ret_format = format;
         break;
     case mlt_image_none:

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -841,6 +841,8 @@ static mlt_image_format pick_image_format(enum AVPixelFormat pix_fmt,
             return mlt_image_yuv444p10;
         case AV_PIX_FMT_YUV422P16LE:
             return mlt_image_yuv422p16;
+        case AV_PIX_FMT_RGBA64LE:
+            return mlt_image_rgba64;
         default:
             current_format = mlt_image_yuv422;
         }
@@ -1949,7 +1951,8 @@ static int convert_image(producer_avformat self,
     // extract alpha from planar formats - only supports 8-bit
     if ((pix_fmt == AV_PIX_FMT_YUVA420P || pix_fmt == AV_PIX_FMT_YUVA422P
          || pix_fmt == AV_PIX_FMT_YUVA444P)
-        && *format != mlt_image_rgba && frame->data[3] && frame->linesize[3]) {
+        && *format != mlt_image_rgba && *format != mlt_image_rgba64 && frame->data[3]
+        && frame->linesize[3]) {
         int i;
         uint8_t *src, *dst;
 
@@ -1983,6 +1986,9 @@ static int convert_image(producer_avformat self,
     case mlt_image_rgba:
         dst_pix_fmt = AV_PIX_FMT_RGBA;
         break;
+    case mlt_image_rgba64:
+        dst_pix_fmt = AV_PIX_FMT_RGBA64LE;
+        break;
     case mlt_image_none:
     case mlt_image_yuv422:
     case mlt_image_movit:
@@ -1992,7 +1998,7 @@ static int convert_image(producer_avformat self,
     }
 
     // Convert
-    if (mlt_image_rgb == *format || mlt_image_rgba == *format) {
+    if (mlt_image_rgb == *format || mlt_image_rgba == *format || mlt_image_rgba64 == *format) {
         convert_image_rgb(self,
                           profile,
                           frame,

--- a/src/modules/core/filter_autofade.c
+++ b/src/modules/core/filter_autofade.c
@@ -1,6 +1,6 @@
 /*
  * filter_autofade.c -- Automatically fade audio between clips in a playlist.
- * Copyright (C) 2023 Meltytech, LLC
+ * Copyright (C) 2023-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/core/filter_autofade.c
+++ b/src/modules/core/filter_autofade.c
@@ -99,7 +99,9 @@ static int filter_get_image(mlt_frame frame,
     mlt_filter filter = (mlt_filter) mlt_frame_pop_service(frame);
 
     // Get the current image
-    *format = mlt_image_rgba;
+    if (*format != mlt_image_rgba64) {
+        *format = mlt_image_rgba;
+    }
     error = mlt_frame_get_image(frame, image, format, width, height, 1);
 
     if (error)
@@ -132,14 +134,25 @@ static int filter_get_image(mlt_frame frame,
         float g_value = color.g * color_factor;
         float b_value = color.b * color_factor;
         float a_value = color.a * color_factor;
-        uint8_t *p = *image;
         int pixels = *width * *height;
-        for (int i = 0; i < pixels; i++) {
-            p[0] = ((float) p[0] * image_factor) + r_value;
-            p[1] = ((float) p[1] * image_factor) + g_value;
-            p[2] = ((float) p[2] * image_factor) + b_value;
-            p[3] = ((float) p[3] * image_factor) + a_value;
-            p += 4;
+        if (*format == mlt_image_rgba64) {
+            uint16_t *p = (uint16_t *) *image;
+            for (int i = 0; i < pixels; i++) {
+                p[0] = ((float) p[0] * image_factor) + r_value;
+                p[1] = ((float) p[1] * image_factor) + g_value;
+                p[2] = ((float) p[2] * image_factor) + b_value;
+                p[3] = ((float) p[3] * image_factor) + a_value;
+                p += 4;
+            }
+        } else { // mlt_image_rgba
+            uint8_t *p = *image;
+            for (int i = 0; i < pixels; i++) {
+                p[0] = ((float) p[0] * image_factor) + r_value;
+                p[1] = ((float) p[1] * image_factor) + g_value;
+                p[2] = ((float) p[2] * image_factor) + b_value;
+                p[3] = ((float) p[3] * image_factor) + a_value;
+                p += 4;
+            }
         }
     }
 

--- a/src/modules/core/filter_box_blur.c
+++ b/src/modules/core/filter_box_blur.c
@@ -52,7 +52,9 @@ static int filter_get_image(mlt_frame frame,
         error = mlt_frame_get_image(frame, image, format, width, height, writable);
     } else {
         // Get the image
-        *format = mlt_image_rgba;
+        if (*format != mlt_image_rgba64) {
+            *format = mlt_image_rgba;
+        }
         error = mlt_frame_get_image(frame, image, format, width, height, 1);
         if (error == 0) {
             struct mlt_image_s img;

--- a/src/modules/core/filter_box_blur.c
+++ b/src/modules/core/filter_box_blur.c
@@ -1,6 +1,6 @@
 /*
  * filter_box_blur.c
- * Copyright (C) 2011-2023 Meltytech, LLC
+ * Copyright (C) 2011-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/core/filter_brightness.c
+++ b/src/modules/core/filter_brightness.c
@@ -72,6 +72,15 @@ static int sliced_proc(int id, int index, int jobs, void *cookie)
                     p += 4;
                 }
             }
+        } else if (ctx->image->format == mlt_image_rgba64) {
+            for (int line = 0; line < slice_height; line++) {
+                uint16_t *p = (uint16_t *) ctx->image->planes[0]
+                              + ((slice_line_start + line) * ctx->image->strides[0]) + 3;
+                for (int pixel = 0; pixel < ctx->image->width; pixel++) {
+                    *p = (*p * m) >> 16;
+                    p += 4;
+                }
+            }
         } else {
             for (int line = 0; line < slice_height; line++) {
                 uint8_t *p = ctx->image->planes[3]
@@ -142,7 +151,8 @@ static int filter_get_image(mlt_frame frame,
         struct sliced_desc desc;
         struct mlt_image_s proc_image;
         mlt_image_set_values(&proc_image, *image, *format, *width, *height);
-        if (alpha_level != 1.0 && proc_image.format != mlt_image_rgba) {
+        if (alpha_level != 1.0 && proc_image.format != mlt_image_rgba
+            && proc_image.format != mlt_image_rgba64) {
             proc_image.planes[3] = mlt_frame_get_alpha(frame);
             proc_image.strides[3] = proc_image.width;
             if (!proc_image.planes[3]) {

--- a/src/modules/core/filter_brightness.c
+++ b/src/modules/core/filter_brightness.c
@@ -1,6 +1,6 @@
 /*
  * filter_brightness.c -- brightness, fade, and opacity filter
- * Copyright (C) 2003-2022 Meltytech, LLC
+ * Copyright (C) 2003-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -73,12 +73,12 @@ static int sliced_proc(int id, int index, int jobs, void *cookie)
                 }
             }
         } else if (ctx->image->format == mlt_image_rgba64) {
-            for (int line = 0; line < slice_height; line++) {
+            for (int row = 0; row < slice_height; row++) {
                 uint16_t *p = (uint16_t *) ctx->image->planes[0]
-                              + ((slice_line_start + line) * ctx->image->strides[0]) + 3;
-                for (int pixel = 0; pixel < ctx->image->width; pixel++) {
-                    *p = (*p * m) >> 16;
-                    p += 4;
+                              + ((slice_line_start + row) * ctx->image->strides[0]) + 3;
+                int components_in_row = ctx->image->width * 4;
+                for (int col = 0; col < components_in_row; col += 4) {
+                    p[col] = (p[col] * m) >> 16;
                 }
             }
         } else {

--- a/src/modules/core/filter_pillar_echo.c
+++ b/src/modules/core/filter_pillar_echo.c
@@ -59,7 +59,7 @@ typedef struct
     mlt_rect rect;
 } scale_sliced_desc;
 
-static int scale_sliced_proc(int id, int index, int jobs, void *data)
+static int scale_sliced_proc_rgb32(int id, int index, int jobs, void *data)
 {
     (void) id; // unused
     scale_sliced_desc *desc = ((scale_sliced_desc *) data);
@@ -152,6 +152,99 @@ static int scale_sliced_proc(int id, int index, int jobs, void *data)
     return 0;
 }
 
+static int scale_sliced_proc_rgb64(int id, int index, int jobs, void *data)
+{
+    (void) id; // unused
+    scale_sliced_desc *desc = ((scale_sliced_desc *) data);
+    mlt_image src = desc->src;
+    mlt_image dst = desc->dst;
+    mlt_rect rect = desc->rect;
+    int slice_line_start,
+        slice_height = mlt_slices_size_slice(jobs, index, src->height, &slice_line_start);
+    int slice_line_end = slice_line_start + slice_height;
+    double srcScale = rect.h / (double) src->height;
+    int linesize = src->width * 4 * 2;
+    uint16_t *d = dst->data + (slice_line_start * linesize);
+    for (int y = slice_line_start; y < slice_line_end; y++) {
+        double srcY = rect.y + (double) y * srcScale;
+        int srcYindex = floor(srcY);
+        double fbottom = srcY - srcYindex;
+        double ftop = 1.0 - fbottom;
+
+        int x = 0;
+        for (x = 0; x < src->width; x++) {
+            double srcX = rect.x + (double) x * srcScale;
+            int srcXindex = floor(srcX);
+            double fright = srcX - srcXindex;
+            double fleft = 1.0 - fright;
+
+            double valueSum[] = {0.0, 0.0, 0.0, 0.0};
+            double factorSum[] = {0.0, 0.0, 0.0, 0.0};
+
+            uint16_t *s = src->data + (srcYindex * linesize) + (srcXindex * 4);
+
+            // Top Left
+            double ftl = ftop * fleft;
+            valueSum[0] += s[0] * ftl;
+            factorSum[0] += ftl;
+            valueSum[1] += s[1] * ftl;
+            factorSum[1] += ftl;
+            valueSum[2] += s[2] * ftl;
+            factorSum[2] += ftl;
+            valueSum[3] += s[3] * ftl;
+            factorSum[3] += ftl;
+
+            // Top Right
+            if (x < src->width - 1) {
+                double ftr = ftop * fright;
+                valueSum[0] += s[4] * ftr;
+                factorSum[0] += ftr;
+                valueSum[1] += s[5] * ftr;
+                factorSum[1] += ftr;
+                valueSum[2] += s[6] * ftr;
+                factorSum[2] += ftr;
+                valueSum[3] += s[7] * ftr;
+                factorSum[3] += ftr;
+            }
+
+            if (y < src->height - 1) {
+                uint16_t *sb = s + linesize;
+
+                // Bottom Left
+                double fbl = fbottom * fleft;
+                valueSum[0] += sb[0] * fbl;
+                factorSum[0] += fbl;
+                valueSum[1] += sb[1] * fbl;
+                factorSum[1] += fbl;
+                valueSum[2] += sb[2] * fbl;
+                factorSum[2] += fbl;
+                valueSum[3] += sb[3] * fbl;
+                factorSum[3] += fbl;
+
+                // Bottom Right
+                if (x < src->width - 1) {
+                    double fbr = fbottom * fright;
+                    valueSum[0] += sb[4] * fbr;
+                    factorSum[0] += fbr;
+                    valueSum[1] += sb[5] * fbr;
+                    factorSum[1] += fbr;
+                    valueSum[2] += sb[6] * fbr;
+                    factorSum[2] += fbr;
+                    valueSum[3] += sb[7] * fbr;
+                    factorSum[3] += fbr;
+                }
+            }
+
+            d[0] = (uint16_t) round(valueSum[0] / factorSum[0]);
+            d[1] = (uint16_t) round(valueSum[1] / factorSum[1]);
+            d[2] = (uint16_t) round(valueSum[2] / factorSum[2]);
+            d[3] = (uint16_t) round(valueSum[3] / factorSum[3]);
+            d += 4;
+        }
+    }
+    return 0;
+}
+
 /** Perform a bilinear scale from the rect inside the source to fill the destination
   *
   * \param src a pointer to the source image
@@ -178,7 +271,11 @@ static void bilinear_scale_rgba(mlt_image src, mlt_image dst, mlt_rect rect)
         desc.rect.h = rect.h * sourceAr / destAr;
         desc.rect.y = rect.y + (rect.h - desc.rect.h) / 2.0;
     }
-    mlt_slices_run_normal(0, scale_sliced_proc, &desc);
+    if (src->format == mlt_image_rgb) {
+        mlt_slices_run_normal(0, scale_sliced_proc_rgb32, &desc);
+    } else {
+        mlt_slices_run_normal(0, scale_sliced_proc_rgb64, &desc);
+    }
 }
 
 /** Copy pixels from source to destination
@@ -194,12 +291,22 @@ static void blit_rect(mlt_image src, mlt_image dst, mlt_rect rect)
     int blitHeight = rect.h;
     int blitWidth = rect.w * 4;
     int linesize = src->width * 4;
-    uint8_t *s = (uint8_t *) ((char *) src->data + (int) rect.y * linesize + (int) rect.x * 4);
-    uint8_t *d = (uint8_t *) ((char *) dst->data + (int) rect.y * linesize + (int) rect.x * 4);
-    while (blitHeight--) {
-        memcpy(d, s, blitWidth);
-        s += linesize;
-        d += linesize;
+    if (src->format == mlt_image_rgba) {
+        uint8_t *s = (uint8_t *) src->data + (int) rect.y * linesize + (int) rect.x * 4;
+        uint8_t *d = (uint8_t *) dst->data + (int) rect.y * linesize + (int) rect.x * 4;
+        while (blitHeight--) {
+            memcpy(d, s, blitWidth);
+            s += linesize;
+            d += linesize;
+        }
+    } else {
+        uint16_t *s = (uint16_t *) src->data + (int) rect.y * linesize + (int) rect.x * 4;
+        uint16_t *d = (uint16_t *) dst->data + (int) rect.y * linesize + (int) rect.x * 4;
+        while (blitHeight--) {
+            memcpy(d, s, blitWidth * 2);
+            s += linesize;
+            d += linesize;
+        }
     }
 }
 
@@ -241,7 +348,9 @@ static int filter_get_image(mlt_frame frame,
         return mlt_frame_get_image(frame, image, format, width, height, writable);
     }
 
-    *format = mlt_image_rgba;
+    if (*format != mlt_image_rgba64) {
+        *format = mlt_image_rgba;
+    }
     error = mlt_frame_get_image(frame, image, format, width, height, 0);
 
     if (error)

--- a/src/modules/core/filter_pillar_echo.c
+++ b/src/modules/core/filter_pillar_echo.c
@@ -1,6 +1,6 @@
 /*
  * filter_pillar_echo.c -- filter to interpolate pixels outside an area of interest
- * Copyright (c) 2020-2023 Meltytech, LLC
+ * Copyright (c) 2020-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -59,7 +59,7 @@ typedef struct
     mlt_rect rect;
 } scale_sliced_desc;
 
-static int scale_sliced_proc_rgb32(int id, int index, int jobs, void *data)
+static int scale_sliced_proc_rgba32(int id, int index, int jobs, void *data)
 {
     (void) id; // unused
     scale_sliced_desc *desc = ((scale_sliced_desc *) data);
@@ -152,7 +152,7 @@ static int scale_sliced_proc_rgb32(int id, int index, int jobs, void *data)
     return 0;
 }
 
-static int scale_sliced_proc_rgb64(int id, int index, int jobs, void *data)
+static int scale_sliced_proc_rgba64(int id, int index, int jobs, void *data)
 {
     (void) id; // unused
     scale_sliced_desc *desc = ((scale_sliced_desc *) data);
@@ -272,9 +272,9 @@ static void bilinear_scale_rgba(mlt_image src, mlt_image dst, mlt_rect rect)
         desc.rect.y = rect.y + (rect.h - desc.rect.h) / 2.0;
     }
     if (src->format == mlt_image_rgb) {
-        mlt_slices_run_normal(0, scale_sliced_proc_rgb32, &desc);
+        mlt_slices_run_normal(0, scale_sliced_proc_rgba32, &desc);
     } else {
-        mlt_slices_run_normal(0, scale_sliced_proc_rgb64, &desc);
+        mlt_slices_run_normal(0, scale_sliced_proc_rgba64, &desc);
     }
 }
 

--- a/src/modules/core/filter_rescale.c
+++ b/src/modules/core/filter_rescale.c
@@ -1,6 +1,6 @@
 /*
  * filter_rescale.c -- scale the producer video frame size to match the consumer
- * Copyright (C) 2003-2024 Meltytech, LLC
+ * Copyright (C) 2003-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/core/filter_rescale.c
+++ b/src/modules/core/filter_rescale.c
@@ -241,7 +241,7 @@ static int filter_get_image(mlt_frame frame,
             // If valid colorspace
             if (*format == mlt_image_yuv422 || *format == mlt_image_rgb || *format == mlt_image_rgba
                 || *format == mlt_image_yuv420p || *format == mlt_image_yuv420p10
-                || *format == mlt_image_yuv444p10) {
+                || *format == mlt_image_yuv444p10 || *format == mlt_image_rgba64) {
                 // Call the virtual function
                 scaler_method(frame, image, format, iwidth, iheight, owidth, oheight);
                 *width = owidth;

--- a/src/modules/core/filter_resize.c
+++ b/src/modules/core/filter_resize.c
@@ -99,6 +99,16 @@ static void resize_image(uint8_t *output,
                 p += 4;
             }
         }
+    } else if (format == mlt_image_rgba64) {
+        uint16_t *p16 = (uint16_t *) p;
+        uint16_t alpha_value_16 = alpha_value << 8;
+        memset(p16, 0, size * bpp);
+        if (alpha_value != 0) {
+            while (size--) {
+                p16[3] = alpha_value_16;
+                p16 += 4;
+            }
+        }
     } else if (bpp == 2) {
         memset(p, 16, size * bpp);
         while (size--) {

--- a/src/modules/core/filter_resize.c
+++ b/src/modules/core/filter_resize.c
@@ -1,6 +1,6 @@
 /*
  * filter_resize.c -- resizing filter
- * Copyright (C) 2003-2023 Meltytech, LLC
+ * Copyright (C) 2003-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/core/image_proc.c
+++ b/src/modules/core/image_proc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Meltytech, LLC
+ * Copyright (c) 2022-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/core/image_proc.c
+++ b/src/modules/core/image_proc.c
@@ -326,6 +326,302 @@ static int blur_v_proc_rgbx(int id, int index, int jobs, void *data)
     return 0;
 }
 
+static int blur_h_proc_rgba64(int id, int index, int jobs, void *data)
+{
+    (void) id; // unused
+    blur_slice_desc *desc = ((blur_slice_desc *) data);
+    int slice_line_start,
+        slice_height = mlt_slices_size_slice(jobs, index, desc->src->height, &slice_line_start);
+    int slice_line_end = slice_line_start + slice_height;
+    int accumulator[] = {0, 0, 0, 0};
+    int x = 0;
+    int y = 0;
+    int step = 4;
+    int linesize = step * desc->src->width;
+    int radius = desc->radius;
+
+    if (desc->radius > (desc->src->width / 2)) {
+        radius = desc->src->width / 2;
+    }
+    double diameter = (radius * 2) + 1;
+
+    for (y = slice_line_start; y < slice_line_end; y++) {
+        uint16_t *first = (uint16_t *) desc->src->data + (y * linesize);
+        uint16_t *last = first + linesize - step;
+        uint16_t *s1 = first;
+        uint16_t *s2 = first;
+        uint16_t *d = (uint16_t *) desc->dst->data + (y * linesize);
+        accumulator[0] = first[0] * (radius + 1);
+        accumulator[1] = first[1] * (radius + 1);
+        accumulator[2] = first[2] * (radius + 1);
+        accumulator[3] = first[3] * (radius + 1);
+
+        for (x = 0; x < radius; x++) {
+            accumulator[0] += s1[0];
+            accumulator[1] += s1[1];
+            accumulator[2] += s1[2];
+            accumulator[3] += s1[3];
+            s1 += step;
+        }
+        for (x = 0; x <= radius; x++) {
+            accumulator[0] += s1[0] - first[0];
+            accumulator[1] += s1[1] - first[1];
+            accumulator[2] += s1[2] - first[2];
+            accumulator[3] += s1[3] - first[3];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            d[3] = lrint((double) accumulator[3] / diameter);
+            s1 += step;
+            d += step;
+        }
+        for (x = radius + 1; x < desc->src->width - radius; x++) {
+            accumulator[0] += s1[0] - s2[0];
+            accumulator[1] += s1[1] - s2[1];
+            accumulator[2] += s1[2] - s2[2];
+            accumulator[3] += s1[3] - s2[3];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            d[3] = lrint((double) accumulator[3] / diameter);
+            s1 += step;
+            s2 += step;
+            d += step;
+        }
+        for (x = desc->src->width - radius; x < desc->src->width; x++) {
+            accumulator[0] += last[0] - s2[0];
+            accumulator[1] += last[1] - s2[1];
+            accumulator[2] += last[2] - s2[2];
+            accumulator[3] += last[3] - s2[3];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            d[3] = lrint((double) accumulator[3] / diameter);
+            s2 += step;
+            d += step;
+        }
+    }
+    return 0;
+}
+
+static int blur_v_proc_rgba64(int id, int index, int jobs, void *data)
+{
+    (void) id; // unused
+    blur_slice_desc *desc = ((blur_slice_desc *) data);
+    int slice_row_start,
+        slice_width = mlt_slices_size_slice(jobs, index, desc->src->width, &slice_row_start);
+    int slice_row_end = slice_row_start + slice_width;
+    int accumulator[] = {0, 0, 0, 0};
+    int x = 0;
+    int y = 0;
+    int step = 4;
+    int linesize = step * desc->src->width;
+    int radius = desc->radius;
+
+    if (desc->radius > (desc->src->height / 2)) {
+        radius = desc->src->height / 2;
+    }
+    double diameter = (radius * 2) + 1;
+
+    for (x = slice_row_start; x < slice_row_end; x++) {
+        uint16_t *first = (uint16_t *) desc->src->data + (x * step);
+        uint16_t *last = first + (linesize * (desc->src->height - 1));
+        uint16_t *s1 = first;
+        uint16_t *s2 = first;
+        uint16_t *d = (uint16_t *) desc->dst->data + (x * step);
+        accumulator[0] = first[0] * (radius + 1);
+        accumulator[1] = first[1] * (radius + 1);
+        accumulator[2] = first[2] * (radius + 1);
+        accumulator[3] = first[3] * (radius + 1);
+
+        for (y = 0; y < radius; y++) {
+            accumulator[0] += s1[0];
+            accumulator[1] += s1[1];
+            accumulator[2] += s1[2];
+            accumulator[3] += s1[3];
+            s1 += linesize;
+        }
+        for (y = 0; y <= radius; y++) {
+            accumulator[0] += s1[0] - first[0];
+            accumulator[1] += s1[1] - first[1];
+            accumulator[2] += s1[2] - first[2];
+            accumulator[3] += s1[3] - first[3];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            d[3] = lrint((double) accumulator[3] / diameter);
+            s1 += linesize;
+            d += linesize;
+        }
+        for (y = radius + 1; y < desc->src->height - radius; y++) {
+            accumulator[0] += s1[0] - s2[0];
+            accumulator[1] += s1[1] - s2[1];
+            accumulator[2] += s1[2] - s2[2];
+            accumulator[3] += s1[3] - s2[3];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            d[3] = lrint((double) accumulator[3] / diameter);
+            s1 += linesize;
+            s2 += linesize;
+            d += linesize;
+        }
+        for (y = desc->src->height - radius; y < desc->src->height; y++) {
+            accumulator[0] += last[0] - s2[0];
+            accumulator[1] += last[1] - s2[1];
+            accumulator[2] += last[2] - s2[2];
+            accumulator[3] += last[3] - s2[3];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            d[3] = lrint((double) accumulator[3] / diameter);
+            s2 += linesize;
+            d += linesize;
+        }
+    }
+    return 0;
+}
+
+static int blur_h_proc_rgbx64(int id, int index, int jobs, void *data)
+{
+    (void) id; // unused
+    blur_slice_desc *desc = ((blur_slice_desc *) data);
+    int slice_line_start,
+        slice_height = mlt_slices_size_slice(jobs, index, desc->src->height, &slice_line_start);
+    int slice_line_end = slice_line_start + slice_height;
+    int accumulator[] = {0, 0, 0};
+    int x = 0;
+    int y = 0;
+    int step = 4;
+    int linesize = step * desc->src->width;
+    int radius = desc->radius;
+
+    if (desc->radius > (desc->src->width / 2)) {
+        radius = desc->src->width / 2;
+    }
+    double diameter = (radius * 2) + 1;
+
+    for (y = slice_line_start; y < slice_line_end; y++) {
+        uint16_t *first = (uint16_t *) desc->src->data + (y * linesize);
+        uint16_t *last = first + linesize - step;
+        uint16_t *s1 = first;
+        uint16_t *s2 = first;
+        uint16_t *d = (uint16_t *) desc->dst->data + (y * linesize);
+        accumulator[0] = first[0] * (radius + 1);
+        accumulator[1] = first[1] * (radius + 1);
+        accumulator[2] = first[2] * (radius + 1);
+
+        for (x = 0; x < radius; x++) {
+            accumulator[0] += s1[0];
+            accumulator[1] += s1[1];
+            accumulator[2] += s1[2];
+            s1 += step;
+        }
+        for (x = 0; x <= radius; x++) {
+            accumulator[0] += s1[0] - first[0];
+            accumulator[1] += s1[1] - first[1];
+            accumulator[2] += s1[2] - first[2];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            s1 += step;
+            d += step;
+        }
+        for (x = radius + 1; x < desc->src->width - radius; x++) {
+            accumulator[0] += s1[0] - s2[0];
+            accumulator[1] += s1[1] - s2[1];
+            accumulator[2] += s1[2] - s2[2];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            s1 += step;
+            s2 += step;
+            d += step;
+        }
+        for (x = desc->src->width - radius; x < desc->src->width; x++) {
+            accumulator[0] += last[0] - s2[0];
+            accumulator[1] += last[1] - s2[1];
+            accumulator[2] += last[2] - s2[2];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            s2 += step;
+            d += step;
+        }
+    }
+    return 0;
+}
+
+static int blur_v_proc_rgbx64(int id, int index, int jobs, void *data)
+{
+    (void) id; // unused
+    blur_slice_desc *desc = ((blur_slice_desc *) data);
+    int slice_row_start,
+        slice_width = mlt_slices_size_slice(jobs, index, desc->src->width, &slice_row_start);
+    int slice_row_end = slice_row_start + slice_width;
+    int accumulator[] = {0, 0, 0};
+    int x = 0;
+    int y = 0;
+    int step = 4;
+    int linesize = step * desc->src->width * 2;
+    int radius = desc->radius;
+
+    if (desc->radius > (desc->src->height / 2)) {
+        radius = desc->src->height / 2;
+    }
+    double diameter = (radius * 2) + 1;
+
+    for (x = slice_row_start; x < slice_row_end; x++) {
+        uint16_t *first = desc->src->data + (x * step);
+        uint16_t *last = first + (linesize * (desc->src->height - 1));
+        uint16_t *s1 = first;
+        uint16_t *s2 = first;
+        uint16_t *d = desc->dst->data + (x * step);
+        accumulator[0] = first[0] * (radius + 1);
+        accumulator[1] = first[1] * (radius + 1);
+        accumulator[2] = first[2] * (radius + 1);
+
+        for (y = 0; y < radius; y++) {
+            accumulator[0] += s1[0];
+            accumulator[1] += s1[1];
+            accumulator[2] += s1[2];
+            s1 += linesize;
+        }
+        for (y = 0; y <= radius; y++) {
+            accumulator[0] += s1[0] - first[0];
+            accumulator[1] += s1[1] - first[1];
+            accumulator[2] += s1[2] - first[2];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            s1 += linesize;
+            d += linesize;
+        }
+        for (y = radius + 1; y < desc->src->height - radius; y++) {
+            accumulator[0] += s1[0] - s2[0];
+            accumulator[1] += s1[1] - s2[1];
+            accumulator[2] += s1[2] - s2[2];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            s1 += linesize;
+            s2 += linesize;
+            d += linesize;
+        }
+        for (y = desc->src->height - radius; y < desc->src->height; y++) {
+            accumulator[0] += last[0] - s2[0];
+            accumulator[1] += last[1] - s2[1];
+            accumulator[2] += last[2] - s2[2];
+            d[0] = lrint((double) accumulator[0] / diameter);
+            d[1] = lrint((double) accumulator[1] / diameter);
+            d[2] = lrint((double) accumulator[2] / diameter);
+            s2 += linesize;
+            d += linesize;
+        }
+    }
+    return 0;
+}
+
 /** Perform a box blur
  *
  * This function uses a sliding window accumulator method - applied
@@ -339,7 +635,7 @@ static int blur_v_proc_rgbx(int id, int index, int jobs, void *data)
 
 void mlt_image_box_blur(mlt_image self, int hradius, int vradius, int preserve_alpha)
 {
-    if (self->format != mlt_image_rgba) {
+    if (self->format != mlt_image_rgba && self->format != mlt_image_rgba64) {
         mlt_log(NULL,
                 MLT_LOG_ERROR,
                 "Image type %s not supported by box blur\n",
@@ -355,18 +651,27 @@ void mlt_image_box_blur(mlt_image self, int hradius, int vradius, int preserve_a
         mlt_image_alloc_alpha(&tmpimage);
     }
 
-    blur_slice_desc desc;
-    if (preserve_alpha) {
-        desc.src = self, desc.dst = &tmpimage, desc.radius = hradius,
-        mlt_slices_run_normal(0, blur_h_proc_rgbx, &desc);
-        desc.src = &tmpimage, desc.dst = self, desc.radius = vradius,
-        mlt_slices_run_normal(0, blur_v_proc_rgbx, &desc);
-    } else {
-        desc.src = self, desc.dst = &tmpimage, desc.radius = hradius,
-        mlt_slices_run_normal(0, blur_h_proc_rgba, &desc);
-        desc.src = &tmpimage, desc.dst = self, desc.radius = vradius,
-        mlt_slices_run_normal(0, blur_v_proc_rgba, &desc);
+    mlt_slices_proc h_proc;
+    mlt_slices_proc v_proc;
+    if (preserve_alpha && self->format == mlt_image_rgba) {
+        h_proc = blur_h_proc_rgbx;
+        v_proc = blur_v_proc_rgbx;
+    } else if (self->format == mlt_image_rgba) {
+        h_proc = blur_h_proc_rgba;
+        v_proc = blur_v_proc_rgba;
+    } else if (preserve_alpha && self->format == mlt_image_rgba64) {
+        h_proc = blur_h_proc_rgbx64;
+        v_proc = blur_v_proc_rgbx64;
+    } else { // self->format == mlt_image_rgba64
+        h_proc = blur_h_proc_rgba64;
+        v_proc = blur_v_proc_rgba64;
     }
+
+    blur_slice_desc desc;
+    desc.src = self, desc.dst = &tmpimage, desc.radius = hradius,
+    mlt_slices_run_normal(0, h_proc, &desc);
+    desc.src = &tmpimage, desc.dst = self, desc.radius = vradius,
+    mlt_slices_run_normal(0, v_proc, &desc);
 
     mlt_image_close(&tmpimage);
 }

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -1,6 +1,6 @@
 /*
  * producer_colour.c
- * Copyright (C) 2003-2020 Meltytech, LLC
+ * Copyright (C) 2003-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -190,12 +190,12 @@ static int producer_get_image(mlt_frame frame,
                 break;
             case mlt_image_rgba64: {
                 uint16_t *p16 = (uint16_t *) p;
-                const int pixel_count = *width * *height;
-                for (int j = 0; j < pixel_count; j++) {
-                    *p16++ = color.r << 8;
-                    *p16++ = color.g << 8;
-                    *p16++ = color.b << 8;
-                    *p16++ = color.a << 8;
+                const int component_count = *width * *height * 4;
+                for (int j = 0; j < component_count; j += 4) {
+                    p16[j] = color.r << 8;
+                    p16[j + 1] = color.g << 8;
+                    p16[j + 2] = color.b << 8;
+                    p16[j + 3] = color.a << 8;
                 }
                 break;
             }

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -102,7 +102,8 @@ static int producer_get_image(mlt_frame frame,
 
     // Choose default image format if specific request is unsupported
     if (*format != mlt_image_yuv420p && *format != mlt_image_yuv422 && *format != mlt_image_rgb
-        && *format != mlt_image_movit && *format != mlt_image_opengl_texture)
+        && *format != mlt_image_movit && *format != mlt_image_opengl_texture
+        && *format != mlt_image_rgba64)
         *format = mlt_image_rgba;
 
     // See if we need to regenerate
@@ -187,6 +188,17 @@ static int producer_get_image(mlt_frame frame,
                     *p++ = color.a;
                 }
                 break;
+            case mlt_image_rgba64: {
+                uint16_t *p16 = (uint16_t *) p;
+                const int pixel_count = *width * *height;
+                for (int j = 0; j < pixel_count; j++) {
+                    *p16++ = color.r << 8;
+                    *p16++ = color.g << 8;
+                    *p16++ = color.b << 8;
+                    *p16++ = color.a << 8;
+                }
+                break;
+            }
             default:
                 mlt_log_error(MLT_PRODUCER_SERVICE(producer),
                               "invalid image format %s\n",

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Dan Dennedy <dan@dennedy.org>
+ * Copyright (C) 2014-2025 Dan Dennedy <dan@dennedy.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -65,68 +65,30 @@ bool createQApplicationIfNeeded(mlt_service service)
 
 mlt_image_format choose_image_format(mlt_image_format format)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     if (format == mlt_image_rgba64) {
         return mlt_image_rgba64;
     }
-#endif
     return mlt_image_rgba;
 }
 
 void convert_qimage_to_mlt(QImage *qImg, uint8_t *mImg, int width, int height)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
-    // QImage::Format_RGBA8888 was added in Qt5.2
-    // QImage::Format_RGBA64 was added in Qt5.12
-    // Nothing to do in this case because the image was modified directly.
     // Destination pointer must be the same pointer that was provided to
     // convert_mlt_to_qimage()
     Q_ASSERT(mImg == qImg->constBits());
-#else
-    int y = height + 1;
-    while (--y) {
-        QRgb *src = (QRgb *) qImg->scanLine(height - y);
-        int x = width + 1;
-        while (--x) {
-            *mImg++ = qRed(*src);
-            *mImg++ = qGreen(*src);
-            *mImg++ = qBlue(*src);
-            *mImg++ = qAlpha(*src);
-            src++;
-        }
-    }
-#endif
 }
 
 void convert_mlt_to_qimage(
     uint8_t *mImg, QImage *qImg, int width, int height, mlt_image_format format)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-    // QImage::Format_RGBA64 was added in Qt5.12
     if (format == mlt_image_rgba64) {
         *qImg = QImage(mImg, width, height, QImage::Format_RGBA64);
         return;
     }
-#endif
 
     Q_ASSERT(format == mlt_image_rgba);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
-    // QImage::Format_RGBA8888 was added in Qt5.2
-    // Initialize the QImage with the MLT image because the data formats match.
     *qImg = QImage(mImg, width, height, QImage::Format_RGBA8888);
-#else
-    *qImg = QImage(width, height, QImage::Format_ARGB32);
-    int y = height + 1;
-    while (--y) {
-        QRgb *dst = (QRgb *) qImg->scanLine(height - y);
-        int x = width + 1;
-        while (--x) {
-            *dst++ = qRgba(mImg[0], mImg[1], mImg[2], mImg[3]);
-            mImg += 4;
-        }
-    }
-#endif
 }
 
 int create_image(mlt_frame frame,

--- a/src/modules/qt/common.h
+++ b/src/modules/qt/common.h
@@ -24,8 +24,10 @@
 class QImage;
 
 bool createQApplicationIfNeeded(mlt_service service);
-void convert_qimage_to_mlt_rgba(QImage *qImg, uint8_t *mImg, int width, int height);
-void convert_mlt_to_qimage_rgba(uint8_t *mImg, QImage *qImg, int width, int height);
+mlt_image_format choose_image_format(mlt_image_format format);
+void convert_qimage_to_mlt(QImage *qImg, uint8_t *mImg, int width, int height);
+void convert_mlt_to_qimage(
+    uint8_t *mImg, QImage *qImg, int width, int height, mlt_image_format format);
 int create_image(mlt_frame frame,
                  uint8_t **image,
                  mlt_image_format *image_format,

--- a/src/modules/qt/common.h
+++ b/src/modules/qt/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Dan Dennedy <dan@dennedy.org>
+ * Copyright (C) 2014-2025 Dan Dennedy <dan@dennedy.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_audiolevelgraph.cpp
+++ b/src/modules/qt/filter_audiolevelgraph.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_audiolevel.cpp -- audio level visualization filter
- * Copyright (c) 2021-2022 Meltytech, LLC
+ * Copyright (c) 2021-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_audiolevelgraph.cpp
+++ b/src/modules/qt/filter_audiolevelgraph.cpp
@@ -194,15 +194,15 @@ static int filter_get_image(mlt_frame frame,
 
     if (mlt_properties_get(frame_properties, "meta.media.audio_level.0")) {
         // Get the current image
-        *format = mlt_image_rgba;
+        *format = choose_image_format(*format);
         error = mlt_frame_get_image(frame, image, format, width, height, 1);
 
         // Draw the audio levels
         if (!error) {
             QImage qimg(*width, *height, QImage::Format_ARGB32);
-            convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+            convert_mlt_to_qimage(*image, &qimg, *width, *height, *format);
             draw_levels(filter, frame, &qimg, *width, *height);
-            convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+            convert_qimage_to_mlt(&qimg, *image, *width, *height);
         }
     } else {
         if (pdata->preprocess_warned++ == 2) {

--- a/src/modules/qt/filter_audiospectrum.cpp
+++ b/src/modules/qt/filter_audiospectrum.cpp
@@ -270,15 +270,15 @@ static int filter_get_image(mlt_frame frame,
 
     if (mlt_properties_get_data(frame_properties, pdata->fft_prop_name, NULL)) {
         // Get the current image
-        *format = mlt_image_rgba;
+        *format = choose_image_format(*format);
         error = mlt_frame_get_image(frame, image, format, width, height, 1);
 
         // Draw the spectrum
         if (!error) {
             QImage qimg(*width, *height, QImage::Format_ARGB32);
-            convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+            convert_mlt_to_qimage(*image, &qimg, *width, *height, *format);
             draw_spectrum(filter, frame, &qimg, *width, *height);
-            convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+            convert_qimage_to_mlt(&qimg, *image, *width, *height);
         }
     } else {
         if (pdata->preprocess_warned++ == 2) {

--- a/src/modules/qt/filter_audiospectrum.cpp
+++ b/src/modules/qt/filter_audiospectrum.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_audiospectrum.cpp -- audio spectrum visualization filter
- * Copyright (c) 2015-2022 Meltytech, LLC
+ * Copyright (c) 2015-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_audiowaveform.cpp
+++ b/src/modules/qt/filter_audiowaveform.cpp
@@ -358,13 +358,13 @@ static int filter_get_image(mlt_frame frame,
 
     if (audio) {
         // Get the current image
-        *image_format = mlt_image_rgba;
+        *image_format = choose_image_format(*image_format);
         error = mlt_frame_get_image(frame, image, image_format, width, height, writable);
 
         // Draw the waveforms
         if (!error) {
             QImage qimg(*width, *height, QImage::Format_ARGB32);
-            convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+            convert_mlt_to_qimage(*image, &qimg, *width, *height, *image_format);
             draw_waveforms(filter,
                            frame,
                            &qimg,
@@ -373,7 +373,7 @@ static int filter_get_image(mlt_frame frame,
                            audio->samples,
                            *width,
                            *height);
-            convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+            convert_qimage_to_mlt(&qimg, *image, *width, *height);
         }
     } else {
         // This filter depends on the consumer processing the audio before

--- a/src/modules/qt/filter_audiowaveform.cpp
+++ b/src/modules/qt/filter_audiowaveform.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_audiowaveform.cpp -- audio waveform visualization filter
- * Copyright (c) 2015-2021 Meltytech, LLC
+ * Copyright (c) 2015-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_dropshadow.cpp
+++ b/src/modules/qt/filter_dropshadow.cpp
@@ -35,12 +35,12 @@ static int get_image(mlt_frame frame,
     auto error = 0;
     auto filter = Mlt::Filter(mlt_filter(mlt_frame_pop_service(frame)));
 
-    *image_format = mlt_image_rgba;
+    *image_format = choose_image_format(*image_format);
     error = mlt_frame_get_image(frame, image, image_format, width, height, writable);
 
     if (!error) {
         QImage qimg;
-        convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+        convert_mlt_to_qimage(*image, &qimg, *width, *height, *image_format);
 
         auto shadow = new QGraphicsDropShadowEffect;
         auto f = Mlt::Frame(frame);
@@ -62,7 +62,7 @@ static int get_image(mlt_frame frame,
         QPainter painter(&qimg);
         scene.render(&painter);
         painter.end();
-        convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+        convert_qimage_to_mlt(&qimg, *image, *width, *height);
     }
 
     return error;

--- a/src/modules/qt/filter_dropshadow.cpp
+++ b/src/modules/qt/filter_dropshadow.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_dropshadow.cpp -- Drop Shadow Effect
- * Copyright (c) 2024 Meltytech, LLC
+ * Copyright (c) 2024-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_gpsgraphic.cpp
+++ b/src/modules/qt/filter_gpsgraphic.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_gpsgraphic.cpp -- draws gps related graphics
- * Copyright (c) 2015-2022 Meltytech, LLC
+ * Copyright (c) 2015-2025 Meltytech, LLC
  * Original author: Daniel F
  *
  * This library is free software; you can redistribute it and/or

--- a/src/modules/qt/filter_gpsgraphic.cpp
+++ b/src/modules/qt/filter_gpsgraphic.cpp
@@ -401,16 +401,16 @@ static int filter_get_image(mlt_frame frame,
     s_base_crops used_crops = {0, 100, 0, 100};
 
     // Get the current image
-    *format = mlt_image_rgba;
+    *format = choose_image_format(*format);
     error = mlt_frame_get_image(frame, image, format, width, height, writable);
 
     // Draw the graph
     if (!error) {
         process_frame_properties(filter, frame, used_crops);
         QImage qimg(*width, *height, QImage::Format_ARGB32);
-        convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+        convert_mlt_to_qimage(*image, &qimg, *width, *height, *format);
         draw_graphics(filter, frame, &qimg, *width, *height, used_crops);
-        convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+        convert_qimage_to_mlt(&qimg, *image, *width, *height);
     } else
         mlt_log_warning(MLT_FILTER_SERVICE(filter),
                         "mlt_frame_get_image error=%d, can't draw at all\n",

--- a/src/modules/qt/filter_lightshow.cpp
+++ b/src/modules/qt/filter_lightshow.cpp
@@ -213,7 +213,7 @@ static int filter_get_image(mlt_frame frame,
         mlt_rect rect = mlt_properties_anim_get_rect(filter_properties, "rect", position, length);
 
         // Get the current image
-        *format = mlt_image_rgba;
+        *format = choose_image_format(*format);
         error = mlt_frame_get_image(frame, image, format, width, height, 1);
 
         if (strchr(mlt_properties_get(filter_properties, "rect"), '%')) {
@@ -234,9 +234,9 @@ static int filter_get_image(mlt_frame frame,
         // Draw the light
         if (!error) {
             QImage qimg(*width, *height, QImage::Format_ARGB32);
-            convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+            convert_mlt_to_qimage(*image, &qimg, *width, *height, *format);
             draw_light(filter_properties, &qimg, &rect, mag);
-            convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+            convert_qimage_to_mlt(&qimg, *image, *width, *height);
         }
     } else {
         if (pdata->preprocess_warned++ == 2) {

--- a/src/modules/qt/filter_lightshow.cpp
+++ b/src/modules/qt/filter_lightshow.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_lightshow.cpp -- animate color to the audio
- * Copyright (C) 2015-2020 Meltytech, LLC
+ * Copyright (C) 2015-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -184,7 +184,7 @@ static int filter_get_image(mlt_frame frame,
     if (!hasAlpha) {
         uint8_t *src_image = NULL;
         error = mlt_frame_get_image(frame, &src_image, format, &b_width, &b_height, 0);
-        if (*format == mlt_image_rgba || mlt_frame_get_alpha(frame)) {
+        if (*format == mlt_image_rgba || *format == mlt_image_rgba64 || mlt_frame_get_alpha(frame)) {
             hasAlpha = true;
         } else {
             // Prepare output image
@@ -196,13 +196,13 @@ static int filter_get_image(mlt_frame frame,
     }
 
     // fetch image
-    *format = mlt_image_rgba;
+    *format = choose_image_format(*format);
     uint8_t *src_image = NULL;
     error = mlt_frame_get_image(frame, &src_image, format, &b_width, &b_height, 0);
 
     // Put source buffer into QImage
     QImage sourceImage;
-    convert_mlt_to_qimage_rgba(src_image, &sourceImage, b_width, b_height);
+    convert_mlt_to_qimage(src_image, &sourceImage, b_width, b_height, *format);
 
     int image_size = mlt_image_format_size(*format, *width, *height, NULL);
 
@@ -226,7 +226,7 @@ static int filter_get_image(mlt_frame frame,
     dest_image = (uint8_t *) mlt_pool_alloc(image_size);
 
     QImage destImage;
-    convert_mlt_to_qimage_rgba(dest_image, &destImage, *width, *height);
+    convert_mlt_to_qimage(dest_image, &destImage, *width, *height, *format);
     destImage.fill(mlt_properties_get_int(properties, "background_color"));
 
     QPainter painter(&destImage);
@@ -239,7 +239,7 @@ static int filter_get_image(mlt_frame frame,
     painter.drawImage(0, 0, sourceImage);
     // finish Qt drawing
     painter.end();
-    convert_qimage_to_mlt_rgba(&destImage, dest_image, *width, *height);
+    convert_qimage_to_mlt(&destImage, dest_image, *width, *height);
     *image = dest_image;
     mlt_frame_set_image(frame, *image, *width * *height * 4, mlt_pool_release);
     return error;

--- a/src/modules/qt/filter_qtcrop.cpp
+++ b/src/modules/qt/filter_qtcrop.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_qtcrop.cpp -- cropping filter
- * Copyright (c) 2020 Meltytech, LLC
+ * Copyright (c) 2020-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/filter_qtcrop.cpp
+++ b/src/modules/qt/filter_qtcrop.cpp
@@ -42,13 +42,13 @@ static int get_image(mlt_frame frame,
     mlt_rect rect = mlt_properties_anim_get_rect(properties, "rect", position, length);
 
     // Get the current image
-    *format = mlt_image_rgba;
+    *format = choose_image_format(*format);
     mlt_properties_set_int(MLT_FRAME_PROPERTIES(frame), "resize_alpha", 255);
     error = mlt_frame_get_image(frame, image, format, width, height, writable);
 
-    if (!error && *format == mlt_image_rgba) {
+    if (!error && (*format == mlt_image_rgba || *format == mlt_image_rgba64)) {
         QImage bgImage;
-        convert_mlt_to_qimage_rgba(*image, &bgImage, *width, *height);
+        convert_mlt_to_qimage(*image, &bgImage, *width, *height, *format);
 
         QImage fgImage = bgImage.copy();
         QPainter painter(&bgImage);
@@ -89,7 +89,7 @@ static int get_image(mlt_frame frame,
         painter.drawImage(QPointF(0, 0), fgImage);
         painter.end();
 
-        convert_qimage_to_mlt_rgba(&bgImage, *image, *width, *height);
+        convert_qimage_to_mlt(&bgImage, *image, *width, *height);
     }
     return error;
 }

--- a/src/modules/qt/filter_qtext.cpp
+++ b/src/modules/qt/filter_qtext.cpp
@@ -346,7 +346,7 @@ static int filter_get_image(mlt_frame frame,
     mlt_rect rect = mlt_properties_anim_get_rect(filter_properties, "geometry", position, length);
 
     // Get the current image
-    *image_format = mlt_image_rgba;
+    *image_format = choose_image_format(*image_format);
     mlt_properties_set_int(MLT_FRAME_PROPERTIES(frame), "resize_alpha", 255);
     mlt_service_lock(MLT_FILTER_SERVICE(filter));
     error = mlt_frame_get_image(frame, image, image_format, width, height, writable);
@@ -367,7 +367,7 @@ static int filter_get_image(mlt_frame frame,
         }
 
         QImage qimg;
-        convert_mlt_to_qimage_rgba(*image, &qimg, *width, *height);
+        convert_mlt_to_qimage(*image, &qimg, *width, *height, *image_format);
 
         QPainterPath text_path;
 #ifdef Q_OS_WIN
@@ -408,7 +408,7 @@ static int filter_get_image(mlt_frame frame,
         }
         painter.end();
 
-        convert_qimage_to_mlt_rgba(&qimg, *image, *width, *height);
+        convert_qimage_to_mlt(&qimg, *image, *width, *height);
     }
     mlt_service_unlock(MLT_FILTER_SERVICE(filter));
     free(argument);

--- a/src/modules/qt/filter_qtext.cpp
+++ b/src/modules/qt/filter_qtext.cpp
@@ -75,11 +75,7 @@ static QRectF get_text_path(QPainterPath *qpath,
     height = fm.lineSpacing() * lines.size();
     for (int i = 0; i < lines.size(); ++i) {
         const QString line = lines[i];
-#if (QT_VERSION > QT_VERSION_CHECK(5, 11, 0))
         int line_width = fm.horizontalAdvance(line);
-#else
-        int line_width = fm.width(line);
-#endif
         int bearing = (line.size() > 0) ? fm.leftBearing(line.at(0)) : 0;
         if (bearing < 0)
             line_width -= bearing;
@@ -96,11 +92,7 @@ static QRectF get_text_path(QPainterPath *qpath,
     for (int i = 0; i < lines.size(); ++i) {
         QString line = lines.at(i);
         x = offset;
-#if (QT_VERSION > QT_VERSION_CHECK(5, 11, 0))
         int line_width = fm.horizontalAdvance(line);
-#else
-        int line_width = fm.width(line);
-#endif
         int bearing = (line.size() > 0) ? fm.leftBearing(line.at(0)) : 0;
 
         if (bearing < 0) {

--- a/src/modules/qt/filter_qtext.cpp
+++ b/src/modules/qt/filter_qtext.cpp
@@ -1,6 +1,6 @@
 /*
  * filter_qtext.cpp -- text overlay filter
- * Copyright (c) 2018-2021 Meltytech, LLC
+ * Copyright (c) 2018-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/gps_drawing.cpp
+++ b/src/modules/qt/gps_drawing.cpp
@@ -70,7 +70,6 @@ static bool rect_intersects_line(QRectF rect, point_2d pt1, point_2d pt2)
     if (rect.contains(pt1.x, pt1.y) || rect.contains(pt2.x, pt2.y))
         return true;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     //check if each side of the rect intersects (bounded) with the line
     QLineF line = QLineF(pt1.x, pt1.y, pt2.x, pt2.y);
     if (line.intersects(QLineF(rect.topLeft(), rect.topRight()), NULL)
@@ -85,9 +84,6 @@ static bool rect_intersects_line(QRectF rect, point_2d pt1, point_2d pt2)
     if (line.intersects(QLineF(rect.topRight(), rect.bottomRight()), NULL)
         == QLineF::BoundedIntersection)
         return true;
-#else
-    return true; //this is ok because rect clipping is enabled, it just skips the optimisation
-#endif
 
     return false;
 }

--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -2,6 +2,7 @@
  * kdenlivetitle_wrapper.cpp -- kdenlivetitle wrapper
  * Copyright (c) 2009 Marco Gittler <g.marco@freenet.de>
  * Copyright (c) 2009 Jean-Baptiste Mardelle <jb@kdenlive.org>
+ * Copyright (c) 2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -166,11 +166,7 @@ public:
 
     void updateText(QString text)
     {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
         m_path.clear();
-#else
-        m_path = QPainterPath();
-#endif
         // Calculate line width
         QStringList lines = text.split('\n');
         double linePos = m_metrics.ascent();
@@ -198,18 +194,10 @@ public:
             }
             linePos += m_lineSpacing;
             if (m_align == Qt::AlignHCenter) {
-#if (QT_VERSION > QT_VERSION_CHECK(5, 11, 0))
                 double offset = (m_width - m_metrics.horizontalAdvance(line)) / 2;
-#else
-                double offset = (m_width - m_metrics.width(line)) / 2;
-#endif
                 linePath.translate(offset, 0);
             } else if (m_align == Qt::AlignRight) {
-#if (QT_VERSION > QT_VERSION_CHECK(5, 11, 0))
                 double offset = (m_width - m_metrics.horizontalAdvance(line));
-#else
-                double offset = (m_width - m_metrics.width(line));
-#endif
                 linePath.translate(offset, 0);
             }
             m_path.addPath(linePath);
@@ -225,10 +213,7 @@ public:
         }
     }
 
-    virtual QRectF boundingRect() const
-    {
-        return m_boundingRect;
-    }
+    virtual QRectF boundingRect() const { return m_boundingRect; }
 
     virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *w)
     {
@@ -874,13 +859,8 @@ void drawKdenliveTitle(producer_ktitle self,
 
         //must be extracted from kdenlive title
         self->rgba_image = (uint8_t *) mlt_pool_alloc(image_size);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
-        // QImage::Format_RGBA8888 was added in Qt5.2
         // Initialize the QImage with the MLT image because the data formats match.
         QImage img(self->rgba_image, width, height, QImage::Format_RGBA8888);
-#else
-        QImage img(width, height, QImage::Format_ARGB32);
-#endif
         img.fill(0);
         QPainter p1;
         p1.begin(&img);

--- a/src/modules/qt/kdenlivetitle_wrapper.cpp
+++ b/src/modules/qt/kdenlivetitle_wrapper.cpp
@@ -936,7 +936,7 @@ void drawKdenliveTitle(producer_ktitle self,
         p1.end();
         self->format = mlt_image_rgba;
 
-        convert_qimage_to_mlt_rgba(&img, self->rgba_image, width, height);
+        convert_qimage_to_mlt(&img, self->rgba_image, width, height);
         self->current_image = (uint8_t *) mlt_pool_alloc(image_size);
         memcpy(self->current_image, self->rgba_image, image_size);
         mlt_properties_set_data(producer_props,

--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -186,11 +186,7 @@ static void generate_qpath(mlt_properties producer_properties)
     height = fm.lineSpacing() * lines.size();
     for (int i = 0; i < lines.size(); ++i) {
         const QString line = lines[i];
-#if (QT_VERSION > QT_VERSION_CHECK(5, 11, 0))
         int line_width = fm.horizontalAdvance(line);
-#else
-        int line_width = fm.width(line);
-#endif
         int bearing = (line.size() > 0) ? fm.leftBearing(line.at(0)) : 0;
         if (bearing < 0)
             line_width -= bearing;
@@ -207,11 +203,7 @@ static void generate_qpath(mlt_properties producer_properties)
     for (int i = 0; i < lines.size(); ++i) {
         QString line = lines.at(i);
         x = offset;
-#if (QT_VERSION > QT_VERSION_CHECK(5, 11, 0))
         int line_width = fm.horizontalAdvance(line);
-#else
-        int line_width = fm.width(line);
-#endif
         int bearing = (line.size() > 0) ? fm.leftBearing(line.at(0)) : 0;
 
         if (bearing < 0) {

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -274,11 +274,11 @@ static int get_image(mlt_frame a_frame,
 
     // convert bottom mlt image to qimage
     QImage bottomImg;
-    convert_mlt_to_qimage_rgba(*image, &bottomImg, *width, *height);
+    convert_mlt_to_qimage(*image, &bottomImg, *width, *height, *format);
 
     // convert top mlt image to qimage
     QImage topImg;
-    convert_mlt_to_qimage_rgba(b_image, &topImg, b_width, b_height);
+    convert_mlt_to_qimage(b_image, &topImg, b_width, b_height, *format);
 
     // setup Qt drawing
     QPainter painter(&bottomImg);
@@ -293,7 +293,7 @@ static int get_image(mlt_frame a_frame,
 
     // finish Qt drawing
     painter.end();
-    convert_qimage_to_mlt_rgba(&bottomImg, *image, *width, *height);
+    convert_qimage_to_mlt(&bottomImg, *image, *width, *height);
     mlt_frame_set_image(a_frame, *image, image_size, mlt_pool_release);
     // Remove potentially large image on the B frame.
     mlt_frame_set_image(b_frame, NULL, 0, NULL);

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -1,6 +1,7 @@
 /*
  * transition_qtblend.cpp -- Qt composite transition
  * Copyright (c) 2016-2025 Jean-Baptiste Mardelle <jb@kdenlive.org>
+ * Copyright (c) 2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/modules/qt/transition_vqm.cpp
+++ b/src/modules/qt/transition_vqm.cpp
@@ -149,7 +149,7 @@ static int get_image(mlt_frame a_frame,
 
     // convert mlt image to qimage
     QImage img;
-    convert_mlt_to_qimage_rgba(*image, &img, *width, *height);
+    convert_mlt_to_qimage(*image, &img, *width, *height, *format);
 
     // setup Qt drawing
     QPainter painter(&img);
@@ -183,7 +183,7 @@ static int get_image(mlt_frame a_frame,
 
     // finish Qt drawing
     painter.end();
-    convert_qimage_to_mlt_rgba(&img, *image, *width, *height);
+    convert_qimage_to_mlt(&img, *image, *width, *height);
 
     return 0;
 }

--- a/src/modules/qt/transition_vqm.cpp
+++ b/src/modules/qt/transition_vqm.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2024 Dan Dennedy <dan@dennedy.org>
  * Core psnr and ssim routines based on code from
  *   qsnr (C) 2010 E. Oriani, ema <AT> fastwebnet <DOT> it
+ * Copyright (c) 2025 Meltytech, LLC
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This proposed patch adds a new image format: 64bit per pixel RGBA (16 bits per channel).
It also implements some filters (boxblur, qt, and ffmpeg) to use the new format.

Example commands:
melt color:red -consumer sdl2 mlt_image_format=rgba64

melt test.mp4 -filter avfilter.gblur av.sigma=50 -consumer sdl2 mlt_image_format=rgba64

melt test.mp4 -filter qtext:"hello" fgcolour=0x777777ff -consumer sdl2 mlt_image_format=rgba64

Looking for discussion and comments about whether we would want to add this image format to support higher bit depth processing. Comments welcome.