### PR TITLE
Fix recent void pointers arithmetic regression

### DIFF
--- a/src/modules/core/filter_pillar_echo.c
+++ b/src/modules/core/filter_pillar_echo.c
@@ -164,7 +164,7 @@ static int scale_sliced_proc_rgba64(int id, int index, int jobs, void *data)
     int slice_line_end = slice_line_start + slice_height;
     double srcScale = rect.h / (double) src->height;
     int linesize = src->width * 4 * 2;
-    uint16_t *d = dst->data + (slice_line_start * linesize);
+    uint16_t *d = (uint16_t *) ((char *) dst->data + (slice_line_start * linesize));
     for (int y = slice_line_start; y < slice_line_end; y++) {
         double srcY = rect.y + (double) y * srcScale;
         int srcYindex = floor(srcY);
@@ -181,7 +181,7 @@ static int scale_sliced_proc_rgba64(int id, int index, int jobs, void *data)
             double valueSum[] = {0.0, 0.0, 0.0, 0.0};
             double factorSum[] = {0.0, 0.0, 0.0, 0.0};
 
-            uint16_t *s = src->data + (srcYindex * linesize) + (srcXindex * 4);
+            uint16_t *s = (uint16_t *) ((char *) src->data + (srcYindex * linesize) + (srcXindex * 4));
 
             // Top Left
             double ftl = ftop * fleft;

--- a/src/modules/core/image_proc.c
+++ b/src/modules/core/image_proc.c
@@ -572,11 +572,11 @@ static int blur_v_proc_rgbx64(int id, int index, int jobs, void *data)
     double diameter = (radius * 2) + 1;
 
     for (x = slice_row_start; x < slice_row_end; x++) {
-        uint16_t *first = desc->src->data + (x * step);
+        uint16_t *first = (uint16_t *) ((char *) desc->src->data + (x * step));
         uint16_t *last = first + (linesize * (desc->src->height - 1));
         uint16_t *s1 = first;
         uint16_t *s2 = first;
-        uint16_t *d = desc->dst->data + (x * step);
+        uint16_t *d = (uint16_t *) ((char *) desc->dst->data + (x * step));
         accumulator[0] = first[0] * (radius + 1);
         accumulator[1] = first[1] * (radius + 1);
         accumulator[2] = first[2] * (radius + 1);


### PR DESCRIPTION
Pointer arithmetic with void pointers works in GNU C by considering the size of the void as 1 hence it worked.

However the C standard doesn't allow pointer arithmetic with void pointers.

Related to #1104 and #1131