### PR TITLE
Use CMake's find_package for SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ if(WIN32)
   endif()
 endif()
 
-pkg_check_modules(sdl2 IMPORTED_TARGET sdl2)
+find_package(SDL2)
 
 if(MOD_QT OR MOD_QT6 OR MOD_PLUS)
   pkg_check_modules(FFTW IMPORTED_TARGET fftw3)
@@ -411,7 +411,7 @@ if(MOD_SDL1)
 endif()
 
 if(MOD_SDL2)
-  if(TARGET PkgConfig::sdl2)
+  if(SDL2_FOUND)
     list(APPEND MLT_SUPPORTED_COMPONENTS sdl2)
   else()
     set(MOD_SDL2 OFF)

--- a/src/melt/CMakeLists.txt
+++ b/src/melt/CMakeLists.txt
@@ -6,8 +6,8 @@ target_link_libraries(melt PRIVATE mlt Threads::Threads)
 
 target_compile_definitions(melt PRIVATE VERSION="${MLT_VERSION}")
 
-if(TARGET PkgConfig::sdl2 AND NOT ANDROID)
-    target_link_libraries(melt PRIVATE PkgConfig::sdl2)
+if(SDL2_FOUND AND NOT ANDROID)
+    target_link_libraries(melt PRIVATE SDL2::SDL2)
     target_compile_definitions(melt PRIVATE HAVE_SDL2)
     if(MINGW)
         target_link_libraries(melt PRIVATE ${MLT_PTHREAD_LIBS})

--- a/src/modules/sdl2/CMakeLists.txt
+++ b/src/modules/sdl2/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(Other_sdl2_Files SOURCES
 
 target_compile_options(mltsdl2 PRIVATE ${MLT_COMPILE_OPTIONS})
 
-target_link_libraries(mltsdl2 PRIVATE mlt Threads::Threads PkgConfig::sdl2)
+target_link_libraries(mltsdl2 PRIVATE mlt Threads::Threads SDL2::SDL2)
 if(MSVC)
   target_link_libraries(mltsdl2 PRIVATE PThreads4W::PThreads4W)
 else()


### PR DESCRIPTION
In general find_package is supposed to work on all platform, whereas pkg-config is focused on Unix-like platforms

See https://cmake.org/cmake/help/latest/module/FindSDL.html#examples