### PR TITLE
xml parser: remove deprecated entity substitution setup to fix #1083

### DIFF
--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -2065,7 +2065,6 @@ mlt_producer producer_xml_init(mlt_profile profile,
 
     // Setup libxml2 SAX parsing
     xmlInitParser();
-    xmlSubstituteEntitiesDefault(1);
     // This is used to facilitate entity substitution in the SAX parser
     context->entity_doc = xmlNewDoc(_x("1.0"));
     if (is_filename)
@@ -2114,6 +2113,8 @@ mlt_producer producer_xml_init(mlt_profile profile,
         free(sax);
         return NULL;
     }
+
+    xmlcontext->replaceEntities = 1;
 
     // Reset the stack.
     mlt_deque_close(context->stack_service);


### PR DESCRIPTION
This fixes #1083 for me

Based on your comment pointing to libxml2:

* I compiled and tested a sample from libxml2 and could not reproduce the problem
* apparently this behavior of replacing &amp; with &  when parsing is called entity substitution
* found this term in producer_xml.c where we were calling  xmlSubstituteEntitiesDefault(1)
* saw that this is marked as deprecated and is not being used in the sample from libxml2
* removed it and it didn't fix the problem
* found that setting replaceEntities fixes it (the docs mention XML_PARSE_NOENT though)

Long story short, I have no idea what I'm doing but at least could confirm your tip regarding libxml2.
I would suggest you may take it from here :slightly_smiling_face: 