### PR TITLE
Update factory.c

### DIFF
--- a/src/modules/ndi/factory.c
+++ b/src/modules/ndi/factory.c
@@ -74,7 +74,7 @@ void swab2(const void *from, void *to, int n)
     to = (unsigned char *) to + n - (n % SWAB_STEP);
     n = (n % SWAB_STEP);
 #endif
-    swab((char *) from, (char *) to, n);
+    swab2((char *) from, (char *) to, n);
 };
 
 #define SWAB_SLICED_ALIGN_POW 5


### PR DESCRIPTION
Hotfix for "src/modules/ndi/factory.c:77:5: error: implicit declaration of function ‘swab’; did you mean ‘swab2’? [-Wimplicit-function-declaration]" error