### PR TITLE
Add rgba and rgba formats to transition luma.

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -667,3 +667,8 @@ MLT_7.32.0 {
   global:
     mlt_service_set_consumer;
 } MLT_7.30.0;
+
+MLT_7.34.0 {
+  global:
+    mlt_image_is_opaque;
+} MLT_7.32.0;

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -559,6 +559,42 @@ void mlt_image_fill_opaque(mlt_image self)
     }
 }
 
+/** Check if the alpha channel of an image is opaque
+ *
+ * \public \memberof mlt_image_s
+ * \param self a mlt_image
+ * \return true (1) or false (0) if the image is opaque
+ */
+extern int mlt_image_is_opaque(mlt_image self)
+{
+    if (!self->data)
+        return 0;
+
+    int pixels = self->width * self->height;
+
+    if (self->format == mlt_image_rgba && self->planes[0] != NULL) {
+        int samples = pixels * 4;
+        uint8_t *img = self->planes[0];
+        for (int i = 0; i < samples; i += 4) {
+            if (img[i + 3] != 0xff)
+                return 0;
+        }
+    } else if (self->format == mlt_image_rgba64 && self->planes[0] != NULL) {
+        int samples = pixels * 4;
+        uint16_t *img = (uint16_t *) self->planes[0];
+        for (int i = 0; i < samples; i += 4) {
+            if (img[i + 3] != 0xffff)
+                return 0;
+        }
+    } else if (self->planes[3] != NULL) {
+        for (int i = 0; i < pixels; i++) {
+            if (self->planes[3][i] != 0xff)
+                return 0;
+        }
+    }
+    return 1;
+}
+
 /** Get the number of bytes needed for an image.
   *
   * \public \memberof mlt_image_s

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -3,7 +3,7 @@
  * \brief Image class
  * \see mlt_image_s
  *
- * Copyright (C) 2022-2024 Meltytech, LLC
+ * Copyright (C) 2022-2025 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -59,6 +59,7 @@ extern void mlt_image_fill_black(mlt_image self);
 extern void mlt_image_fill_checkerboard(mlt_image self, double sample_aspect_ratio);
 extern void mlt_image_fill_white(mlt_image self, int full_range);
 extern void mlt_image_fill_opaque(mlt_image self);
+extern int mlt_image_is_opaque(mlt_image self);
 extern const char *mlt_image_format_name(mlt_image_format format);
 extern mlt_image_format mlt_image_format_id(const char *name);
 extern int mlt_image_rgba_opaque(uint8_t *image, int width, int height);


### PR DESCRIPTION
I added rgba and rgba64 formats to transition luma. Everything seems to test find in Shotcut when i force it to use those image formats.

Posting for review here because there are a few things I am unsure of. I notice that the composite line function branches off to some code shared with transition composite. I did not recreate that code. So I am unsure if this will perfectly match those scenarios.

This is the specific case that I did not duplicate:
https://github.com/mltframework/mlt/blob/ff1f0d7215bf6ebde7291cd2f14f34f738eb88eb/src/modules/core/transition_luma.c#L170

I only implemented the case for `is_translucent && alpha_over`
Shotcut  sets "alpha_over". And i do not really know the significance of "is_translucent". 