### PR TITLE
Fix source documentation typos

### DIFF
--- a/demo/README
+++ b/demo/README
@@ -83,7 +83,7 @@ Audio Stuff
 	video clip has a "floating" amplitude normalisation filter applied.
 	Typically, audio normalisation applies a constant gain factor across the
 	entire duration of an audio segment from a single source where the 
-	gain factor is automatically determined by anaylsing the maximum "power"
+	gain factor is automatically determined by analysing the maximum "power"
 	or peak levels. However, in news production, a popular requirement is to
 	to dynamically boost the amplitude in soft areas and reduce the amplitude
 	in louder areas. Thus, the gain analysis is performed using a "sliding

--- a/src/framework/mlt_animation.c
+++ b/src/framework/mlt_animation.c
@@ -1347,7 +1347,7 @@ static inline double interpolate_value(double x0,
  * \private \memberof mlt_animation_s
  *
  * \param item an unpopulated animation item to be interpolated.
- *  The frame and keyframe_type fields must already be set. The value for "frame" is the postion
+ *  The frame and keyframe_type fields must already be set. The value for "frame" is the position
  *  at which the value will be interpolated. The value for "keyframe_type" determines which
  *  interpolation will be used.
  * \param p a sequential array of 4 animation items. The frame value for item must lie between the

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -63,7 +63,7 @@
  * or infinity. Those producers tend to not override the default length and one
  * expect the app or user to set the length. The default value of 15000 was chosen
  * to provide something useful - not too long or short and convenient to simply
- * set an out point without necessarily nedding to extend the length.
+ * set an out point without necessarily needing to extend the length.
  * \todo define the media metadata taxonomy
  */
 

--- a/src/framework/mlt_repository.c
+++ b/src/framework/mlt_repository.c
@@ -517,7 +517,7 @@ static char *getenv_locale()
 /** Return a list of user-preferred language codes taken from environment variables.
  *
  * A module should use this to locate a localized YAML Tiny file from which to build
- * its metadata strucutured properties.
+ * its metadata structured properties.
  *
  * \public \memberof mlt_repository_s
  * \param self a repository

--- a/src/modules/core/filter_autofade.yml
+++ b/src/modules/core/filter_autofade.yml
@@ -11,7 +11,7 @@ tags:
 description: >
   Automatically fade audio between clips in a playlist.
   This filter will fade the audio out at the end of a clip and fade the
-  audio in at the  begining of a clip.
+  audio in at the beginning of a clip.
   Only to be used as a filter on playlist producers.
   Uses the "meta.playlist.clip_position" and "meta.playlist.clip_length"
   properties that are added by the playlist producer to determine where

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -1035,7 +1035,7 @@ protected:
                     if (m_currentSpeed || preroll) {
                         if (!preroll && m_previousSpeed != 1 && m_currentSpeed == 1) {
                             // Resume
-                            mlt_log_verbose(getConsumer(), "Resuming foward 1x playback\n");
+                            mlt_log_verbose(getConsumer(), "Resuming forward 1x playback\n");
                             m_deckLinkOutput->StopScheduledPlayback(0, nullptr, 0);
                             m_count = 0;
                             if (m_isAudio)

--- a/src/modules/gdk/producer_pixbuf.yml
+++ b/src/modules/gdk/producer_pixbuf.yml
@@ -117,7 +117,7 @@ parameters:
     mutable: yes
 
   - identifier: loop
-    title: Loop sequence of images indefinitively
+    title: Loop sequence of images indefinitely
     description: when 1 (default) loop sequences of images, when 0, play them only once
     type: boolean
     default: 1

--- a/src/modules/plus/filter_subtitle_feed.yml
+++ b/src/modules/plus/filter_subtitle_feed.yml
@@ -26,7 +26,7 @@ parameters:
     title: Text
     type: string
     description: >
-        A string that containes a complete SRT document.
+        A string that contains a complete SRT document.
         This parameter is ignored if resource is set.
     required: no
     readonly: no

--- a/src/modules/qt/filter_gpstext.yml
+++ b/src/modules/qt/filter_gpstext.yml
@@ -49,7 +49,7 @@ parameters:
       Keywords returning numeric values can use the extra word "decimals" to forcefully
       set a specific number of decimals (0-9). Example: #gps_speed decimals 3#.
       Time-based keywords can include a strftime format string to customize the
-      output and a number (representing seconds) preceeded by '+' or '-' which will 
+      output and a number (representing seconds) preceded by '+' or '-' which will 
       offset the actual time. For example,  "#gps_datetime_now %I:%M:%S %p +3600#" shows 
       only the time in 12-hour format, offset by 1 hour.
       The speed keyword can have an extra "vertical" or "3D" word as a format to show


### PR DESCRIPTION
Fixed various typos in the source that would show up in documentation or user-facing context.