### PR TITLE
Fix void pointers arithmetic

### DIFF
--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -1416,8 +1416,8 @@ static int encode_audio(encode_ctx_t *ctx)
                 if (source_offset < ctx->channels) {
                     // Interleave the audio buffer with the # channels for this stream/mapping.
                     for (k = 0; k < map_channels; k++, j++, source_offset++, dest_offset++) {
-                        void *src = ctx->audio_buf_1 + source_offset * ctx->sample_bytes;
-                        void *dest = ctx->audio_buf_2 + dest_offset * ctx->sample_bytes;
+                        uint8_t *src = ctx->audio_buf_1 + source_offset * ctx->sample_bytes;
+                        uint8_t *dest = ctx->audio_buf_2 + dest_offset * ctx->sample_bytes;
                         int s = samples + 1;
 
                         while (--s) {


### PR DESCRIPTION
Pointer arithmetic with void pointers works in GNU C by considering the size of the void as 1 hence it worked.

However the C standard doesn't allow pointer arithmetic with void pointers. Hence MSVC fails with Error C2036.

Please that I am not too confident when it comes to "low level" pointer related C stuff. As far as I understand this is correct and should be low risk, but please review extra carefull anyways.