### PR TITLE
Fix mlt_log_* defines for MSVC

### DIFF
--- a/src/framework/mlt_log.h
+++ b/src/framework/mlt_log.h
@@ -80,6 +80,21 @@ void mlt_log(void *service, int level, const char *fmt, ...)
 void mlt_log(void *service, int level, const char *fmt, ...);
 #endif
 
+#ifdef _MSC_VER
+
+#define MLT_LOG_EXPAND_ARGS(...) , ##__VA_ARGS__
+
+#define mlt_log_panic(service, format, ...)   mlt_log((service), MLT_LOG_PANIC, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_fatal(service, format, ...)   mlt_log((service), MLT_LOG_FATAL, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_error(service, format, ...)   mlt_log((service), MLT_LOG_ERROR, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_warning(service, format, ...) mlt_log((service), MLT_LOG_WARNING, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_info(service, format, ...)    mlt_log((service), MLT_LOG_INFO, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_verbose(service, format, ...) mlt_log((service), MLT_LOG_VERBOSE, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_timings(service, format, ...) mlt_log((service), MLT_LOG_TIMINGS, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+#define mlt_log_debug(service, format, ...)   mlt_log((service), MLT_LOG_DEBUG, format MLT_LOG_EXPAND_ARGS(__VA_ARGS__))
+
+#else
+
 #define mlt_log_panic(service, format, args...) mlt_log((service), MLT_LOG_PANIC, (format), ##args)
 #define mlt_log_fatal(service, format, args...) mlt_log((service), MLT_LOG_FATAL, (format), ##args)
 #define mlt_log_error(service, format, args...) mlt_log((service), MLT_LOG_ERROR, (format), ##args)
@@ -91,6 +106,8 @@ void mlt_log(void *service, int level, const char *fmt, ...);
 #define mlt_log_timings(service, format, args...) \
     mlt_log((service), MLT_LOG_TIMINGS, (format), ##args)
 #define mlt_log_debug(service, format, args...) mlt_log((service), MLT_LOG_DEBUG, (format), ##args)
+
+#endif
 
 void mlt_vlog(void *service, int level, const char *fmt, va_list);
 int mlt_log_get_level(void);


### PR DESCRIPTION
Variadic arguments behave diffently with MSVC

See eg. https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170#comma-elision-in-variadic-macros