### PR TITLE
Fix #1113: progress2 is not in documentation

### DIFF
--- a/src/melt/melt.c
+++ b/src/melt/melt.c
@@ -515,6 +515,7 @@ static void show_usage(char *program_name)
         "  -null-track | -hide-track                Add a hidden track\n"
         "  -profile name                            Set the processing settings\n"
         "  -progress                                Display progress along with position\n"
+        "  -progress2                               Display progress along with position on a new line\n"
         "  -query                                   List all of the registered services\n"
         "  -query \"consumers\" | \"consumer\"=id       List consumers or show info about one\n"
         "  -query \"filters\" | \"filter\"=id           List filters or show info about one\n"


### PR DESCRIPTION
As reported here: https://github.com/mltframework/mlt/issues/1113