### PR TITLE
Add mlt types for colorspace, trc, and primaries

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -671,4 +671,6 @@ MLT_7.32.0 {
 MLT_7.34.0 {
   global:
     mlt_image_is_opaque;
+    mlt_image_color_trc_name;
+    mlt_image_color_trc_id;
 } MLT_7.32.0;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -675,4 +675,6 @@ MLT_7.34.0 {
     mlt_image_color_trc_id;
     mlt_image_colorspace_name;
     mlt_image_colorspace_id;
+    mlt_image_color_pri_name;
+    mlt_image_color_pri_id;
 } MLT_7.32.0;

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -673,4 +673,6 @@ MLT_7.34.0 {
     mlt_image_is_opaque;
     mlt_image_color_trc_name;
     mlt_image_color_trc_id;
+    mlt_image_colorspace_name;
+    mlt_image_colorspace_id;
 } MLT_7.32.0;

--- a/src/framework/mlt_consumer.h
+++ b/src/framework/mlt_consumer.h
@@ -87,7 +87,7 @@
  * \properties \em video_off set non-zero to disable video processing
  * \properties \em drop_count the number of video frames not rendered since starting consumer
  * \properties \em color_range the color range as tv/mpeg (limited) or pc/jpeg (full); default is unset, which implies tv/mpeg
- * \properties \em color_trc the color transfer characteristic (gamma), default is unset, use FFmpeg's string values
+ * \properties \em color_trc the color transfer characteristic (gamma), default is unset, use mlt_color_trc string values
  * \properties \em deinterlacer the deinterlace algorithm to pass to deinterlace filters, defaults to "yadif"
  */
 

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -339,6 +339,72 @@ mlt_color_trc mlt_image_color_trc_id(const char *name)
     return mlt_color_trc_none;
 }
 
+const char *mlt_image_colorspace_name(mlt_colorspace colorspace)
+{
+    switch (colorspace) {
+    case mlt_colorspace_rgb:
+        return "rgb";
+    case mlt_colorspace_bt709:
+        return "bt709";
+    case mlt_colorspace_unspecified:
+        return "unspecified";
+    case mlt_colorspace_reserved:
+        return "reserved";
+    case mlt_colorspace_fcc:
+        return "fcc";
+    case mlt_colorspace_bt470bg:
+        return "bt470bg";
+    case mlt_colorspace_smpte170m:
+        return "smpte170m";
+    case mlt_colorspace_smpte240m:
+        return "smpte240m";
+    case mlt_colorspace_ycgco:
+        return "ycgco";
+    case mlt_colorspace_bt2020_ncl:
+        return "bt2020nc";
+    case mlt_colorspace_bt2020_cl:
+        return "bt2020c";
+    case mlt_colorspace_smpte2085:
+        return "smpte2085";
+    case mlt_colorspace_bt601:
+        return "bt601";
+    case mlt_colorspace_invalid:
+        return "invalid";
+    }
+    return "invalid";
+}
+
+mlt_colorspace mlt_image_colorspace_id(const char *name)
+{
+    const mlt_colorspace colorspaces[] = {mlt_colorspace_rgb,
+                                          mlt_colorspace_bt709,
+                                          mlt_colorspace_unspecified,
+                                          mlt_colorspace_reserved,
+                                          mlt_colorspace_fcc,
+                                          mlt_colorspace_bt470bg,
+                                          mlt_colorspace_smpte170m,
+                                          mlt_colorspace_smpte240m,
+                                          mlt_colorspace_ycgco,
+                                          mlt_colorspace_bt2020_ncl,
+                                          mlt_colorspace_bt2020_cl,
+                                          mlt_colorspace_smpte2085,
+                                          mlt_colorspace_bt601,
+                                          mlt_colorspace_invalid};
+
+    // Fall back to see if it was specified as a number
+    int value = strtol(name, NULL, 10);
+    if (!value && strcmp(name, "0"))
+        value = -1; // strtol returned an error;
+
+    for (int i = 0; name && i < sizeof(colorspaces); i++) {
+        const char *s = mlt_image_colorspace_name(colorspaces[i]);
+        if (value == colorspaces[i] || !strcmp(s, name))
+            return colorspaces[i];
+    }
+
+    return mlt_colorspace_invalid;
+}
+
 /** Fill an image with black.
   *
   * \bug This does not respect full range YUV if needed.

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -262,6 +262,83 @@ mlt_image_format mlt_image_format_id(const char *name)
     return mlt_image_invalid;
 }
 
+/** Get the short name for a color transfer characteristics.
+ *
+ * \public \memberof mlt_image_s
+ * \param trc the color transfer characteristics
+ * \return a string
+ */
+
+const char *mlt_image_color_trc_name(mlt_color_trc trc)
+{
+    switch (trc) {
+    case mlt_color_trc_none:
+    case mlt_color_trc_unspecified:
+    case mlt_color_trc_reserved:
+        return "none";
+    case mlt_color_trc_bt709:
+        return "bt709";
+    case mlt_color_trc_gamma22:
+        return "bt470m";
+    case mlt_color_trc_gamma28:
+        return "bt470bg";
+    case mlt_color_trc_smpte170m:
+        return "smpte170m";
+    case mlt_color_trc_smpte240m:
+        return "smpte240m";
+    case mlt_color_trc_linear:
+        return "linear";
+    case mlt_color_trc_log:
+        return "log100";
+    case mlt_color_trc_log_sqrt:
+        return "log316";
+    case mlt_color_trc_iec61966_2_4:
+        return "iec61966-2-4";
+    case mlt_color_trc_bt1361_ecg:
+        return "bt1361e";
+    case mlt_color_trc_iec61966_2_1:
+        return "iec61966-2-1";
+    case mlt_color_trc_bt2020_10:
+        return "bt2020-10";
+    case mlt_color_trc_bt2020_12:
+        return "bt2020-12";
+    case mlt_color_trc_smpte2084:
+        return "smpte2084";
+    case mlt_color_trc_smpte428:
+        return "smpte428";
+    case mlt_color_trc_arib_std_b67:
+        return "arib-std-b67";
+    case mlt_color_trc_invalid:
+        return "invalid";
+    }
+    return "none";
+}
+
+/** Get the id of color transfer characteristics from short name.
+ *
+ * \public \memberof mlt_image_s
+ * \param name the color trc short name
+ * \return a color trc
+ */
+
+mlt_color_trc mlt_image_color_trc_id(const char *name)
+{
+    mlt_color_trc c;
+
+    for (c = mlt_color_trc_none; name && c <= mlt_color_trc_invalid; c++) {
+        const char *s = mlt_image_color_trc_name(c);
+        if (!strcmp(s, name))
+            return c;
+    }
+
+    // Fall back to see if it was specified as a number
+    int value = strtol(name, NULL, 10);
+    if (value && value < mlt_color_trc_invalid)
+        return value;
+
+    return mlt_color_trc_none;
+}
+
 /** Fill an image with black.
   *
   * \bug This does not respect full range YUV if needed.

--- a/src/framework/mlt_image.c
+++ b/src/framework/mlt_image.c
@@ -405,6 +405,63 @@ mlt_colorspace mlt_image_colorspace_id(const char *name)
     return mlt_colorspace_invalid;
 }
 
+const char *mlt_image_color_pri_name(mlt_color_primaries primaries)
+{
+    switch (primaries) {
+    case mlt_color_pri_none:
+        return "none";
+    case mlt_color_pri_bt709:
+        return "bt709";
+    case mlt_color_pri_bt470m:
+        return "bt470m";
+    case mlt_color_pri_bt470bg:
+        return "bt470bg";
+    case mlt_color_pri_smpte170m:
+        return "smpte170m";
+    case mlt_color_pri_film:
+        return "film";
+    case mlt_color_pri_bt2020:
+        return "bt2020";
+    case mlt_color_pri_smpte428:
+        return "smpte428";
+    case mlt_color_pri_smpte431:
+        return "smpte431";
+    case mlt_color_pri_smpte432:
+        return "smpte432";
+    case mlt_color_pri_invalid:
+        return "invalid";
+    }
+    return "invalid";
+}
+
+mlt_color_primaries mlt_image_color_pri_id(const char *name)
+{
+    const mlt_color_primaries primaries[] = {mlt_color_pri_none,
+                                             mlt_color_pri_bt709,
+                                             mlt_color_pri_bt470m,
+                                             mlt_color_pri_bt470bg,
+                                             mlt_color_pri_smpte170m,
+                                             mlt_color_pri_film,
+                                             mlt_color_pri_bt2020,
+                                             mlt_color_pri_smpte428,
+                                             mlt_color_pri_smpte431,
+                                             mlt_color_pri_smpte432,
+                                             mlt_color_pri_invalid};
+
+    // Fall back to see if it was specified as a number
+    int value = strtol(name, NULL, 10);
+    if (!value && strcmp(name, "0"))
+        value = -1; // strtol returned an error;
+
+    for (int i = 0; name && i < sizeof(primaries); i++) {
+        const char *s = mlt_image_color_pri_name(primaries[i]);
+        if (value == primaries[i] || !strcmp(s, name))
+            return primaries[i];
+    }
+
+    return mlt_color_pri_none;
+}
+
 /** Fill an image with black.
   *
   * \bug This does not respect full range YUV if needed.

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -65,6 +65,8 @@ MLT_EXPORT const char *mlt_image_format_name(mlt_image_format format);
 MLT_EXPORT mlt_image_format mlt_image_format_id(const char *name);
 MLT_EXPORT const char *mlt_image_color_trc_name(mlt_color_trc trc);
 MLT_EXPORT mlt_color_trc mlt_image_color_trc_id(const char *name);
+MLT_EXPORT const char *mlt_image_colorspace_name(mlt_colorspace colorspace);
+MLT_EXPORT mlt_colorspace mlt_image_colorspace_id(const char *name);
 MLT_EXPORT int mlt_image_rgba_opaque(uint8_t *image, int width, int height);
 MLT_EXPORT int mlt_image_full_range(const char *color_range);
 

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -63,6 +63,8 @@ MLT_EXPORT void mlt_image_fill_opaque(mlt_image self);
 MLT_EXPORT int mlt_image_is_opaque(mlt_image self);
 MLT_EXPORT const char *mlt_image_format_name(mlt_image_format format);
 MLT_EXPORT mlt_image_format mlt_image_format_id(const char *name);
+MLT_EXPORT const char *mlt_image_color_trc_name(mlt_color_trc trc);
+MLT_EXPORT mlt_color_trc mlt_image_color_trc_id(const char *name);
 MLT_EXPORT int mlt_image_rgba_opaque(uint8_t *image, int width, int height);
 MLT_EXPORT int mlt_image_full_range(const char *color_range);
 

--- a/src/framework/mlt_image.h
+++ b/src/framework/mlt_image.h
@@ -67,6 +67,8 @@ MLT_EXPORT const char *mlt_image_color_trc_name(mlt_color_trc trc);
 MLT_EXPORT mlt_color_trc mlt_image_color_trc_id(const char *name);
 MLT_EXPORT const char *mlt_image_colorspace_name(mlt_colorspace colorspace);
 MLT_EXPORT mlt_colorspace mlt_image_colorspace_id(const char *name);
+MLT_EXPORT const char *mlt_image_color_pri_name(mlt_color_primaries primaries);
+MLT_EXPORT mlt_color_primaries mlt_image_color_pri_id(const char *name);
 MLT_EXPORT int mlt_image_rgba_opaque(uint8_t *image, int width, int height);
 MLT_EXPORT int mlt_image_full_range(const char *color_range);
 

--- a/src/framework/mlt_profile.c
+++ b/src/framework/mlt_profile.c
@@ -202,7 +202,8 @@ mlt_profile mlt_profile_load_properties(mlt_properties properties)
         profile->sample_aspect_den = mlt_properties_get_int(properties, "sample_aspect_den");
         profile->display_aspect_num = mlt_properties_get_int(properties, "display_aspect_num");
         profile->display_aspect_den = mlt_properties_get_int(properties, "display_aspect_den");
-        profile->colorspace = mlt_properties_get_int(properties, "colorspace");
+        const char *colorspace_str = mlt_properties_get(properties, "colorspace");
+        profile->colorspace = mlt_image_colorspace_id(colorspace_str);
     }
     return profile;
 }

--- a/src/framework/mlt_profile.h
+++ b/src/framework/mlt_profile.h
@@ -44,7 +44,7 @@ struct mlt_profile_s
     int sample_aspect_den;  /**< the denominator of the pixel aspect ratio */
     int display_aspect_num; /**< the numerator of the image aspect ratio in case it can not be simply derived (e.g. ITU-R 601) */
     int display_aspect_den; /**< the denominator of the image aspect ratio in case it can not be simply derived (e.g. ITU-R 601) */
-    int colorspace; /**< the Y'CbCr colorspace standard: `601` for ITU-R 601, `709` for ITU-R 709, `240` for SMPTE240M, `2020` for ITU-R BT.2020 non-constant luminance, `2021` for ITU-R BT.2020 constant luminance */
+    int colorspace;         /**< the Y'CbCr colorspace standard: see mlt_colorspace */
     int is_explicit; /**< used internally to indicate if the profile was requested explicitly or computed or defaulted */
 };
 

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -140,14 +140,13 @@ typedef enum {
 
 typedef enum {
     mlt_color_pri_none = 0,
-    mlt_color_pri_bt709 = 709,  ///< also ITU-R BT1361 / IEC 61966-2-4 / SMPTE RP177 Annex B
-    mlt_color_pri_bt470m = 470, ///< also FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
+    mlt_color_pri_bt709 = 1,  ///< also ITU-R BT1361 / IEC 61966-2-4 / SMPTE RP177 Annex B
+    mlt_color_pri_bt470m = 4, ///< also FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
     mlt_color_pri_bt470bg
-    = 601625, ///< also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM
-    mlt_color_pri_smpte170m
-    = 601525,                    ///< also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
+    = 5, ///< also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM
+    mlt_color_pri_smpte170m = 6, ///< also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
     mlt_color_pri_film = 8,      ///< colour filters using Illuminant C
-    mlt_color_pri_bt2020 = 2020, ///< ITU-R BT2020
+    mlt_color_pri_bt2020 = 9,    ///< ITU-R BT2020
     mlt_color_pri_smpte428 = 10, ///< SMPTE ST 428-1 (CIE 1931 XYZ)
     mlt_color_pri_smpte431 = 11, ///< SMPTE ST 431-2 (2011) / DCI P3
     mlt_color_pri_smpte432 = 12, ///< SMPTE ST 432-1 (2010) / P3 D65 / Display P3

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -97,19 +97,21 @@ typedef enum {
 /** Colorspace definitions */
 
 typedef enum {
-    mlt_colorspace_rgb = 0,   ///< order of coefficients is actually GBR, also IEC 61966-2-1 (sRGB)
-    mlt_colorspace_bt709 = 1, ///< also ITU-R BT1361 / IEC 61966-2-4 xvYCC709 / SMPTE RP177 Annex B
+    mlt_colorspace_rgb = 0, ///< order of coefficients is actually GBR, also IEC 61966-2-1 (sRGB)
+    mlt_colorspace_bt709 = 709, ///< also ITU-R BT1361 / IEC 61966-2-4 xvYCC709 / SMPTE RP177 Annex B
     mlt_colorspace_unspecified = 2,
     mlt_colorspace_reserved = 3,
     mlt_colorspace_fcc = 4, ///< FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
     mlt_colorspace_bt470bg
-    = 5, ///< also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM / IEC 61966-2-4 xvYCC601
-    mlt_colorspace_smpte170m = 6, ///< also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
-    mlt_colorspace_smpte240m = 7, ///< functionally identical to above
-    mlt_colorspace_ycgco = 8,     ///< Used by Dirac / VC-2 and H.264 FRext, see ITU-T SG16
-    mlt_colorspace_bt2020_ncl = 9, ///< ITU-R BT2020 non-constant luminance system
-    mlt_colorspace_bt2020_cl = 10, ///< ITU-R BT2020 constant luminance system
-    mlt_colorspace_smpte2085 = 11, ///< SMPTE 2085, Y'D'zD'x
+    = 470, ///< also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM / IEC 61966-2-4 xvYCC601
+    mlt_colorspace_smpte170m = 170, ///< also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
+    mlt_colorspace_smpte240m = 240,   ///< functionally identical to above
+    mlt_colorspace_ycgco = 8,         ///< Used by Dirac / VC-2 and H.264 FRext, see ITU-T SG16
+    mlt_colorspace_bt2020_ncl = 2020, ///< ITU-R BT2020 non-constant luminance system
+    mlt_colorspace_bt2020_cl = 2021,  ///< ITU-R BT2020 constant luminance system
+    mlt_colorspace_smpte2085 = 11,    ///< SMPTE 2085, Y'D'zD'x
+    mlt_colorspace_bt601 = 601,       ///< BT.470 (625/PAL) or SMPTE170M (525/NTSC)
+    mlt_colorspace_invalid
 } mlt_colorspace;
 
 typedef enum {

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -139,6 +139,22 @@ typedef enum {
 } mlt_color_trc;
 
 typedef enum {
+    mlt_color_pri_none = 0,
+    mlt_color_pri_bt709 = 709,  ///< also ITU-R BT1361 / IEC 61966-2-4 / SMPTE RP177 Annex B
+    mlt_color_pri_bt470m = 470, ///< also FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
+    mlt_color_pri_bt470bg
+    = 601625, ///< also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM
+    mlt_color_pri_smpte170m
+    = 601525,                    ///< also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
+    mlt_color_pri_film = 8,      ///< colour filters using Illuminant C
+    mlt_color_pri_bt2020 = 2020, ///< ITU-R BT2020
+    mlt_color_pri_smpte428 = 10, ///< SMPTE ST 428-1 (CIE 1931 XYZ)
+    mlt_color_pri_smpte431 = 11, ///< SMPTE ST 431-2 (2011) / DCI P3
+    mlt_color_pri_smpte432 = 12, ///< SMPTE ST 432-1 (2010) / P3 D65 / Display P3
+    mlt_color_pri_invalid
+} mlt_color_primaries;
+
+typedef enum {
     mlt_deinterlacer_none,
     mlt_deinterlacer_onefield,
     mlt_deinterlacer_linearblend,

--- a/src/framework/mlt_types.h
+++ b/src/framework/mlt_types.h
@@ -113,6 +113,30 @@ typedef enum {
 } mlt_colorspace;
 
 typedef enum {
+    mlt_color_trc_none = 0,
+    mlt_color_trc_bt709 = 1, ///< also ITU-R BT1361
+    mlt_color_trc_unspecified = 2,
+    mlt_color_trc_reserved = 3,
+    mlt_color_trc_gamma22 = 4, ///< also ITU-R BT470M / ITU-R BT1700 625 PAL & SECAM
+    mlt_color_trc_gamma28 = 5, ///< also ITU-R BT470BG
+    mlt_color_trc_smpte170m
+    = 6, ///< also ITU-R BT601-6 525 or 625 / ITU-R BT1358 525 or 625 / ITU-R BT1700 NTSC
+    mlt_color_trc_smpte240m = 7,
+    mlt_color_trc_linear = 8,    ///< "Linear transfer characteristics"
+    mlt_color_trc_log = 9,       ///< "Logarithmic transfer characteristic (100:1 range)"
+    mlt_color_trc_log_sqrt = 10, ///< "Logarithmic transfer characteristic (100 * Sqrt(10) : 1 range)"
+    mlt_color_trc_iec61966_2_4 = 11, ///< IEC 61966-2-4
+    mlt_color_trc_bt1361_ecg = 12,   ///< ITU-R BT1361 Extended Colour Gamut
+    mlt_color_trc_iec61966_2_1 = 13, ///< IEC 61966-2-1 (sRGB or sYCC)
+    mlt_color_trc_bt2020_10 = 14,    ///< ITU-R BT2020 for 10-bit system
+    mlt_color_trc_bt2020_12 = 15,    ///< ITU-R BT2020 for 12-bit system
+    mlt_color_trc_smpte2084 = 16,    ///< SMPTE ST 2084 for 10-, 12-, 14- and 16-bit systems
+    mlt_color_trc_smpte428 = 17,     ///< SMPTE ST 428-1
+    mlt_color_trc_arib_std_b67 = 18, ///< ARIB STD-B67, known as "Hybrid log-gamma"
+    mlt_color_trc_invalid
+} mlt_color_trc;
+
+typedef enum {
     mlt_deinterlacer_none,
     mlt_deinterlacer_onefield,
     mlt_deinterlacer_linearblend,

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -520,6 +520,96 @@ mlt_colorspace av_to_mlt_colorspace(int colorspace, int width, int height)
     return mlt_colorspace_bt601;
 }
 
+int mlt_to_av_color_primaries(mlt_color_primaries primaries)
+{
+    switch (primaries) {
+    case mlt_color_pri_none:
+        return AVCOL_PRI_UNSPECIFIED;
+    case mlt_color_pri_bt709:
+        return AVCOL_PRI_BT709;
+    case mlt_color_pri_bt470m:
+        return AVCOL_PRI_BT470M;
+    case mlt_color_pri_bt470bg:
+        return AVCOL_PRI_BT470BG;
+    case mlt_color_pri_smpte170m:
+        return AVCOL_PRI_SMPTE170M;
+    case mlt_color_pri_film:
+        return AVCOL_PRI_FILM;
+    case mlt_color_pri_bt2020:
+        return AVCOL_PRI_BT2020;
+    case mlt_color_pri_smpte428:
+        return AVCOL_PRI_SMPTE428;
+    case mlt_color_pri_smpte431:
+        return AVCOL_PRI_SMPTE431;
+    case mlt_color_pri_smpte432:
+        return AVCOL_PRI_SMPTE432;
+    case mlt_color_pri_invalid:
+        return AVCOL_PRI_UNSPECIFIED;
+    }
+    return AVCOL_PRI_UNSPECIFIED;
+}
+
+mlt_color_primaries av_to_mlt_color_primaries(int primaries)
+{
+    switch (primaries) {
+    case AVCOL_PRI_RESERVED0:
+        return mlt_color_pri_none;
+    case AVCOL_PRI_BT709:
+        return mlt_color_pri_bt709;
+    case AVCOL_PRI_UNSPECIFIED:
+        return mlt_color_pri_none;
+    case AVCOL_PRI_RESERVED:
+        return mlt_color_pri_none;
+    case AVCOL_PRI_BT470M:
+        return mlt_color_pri_bt470m;
+    case AVCOL_PRI_BT470BG:
+        return mlt_color_pri_bt470bg;
+    case AVCOL_PRI_SMPTE170M:
+        return mlt_color_pri_smpte170m;
+    case AVCOL_PRI_SMPTE240M:
+        return mlt_color_pri_smpte170m;
+    case AVCOL_PRI_FILM:
+        return mlt_color_pri_film;
+    case AVCOL_PRI_BT2020:
+        return mlt_color_pri_bt2020;
+    case AVCOL_PRI_SMPTE428:
+        return mlt_color_pri_smpte428;
+    case AVCOL_PRI_SMPTE431:
+        return mlt_color_pri_smpte431;
+    case AVCOL_PRI_SMPTE432:
+        return mlt_color_pri_smpte432;
+    }
+    return mlt_color_pri_none;
+}
+
+mlt_color_primaries mlt_color_primaries_from_colorspace(mlt_colorspace colorspace, int height)
+{
+    switch (colorspace) {
+    case mlt_colorspace_rgb: // sRGB
+    case mlt_colorspace_bt709:
+        return mlt_color_pri_bt709;
+    case mlt_colorspace_bt470bg:
+        return mlt_color_pri_bt470bg;
+    case mlt_colorspace_smpte240m:
+        return mlt_color_pri_smpte170m;
+    case mlt_colorspace_bt601:
+        return height == 576 ? mlt_color_pri_bt470bg : mlt_color_pri_smpte170m;
+    case mlt_colorspace_smpte170m:
+        return mlt_color_pri_smpte170m;
+    case mlt_colorspace_bt2020_ncl:
+        return mlt_color_pri_bt2020;
+    case mlt_colorspace_unspecified:
+    case mlt_colorspace_reserved:
+    case mlt_colorspace_fcc:
+    case mlt_colorspace_ycgco:
+    case mlt_colorspace_bt2020_cl:
+    case mlt_colorspace_smpte2085:
+    case mlt_colorspace_invalid:
+        break;
+    }
+    return mlt_color_pri_none;
+}
+
 void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe)
 {
     mlt_properties frame_properties = MLT_FRAME_PROPERTIES(mltframe);
@@ -541,7 +631,9 @@ void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe)
     avframe->interlaced_frame = !mlt_properties_get_int(frame_properties, "progressive");
     avframe->top_field_first = mlt_properties_get_int(frame_properties, "top_field_first");
 #endif
-    avframe->color_primaries = mlt_properties_get_int(frame_properties, "color_primaries");
+    const char *primaries_str = mlt_properties_get(frame_properties, "color_primaries");
+    mlt_color_primaries primaries = mlt_image_color_pri_id(primaries_str);
+    avframe->color_primaries = mlt_to_av_color_primaries(primaries);
     const char *color_trc_str = mlt_properties_get(frame_properties, "color_trc");
     avframe->color_trc = mlt_to_av_color_trc(mlt_image_color_trc_id(color_trc_str));
     avframe->color_range = mlt_properties_get_int(frame_properties, "full_range")

--- a/src/modules/avformat/common.c
+++ b/src/modules/avformat/common.c
@@ -362,6 +362,98 @@ mlt_image_format mlt_get_supported_image_format(mlt_image_format format)
     return mlt_image_rgba;
 }
 
+int mlt_to_av_color_trc(mlt_color_trc trc)
+{
+    switch (trc) {
+    case mlt_color_trc_none:
+        return AVCOL_TRC_RESERVED0;
+    case mlt_color_trc_bt709:
+        return AVCOL_TRC_BT709;
+    case mlt_color_trc_unspecified:
+        return AVCOL_TRC_UNSPECIFIED;
+    case mlt_color_trc_reserved:
+        return AVCOL_TRC_RESERVED;
+    case mlt_color_trc_gamma22:
+        return AVCOL_TRC_GAMMA22;
+    case mlt_color_trc_gamma28:
+        return AVCOL_TRC_GAMMA28;
+    case mlt_color_trc_smpte170m:
+        return AVCOL_TRC_SMPTE170M;
+    case mlt_color_trc_smpte240m:
+        return AVCOL_TRC_SMPTE240M;
+    case mlt_color_trc_linear:
+        return AVCOL_TRC_LINEAR;
+    case mlt_color_trc_log:
+        return AVCOL_TRC_LOG;
+    case mlt_color_trc_log_sqrt:
+        return AVCOL_TRC_LOG_SQRT;
+    case mlt_color_trc_iec61966_2_4:
+        return AVCOL_TRC_IEC61966_2_4;
+    case mlt_color_trc_bt1361_ecg:
+        return AVCOL_TRC_BT1361_ECG;
+    case mlt_color_trc_iec61966_2_1:
+        return AVCOL_TRC_IEC61966_2_1;
+    case mlt_color_trc_bt2020_10:
+        return AVCOL_TRC_BT2020_10;
+    case mlt_color_trc_bt2020_12:
+        return AVCOL_TRC_BT2020_12;
+    case mlt_color_trc_smpte2084:
+        return AVCOL_TRC_SMPTE2084;
+    case mlt_color_trc_smpte428:
+        return AVCOL_TRC_SMPTE428;
+    case mlt_color_trc_arib_std_b67:
+        return AVCOL_TRC_ARIB_STD_B67;
+    case mlt_color_trc_invalid:
+        return AVCOL_TRC_UNSPECIFIED;
+    }
+    return AVCOL_TRC_UNSPECIFIED;
+}
+
+mlt_color_trc av_to_mlt_color_trc(int trc)
+{
+    switch (trc) {
+    case AVCOL_TRC_RESERVED0:
+        return mlt_color_trc_none;
+    case AVCOL_TRC_BT709:
+        return mlt_color_trc_bt709;
+    case AVCOL_TRC_UNSPECIFIED:
+        return mlt_color_trc_unspecified;
+    case AVCOL_TRC_RESERVED:
+        return mlt_color_trc_reserved;
+    case AVCOL_TRC_GAMMA22:
+        return mlt_color_trc_gamma22;
+    case AVCOL_TRC_GAMMA28:
+        return mlt_color_trc_gamma28;
+    case AVCOL_TRC_SMPTE170M:
+        return mlt_color_trc_smpte170m;
+    case AVCOL_TRC_SMPTE240M:
+        return mlt_color_trc_smpte240m;
+    case AVCOL_TRC_LINEAR:
+        return mlt_color_trc_linear;
+    case AVCOL_TRC_LOG:
+        return mlt_color_trc_log;
+    case AVCOL_TRC_LOG_SQRT:
+        return mlt_color_trc_log_sqrt;
+    case AVCOL_TRC_IEC61966_2_4:
+        return mlt_color_trc_iec61966_2_4;
+    case AVCOL_TRC_BT1361_ECG:
+        return mlt_color_trc_bt1361_ecg;
+    case AVCOL_TRC_IEC61966_2_1:
+        return mlt_color_trc_iec61966_2_1;
+    case AVCOL_TRC_BT2020_10:
+        return mlt_color_trc_bt2020_10;
+    case AVCOL_TRC_BT2020_12:
+        return mlt_color_trc_bt2020_12;
+    case AVCOL_TRC_SMPTE2084:
+        return mlt_color_trc_smpte2084;
+    case AVCOL_TRC_SMPTE428:
+        return mlt_color_trc_smpte428;
+    case AVCOL_TRC_ARIB_STD_B67:
+        return mlt_color_trc_arib_std_b67;
+    }
+    return mlt_color_trc_unspecified;
+}
+
 void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe)
 {
     mlt_properties frame_properties = MLT_FRAME_PROPERTIES(mltframe);
@@ -384,7 +476,8 @@ void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe)
     avframe->top_field_first = mlt_properties_get_int(frame_properties, "top_field_first");
 #endif
     avframe->color_primaries = mlt_properties_get_int(frame_properties, "color_primaries");
-    avframe->color_trc = mlt_properties_get_int(frame_properties, "color_trc");
+    const char *color_trc_str = mlt_properties_get(frame_properties, "color_trc");
+    avframe->color_trc = mlt_to_av_color_trc(mlt_image_color_trc_id(color_trc_str));
     avframe->color_range = mlt_properties_get_int(frame_properties, "full_range")
                                ? AVCOL_RANGE_JPEG
                                : AVCOL_RANGE_MPEG;

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -44,6 +44,8 @@ int mlt_get_sws_flags(
     int srcwidth, int srcheight, int srcformat, int dstwidth, int dstheight, int dstformat);
 int mlt_to_av_image_format(mlt_image_format format);
 mlt_image_format mlt_get_supported_image_format(mlt_image_format format);
+int mlt_to_av_color_trc(mlt_color_trc trc);
+mlt_color_trc av_to_mlt_color_trc(int trc);
 void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe);
 void avframe_to_mlt_image(AVFrame *avframe, mlt_image image);
 

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -48,6 +48,9 @@ int mlt_to_av_color_trc(mlt_color_trc trc);
 mlt_color_trc av_to_mlt_color_trc(int trc);
 int mlt_to_av_colorspace(mlt_colorspace colorspace, int height);
 mlt_colorspace av_to_mlt_colorspace(int colorspace, int width, int height);
+int mlt_to_av_color_primaries(mlt_color_primaries primaries);
+mlt_color_primaries av_to_mlt_color_primaries(int primaries);
+mlt_color_primaries mlt_color_primaries_from_colorspace(mlt_colorspace colorspace, int height);
 void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe);
 void avframe_to_mlt_image(AVFrame *avframe, mlt_image image);
 

--- a/src/modules/avformat/common.h
+++ b/src/modules/avformat/common.h
@@ -36,8 +36,8 @@ mlt_channel_layout av_channel_layout_to_mlt(int64_t layout);
 #endif
 mlt_channel_layout mlt_get_channel_layout_or_default(const char *name, int channels);
 int mlt_set_luma_transfer(struct SwsContext *context,
-                          int src_colorspace,
-                          int dst_colorspace,
+                          mlt_colorspace src_colorspace,
+                          mlt_colorspace dst_colorspace,
                           int src_full_range,
                           int dst_full_range);
 int mlt_get_sws_flags(
@@ -46,6 +46,8 @@ int mlt_to_av_image_format(mlt_image_format format);
 mlt_image_format mlt_get_supported_image_format(mlt_image_format format);
 int mlt_to_av_color_trc(mlt_color_trc trc);
 mlt_color_trc av_to_mlt_color_trc(int trc);
+int mlt_to_av_colorspace(mlt_colorspace colorspace, int height);
+mlt_colorspace av_to_mlt_colorspace(int colorspace, int width, int height);
 void mlt_image_to_avframe(mlt_image image, mlt_frame mltframe, AVFrame *avframe);
 void avframe_to_mlt_image(AVFrame *avframe, mlt_image image);
 

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -358,39 +358,10 @@ static void color_primaries_from_colorspace(mlt_properties properties)
     // Default color_primaries from MLT colorspace.
     const char *colorspace_str = mlt_properties_get(properties, "colorspace");
     mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
-    switch (colorspace) {
-    case mlt_colorspace_rgb: // sRGB
-    case mlt_colorspace_bt709:
-        mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_BT709);
-        break;
-    case mlt_colorspace_bt470bg:
-        mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_BT470M);
-        break;
-    case mlt_colorspace_smpte240m:
-        mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_SMPTE240M);
-        break;
-    case mlt_colorspace_bt601:
-        mlt_properties_set_int(properties,
-                               "color_primaries",
-                               mlt_properties_get_int(properties, "height") == 576
-                                   ? AVCOL_PRI_BT470BG
-                                   : AVCOL_PRI_SMPTE170M);
-        break;
-    case mlt_colorspace_smpte170m:
-        mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_SMPTE170M);
-        break;
-    case mlt_colorspace_bt2020_ncl:
-        mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_BT2020);
-        break;
-    case mlt_colorspace_unspecified:
-    case mlt_colorspace_reserved:
-    case mlt_colorspace_fcc:
-    case mlt_colorspace_ycgco:
-    case mlt_colorspace_bt2020_cl:
-    case mlt_colorspace_smpte2085:
-    case mlt_colorspace_invalid:
-        break;
-    }
+    int height = mlt_properties_get_int(properties, "height");
+    mlt_color_primaries primaries = mlt_color_primaries_from_colorspace(colorspace, height);
+    if (primaries != mlt_color_pri_none)
+        mlt_properties_set_int(properties, "color_primaries", primaries);
 }
 
 static void property_changed(mlt_properties owner, mlt_consumer self, mlt_event_data event_data)

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -328,23 +328,23 @@ static void color_trc_from_colorspace(mlt_properties properties)
     // Default color transfer characteristic from MLT colorspace.
     switch (mlt_properties_get_int(properties, "colorspace")) {
     case 709:
-        mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_BT709);
+        mlt_properties_set_int(properties, "color_trc", mlt_color_trc_bt709);
         break;
     case 470:
-        mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_GAMMA28);
+        mlt_properties_set_int(properties, "color_trc", mlt_color_trc_gamma28);
         break;
     case 240:
-        mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_SMPTE240M);
+        mlt_properties_set_int(properties, "color_trc", mlt_color_trc_smpte240m);
         break;
     case 0: // sRGB
-        mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_IEC61966_2_1);
+        mlt_properties_set_int(properties, "color_trc", mlt_color_trc_iec61966_2_1);
         break;
     case 601:
     case 170:
-        mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_SMPTE170M);
+        mlt_properties_set_int(properties, "color_trc", mlt_color_trc_smpte170m);
         break;
     case 2020:
-        mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_BT2020_10);
+        mlt_properties_set_int(properties, "color_trc", mlt_color_trc_bt2020_10);
         break;
     default:
         break;

--- a/src/modules/avformat/consumer_avformat.c
+++ b/src/modules/avformat/consumer_avformat.c
@@ -326,24 +326,26 @@ static void recompute_aspect_ratio(mlt_properties properties)
 static void color_trc_from_colorspace(mlt_properties properties)
 {
     // Default color transfer characteristic from MLT colorspace.
-    switch (mlt_properties_get_int(properties, "colorspace")) {
-    case 709:
+    const char *colorspace_str = mlt_properties_get(properties, "colorspace");
+    mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
+    switch (colorspace) {
+    case mlt_colorspace_bt709:
         mlt_properties_set_int(properties, "color_trc", mlt_color_trc_bt709);
         break;
-    case 470:
+    case mlt_colorspace_bt470bg:
         mlt_properties_set_int(properties, "color_trc", mlt_color_trc_gamma28);
         break;
-    case 240:
+    case mlt_colorspace_smpte240m:
         mlt_properties_set_int(properties, "color_trc", mlt_color_trc_smpte240m);
         break;
-    case 0: // sRGB
+    case mlt_colorspace_rgb: // sRGB
         mlt_properties_set_int(properties, "color_trc", mlt_color_trc_iec61966_2_1);
         break;
-    case 601:
-    case 170:
+    case mlt_colorspace_bt601:
+    case mlt_colorspace_smpte170m:
         mlt_properties_set_int(properties, "color_trc", mlt_color_trc_smpte170m);
         break;
-    case 2020:
+    case mlt_colorspace_bt2020_ncl:
         mlt_properties_set_int(properties, "color_trc", mlt_color_trc_bt2020_10);
         break;
     default:
@@ -354,61 +356,39 @@ static void color_trc_from_colorspace(mlt_properties properties)
 static void color_primaries_from_colorspace(mlt_properties properties)
 {
     // Default color_primaries from MLT colorspace.
-    switch (mlt_properties_get_int(properties, "colorspace")) {
-    case 0: // sRGB
-    case 709:
+    const char *colorspace_str = mlt_properties_get(properties, "colorspace");
+    mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
+    switch (colorspace) {
+    case mlt_colorspace_rgb: // sRGB
+    case mlt_colorspace_bt709:
         mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_BT709);
         break;
-    case 470:
+    case mlt_colorspace_bt470bg:
         mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_BT470M);
         break;
-    case 240:
+    case mlt_colorspace_smpte240m:
         mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_SMPTE240M);
         break;
-    case 601:
+    case mlt_colorspace_bt601:
         mlt_properties_set_int(properties,
                                "color_primaries",
                                mlt_properties_get_int(properties, "height") == 576
                                    ? AVCOL_PRI_BT470BG
                                    : AVCOL_PRI_SMPTE170M);
         break;
-    case 170:
+    case mlt_colorspace_smpte170m:
         mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_SMPTE170M);
         break;
-    case 2020:
+    case mlt_colorspace_bt2020_ncl:
         mlt_properties_set_int(properties, "color_primaries", AVCOL_PRI_BT2020);
         break;
-    default:
-        break;
-    }
-}
-
-static void av_colorspace_from_colorspace(mlt_properties properties, int colorspace)
-{
-    // Convert MLT colorspace to FFmpeg colorspace.
-    switch (colorspace) {
-    case 0: // sRGB
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_RGB);
-        break;
-    case 601:
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_BT470BG);
-        break;
-    case 709:
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_BT709);
-        break;
-    case 240:
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_SMPTE240M);
-        break;
-    case 170:
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_SMPTE170M);
-        break;
-    case 2020:
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_BT2020_NCL);
-        break;
-    case 2021:
-        mlt_properties_set_int(properties, "colorspace", AVCOL_SPC_BT2020_CL);
-        break;
-    default:
+    case mlt_colorspace_unspecified:
+    case mlt_colorspace_reserved:
+    case mlt_colorspace_fcc:
+    case mlt_colorspace_ycgco:
+    case mlt_colorspace_bt2020_cl:
+    case mlt_colorspace_smpte2085:
+    case mlt_colorspace_invalid:
         break;
     }
 }
@@ -959,9 +939,12 @@ static AVStream *add_video_stream(mlt_consumer consumer,
             apply_properties(c, p, AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM);
             mlt_properties_close(p);
         }
-        int colorspace = mlt_properties_get_int(properties, "colorspace");
-        mlt_properties_set(properties, "colorspace", NULL);
-        av_colorspace_from_colorspace(properties, colorspace);
+        // Temporarily convert the mlt colorspace to av colorspace before applying the properties
+        const char *colorspace_str = mlt_properties_get(properties, "colorspace");
+        mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
+        mlt_properties_clear(properties, "colorspace");
+        int av_colorspace = mlt_to_av_colorspace(colorspace,
+                                                 mlt_properties_get_int(properties, "height"));
         apply_properties(c, properties, AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM);
         mlt_properties_set_int(properties, "colorspace", colorspace);
 
@@ -994,29 +977,7 @@ static AVStream *add_video_stream(mlt_consumer consumer,
             }
         }
 
-        switch (colorspace) {
-        case 170:
-            c->colorspace = AVCOL_SPC_SMPTE170M;
-            break;
-        case 240:
-            c->colorspace = AVCOL_SPC_SMPTE240M;
-            break;
-        case 470:
-            c->colorspace = AVCOL_SPC_BT470BG;
-            break;
-        case 601:
-            c->colorspace = (576 % c->height) ? AVCOL_SPC_SMPTE170M : AVCOL_SPC_BT470BG;
-            break;
-        case 709:
-            c->colorspace = AVCOL_SPC_BT709;
-            break;
-        case 2020:
-            c->colorspace = AVCOL_SPC_BT2020_NCL;
-            break;
-        case 2021:
-            c->colorspace = AVCOL_SPC_BT2020_CL;
-            break;
-        }
+        c->colorspace = av_colorspace;
 
         if (mlt_properties_get(properties, "aspect")) {
             // "-aspect" on ffmpeg command line is display aspect ratio
@@ -1715,7 +1676,8 @@ static int encode_video(encode_ctx_t *enc_ctx,
 {
     int ret = 0;
     mlt_properties properties = enc_ctx->properties;
-    int dst_colorspace = mlt_properties_get_int(properties, "colorspace");
+    const char *dst_colorspace_str = mlt_properties_get(properties, "colorspace");
+    mlt_colorspace dst_colorspace = mlt_image_colorspace_id(dst_colorspace_str);
     const char *color_range = mlt_properties_get(properties, "color_range");
     int dst_full_range = mlt_image_full_range(color_range);
 
@@ -1772,7 +1734,8 @@ static int encode_video(encode_ctx_t *enc_ctx,
                                                     NULL,
                                                     NULL,
                                                     NULL);
-        int src_colorspace = mlt_properties_get_int(frame_properties, "colorspace");
+        const char *src_colorspace_str = mlt_properties_get(frame_properties, "colorspace");
+        mlt_colorspace src_colorspace = mlt_image_colorspace_id(src_colorspace_str);
         int src_full_range = mlt_properties_get_int(frame_properties, "full_range");
         mlt_set_luma_transfer(context,
                               src_colorspace,

--- a/src/modules/avformat/filter_avcolour_space.c
+++ b/src/modules/avformat/filter_avcolour_space.c
@@ -93,8 +93,8 @@ static int av_convert_image(uint8_t *out,
                             int out_height,
                             int in_width,
                             int in_height,
-                            int src_colorspace,
-                            int dst_colorspace,
+                            mlt_colorspace src_colorspace,
+                            mlt_colorspace dst_colorspace,
                             int src_full_range,
                             int dst_full_range)
 {
@@ -118,7 +118,7 @@ static int av_convert_image(uint8_t *out,
     if (context) {
         // libswscale wants the RGB colorspace to be SWS_CS_DEFAULT, which is = SWS_CS_ITU601.
         if (out_fmt == AV_PIX_FMT_RGB24 || out_fmt == AV_PIX_FMT_RGBA)
-            dst_colorspace = 601;
+            dst_colorspace = mlt_colorspace_bt601;
         error = mlt_set_luma_transfer(context,
                                       src_colorspace,
                                       dst_colorspace,
@@ -155,8 +155,9 @@ static int convert_image(mlt_frame frame,
     if (*format != output_format || out_width) {
         mlt_profile profile = mlt_service_profile(
             MLT_PRODUCER_SERVICE(mlt_frame_get_original_producer(frame)));
-        int profile_colorspace = profile ? profile->colorspace : 601;
-        int colorspace = mlt_properties_get_int(properties, "colorspace");
+        mlt_colorspace profile_colorspace = profile ? profile->colorspace : mlt_colorspace_bt601;
+        const char *colorspace_str = mlt_properties_get(properties, "colorspace");
+        mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
         int width = mlt_properties_get_int(properties, "width");
         int height = mlt_properties_get_int(properties, "height");
         int src_full_range = mlt_properties_get_int(properties, "full_range");

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -825,8 +825,9 @@ static int filter_get_image(mlt_frame frame,
         pdata->avinframe->top_field_first = mlt_properties_get_int(frame_properties,
                                                                    "top_field_first");
 #endif
-        pdata->avinframe->color_primaries = mlt_properties_get_int(frame_properties,
-                                                                   "color_primaries");
+        const char *primaries_str = mlt_properties_get(frame_properties, "color_primaries");
+        mlt_color_primaries primaries = mlt_image_color_pri_id(primaries_str);
+        pdata->avinframe->color_primaries = mlt_to_av_color_primaries(primaries);
         const char *color_trc_str = mlt_properties_get(frame_properties, "color_trc");
         pdata->avinframe->color_trc = mlt_to_av_color_trc(mlt_image_color_trc_id(color_trc_str));
         // Setting full_range here causes full range input to always be down-converted to limited

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -827,7 +827,8 @@ static int filter_get_image(mlt_frame frame,
 #endif
         pdata->avinframe->color_primaries = mlt_properties_get_int(frame_properties,
                                                                    "color_primaries");
-        pdata->avinframe->color_trc = mlt_properties_get_int(frame_properties, "color_trc");
+        const char *color_trc_str = mlt_properties_get(frame_properties, "color_trc");
+        pdata->avinframe->color_trc = mlt_to_av_color_trc(mlt_image_color_trc_id(color_trc_str));
         // Setting full_range here causes full range input to always be down-converted to limited
         // range when operating in YUV, regardless of the consumer.color_range -- for each avfilter!
         // pdata->avinframe->color_range = mlt_properties_get_int(frame_properties, "full_range")

--- a/src/modules/avformat/filter_avfilter.c
+++ b/src/modules/avformat/filter_avfilter.c
@@ -838,23 +838,10 @@ static int filter_get_image(mlt_frame frame,
         if (is_rgb(*format)) {
             pdata->avinframe->colorspace = AVCOL_SPC_RGB;
         } else {
-            switch (mlt_properties_get_int(frame_properties, "colorspace")) {
-            case 240:
-                pdata->avinframe->colorspace = AVCOL_SPC_SMPTE240M;
-                break;
-            case 601:
-                pdata->avinframe->colorspace = AVCOL_SPC_BT470BG;
-                break;
-            case 709:
-                pdata->avinframe->colorspace = AVCOL_SPC_BT709;
-                break;
-            case 2020:
-                pdata->avinframe->colorspace = AVCOL_SPC_BT2020_NCL;
-                break;
-            case 2021:
-                pdata->avinframe->colorspace = AVCOL_SPC_BT2020_CL;
-                break;
-            }
+            const char *colorspace_str = mlt_properties_get(frame_properties, "colorspace");
+            mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
+            pdata->avinframe->colorspace = mlt_to_av_colorspace(colorspace,
+                                                                pdata->avinframe->height);
         }
 
         ret = av_frame_get_buffer(pdata->avinframe, 1);

--- a/src/modules/avformat/filter_swscale.c
+++ b/src/modules/avformat/filter_swscale.c
@@ -148,8 +148,9 @@ static int filter_scale(mlt_frame frame,
 
         mlt_profile profile = mlt_service_profile(
             MLT_PRODUCER_SERVICE(mlt_frame_get_original_producer(frame)));
-        int dst_colorspace = profile ? profile->colorspace : 601;
-        int src_colorspace = mlt_properties_get_int(properties, "colorspace");
+        mlt_colorspace dst_colorspace = profile ? profile->colorspace : mlt_colorspace_bt601;
+        char *src_colorspace_str = mlt_properties_get(properties, "colorspace");
+        mlt_colorspace src_colorspace = mlt_image_colorspace_id(src_colorspace_str);
         int src_full_range = mlt_properties_get_int(properties, "full_range");
         const char *dst_color_range = mlt_properties_get(properties, "consumer.color_range");
         int dst_full_range = mlt_image_full_range(dst_color_range);

--- a/src/modules/avformat/link_avfilter.c
+++ b/src/modules/avformat/link_avfilter.c
@@ -936,24 +936,9 @@ static int link_get_image(mlt_frame frame,
         pdata->avinframe->color_range = mlt_properties_get_int(frame_properties, "full_range")
                                             ? AVCOL_RANGE_JPEG
                                             : AVCOL_RANGE_MPEG;
-
-        switch (mlt_properties_get_int(frame_properties, "colorspace")) {
-        case 240:
-            pdata->avinframe->colorspace = AVCOL_SPC_SMPTE240M;
-            break;
-        case 601:
-            pdata->avinframe->colorspace = AVCOL_SPC_BT470BG;
-            break;
-        case 709:
-            pdata->avinframe->colorspace = AVCOL_SPC_BT709;
-            break;
-        case 2020:
-            pdata->avinframe->colorspace = AVCOL_SPC_BT2020_NCL;
-            break;
-        case 2021:
-            pdata->avinframe->colorspace = AVCOL_SPC_BT2020_CL;
-            break;
-        }
+        const char *colorspace_str = mlt_properties_get(frame_properties, "colorspace");
+        mlt_colorspace colorspace = mlt_image_colorspace_id(colorspace_str);
+        pdata->avinframe->colorspace = mlt_to_av_colorspace(colorspace, pdata->avinframe->height);
 
         ret = av_frame_get_buffer(pdata->avinframe, 1);
         if (ret < 0) {

--- a/src/modules/avformat/link_avfilter.c
+++ b/src/modules/avformat/link_avfilter.c
@@ -929,8 +929,9 @@ static int link_get_image(mlt_frame frame,
         pdata->avinframe->top_field_first = mlt_properties_get_int(frame_properties,
                                                                    "top_field_first");
 #endif
-        pdata->avinframe->color_primaries = mlt_properties_get_int(frame_properties,
-                                                                   "color_primaries");
+        const char *primaries_str = mlt_properties_get(frame_properties, "color_primaries");
+        mlt_color_primaries primaries = mlt_image_color_pri_id(primaries_str);
+        pdata->avinframe->color_primaries = mlt_to_av_color_primaries(primaries);
         const char *color_trc_str = mlt_properties_get(frame_properties, "color_trc");
         pdata->avinframe->color_trc = mlt_to_av_color_trc(mlt_image_color_trc_id(color_trc_str));
         pdata->avinframe->color_range = mlt_properties_get_int(frame_properties, "full_range")

--- a/src/modules/avformat/link_avfilter.c
+++ b/src/modules/avformat/link_avfilter.c
@@ -931,7 +931,8 @@ static int link_get_image(mlt_frame frame,
 #endif
         pdata->avinframe->color_primaries = mlt_properties_get_int(frame_properties,
                                                                    "color_primaries");
-        pdata->avinframe->color_trc = mlt_properties_get_int(frame_properties, "color_trc");
+        const char *color_trc_str = mlt_properties_get(frame_properties, "color_trc");
+        pdata->avinframe->color_trc = mlt_to_av_color_trc(mlt_image_color_trc_id(color_trc_str));
         pdata->avinframe->color_range = mlt_properties_get_int(frame_properties, "full_range")
                                             ? AVCOL_RANGE_JPEG
                                             : AVCOL_RANGE_MPEG;

--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -109,7 +109,8 @@ struct producer_avformat_s
     unsigned int invalid_dts_counter;
     mlt_cache image_cache;
     mlt_cache audio_cache;
-    int yuv_colorspace, color_primaries;
+    mlt_colorspace yuv_colorspace;
+    int color_primaries;
     mlt_color_trc color_trc;
     int full_range;
     pthread_mutex_t video_mutex;
@@ -572,29 +573,10 @@ static mlt_properties find_default_streams(producer_avformat self)
             snprintf(key, sizeof(key), "meta.media.%u.codec.sample_aspect_ratio", i);
             mlt_properties_set_double(meta_media, key, av_q2d(codec_params->sample_aspect_ratio));
             snprintf(key, sizeof(key), "meta.media.%u.codec.colorspace", i);
-            switch (codec_params->color_space) {
-            case AVCOL_SPC_SMPTE240M:
-                mlt_properties_set_int(meta_media, key, 240);
-                break;
-            case AVCOL_SPC_BT470BG:
-            case AVCOL_SPC_SMPTE170M:
-                mlt_properties_set_int(meta_media, key, 601);
-                break;
-            case AVCOL_SPC_BT709:
-                mlt_properties_set_int(meta_media, key, 709);
-                break;
-            case AVCOL_SPC_UNSPECIFIED:
-            case AVCOL_SPC_RESERVED:
-                // This is a heuristic Charles Poynton suggests in "Digital Video and HDTV"
-                mlt_properties_set_int(meta_media,
-                                       key,
-                                       codec_params->width * codec_params->height > 750000 ? 709
-                                                                                           : 601);
-                break;
-            default:
-                mlt_properties_set_int(meta_media, key, codec_params->color_space);
-                break;
-            }
+            mlt_colorspace colorspace = av_to_mlt_colorspace(codec_params->color_space,
+                                                             codec_params->width,
+                                                             codec_params->height);
+            mlt_properties_set_int(meta_media, key, colorspace);
             if (codec_params->color_trc && codec_params->color_trc != AVCOL_TRC_UNSPECIFIED) {
                 snprintf(key, sizeof(key), "meta.media.%u.codec.color_trc", i);
                 mlt_color_trc trc = av_to_mlt_color_trc(codec_params->color_trc);
@@ -1704,7 +1686,8 @@ struct sliced_pix_fmt_conv_t
     int out_stride[4];
     enum AVPixelFormat src_format, dst_format;
     const AVPixFmtDescriptor *src_desc, *dst_desc;
-    int flags, src_colorspace, dst_colorspace, src_full_range, dst_full_range;
+    int flags, src_full_range, dst_full_range;
+    mlt_colorspace src_colorspace, dst_colorspace;
 };
 
 static int sliced_h_pix_fmt_conv_proc(int id, int idx, int jobs, void *cookie)
@@ -1819,18 +1802,18 @@ static int sliced_h_pix_fmt_conv_proc(int id, int idx, int jobs, void *cookie)
     return 0;
 }
 
-static int convert_image_yuvp(producer_avformat self,
-                              mlt_profile profile,
-                              AVFrame *frame,
-                              uint8_t *buffer,
-                              mlt_image_format format,
-                              int width,
-                              int height,
-                              int src_pix_fmt,
-                              int dst_pix_fmt,
-                              int dst_full_range)
+static mlt_colorspace convert_image_yuvp(producer_avformat self,
+                                         mlt_profile profile,
+                                         AVFrame *frame,
+                                         uint8_t *buffer,
+                                         mlt_image_format format,
+                                         int width,
+                                         int height,
+                                         int src_pix_fmt,
+                                         int dst_pix_fmt,
+                                         int dst_full_range)
 {
-    int result = self->yuv_colorspace;
+    mlt_colorspace result = self->yuv_colorspace;
     int flags = mlt_get_sws_flags(width, height, src_pix_fmt, width, height, dst_pix_fmt);
     struct SwsContext *context = sws_getContext(
         width, height, src_pix_fmt, width, height, dst_pix_fmt, flags, NULL, NULL, NULL);
@@ -1891,7 +1874,11 @@ static void convert_image_rgb(producer_avformat self,
                                                     NULL,
                                                     NULL);
         // libswscale wants the RGB colorspace to be SWS_CS_DEFAULT, which is = SWS_CS_ITU601.
-        mlt_set_luma_transfer(context, self->yuv_colorspace, 601, self->full_range, 1);
+        mlt_set_luma_transfer(context,
+                              self->yuv_colorspace,
+                              mlt_colorspace_bt601,
+                              self->full_range,
+                              1);
         av_image_fill_arrays(out_data, out_stride, buffer, dst_pix_fmt, width, height, IMAGE_ALIGN);
         // Copy the input frame arrays
         for (int i = 0; i < 4; i++) {
@@ -1918,7 +1905,11 @@ static void convert_image_rgb(producer_avformat self,
             width, height, src_pix_fmt, width, height, dst_pix_fmt, flags, NULL, NULL, NULL);
         av_image_fill_arrays(out_data, out_stride, buffer, dst_pix_fmt, width, height, IMAGE_ALIGN);
         // libswscale wants the RGB colorspace to be SWS_CS_DEFAULT, which is = SWS_CS_ITU601.
-        mlt_set_luma_transfer(context, self->yuv_colorspace, 601, self->full_range, 1);
+        mlt_set_luma_transfer(context,
+                              self->yuv_colorspace,
+                              mlt_colorspace_bt601,
+                              self->full_range,
+                              1);
         sws_scale(context,
                   (const uint8_t *const *) frame->data,
                   frame->linesize,
@@ -1943,7 +1934,7 @@ static void convert_image(producer_avformat self,
                           int dst_full_range)
 {
     mlt_profile profile = mlt_service_profile(MLT_PRODUCER_SERVICE(self->parent));
-    int colorspace = self->yuv_colorspace;
+    mlt_colorspace colorspace = self->yuv_colorspace;
 
     mlt_log_timings_begin();
 
@@ -2096,14 +2087,14 @@ static void convert_image(producer_avformat self,
     mlt_log_timings_end(NULL, __FUNCTION__);
 
     switch (colorspace) {
-    case 170:
-    case 240:
+    case mlt_colorspace_smpte170m:
+    case mlt_colorspace_smpte240m:
         mlt_properties_set_int(frame_properties, "color_primaries", 601525);
         break;
-    case 601:
+    case mlt_colorspace_bt601:
         mlt_properties_set_int(frame_properties, "color_primaries", 601625);
         break;
-    case 2020:
+    case mlt_colorspace_bt2020_ncl:
         mlt_properties_set_int(frame_properties, "color_primaries", 2020);
         break;
     default:
@@ -2926,34 +2917,13 @@ static int video_codec_init(producer_avformat self, int index, mlt_properties pr
             self->video_seekable = 0;
 
         // Set the YUV colorspace from override or detect
-        self->yuv_colorspace = mlt_properties_get_int(properties, "force_colorspace");
-        if (!self->yuv_colorspace) {
-            switch (self->video_codec->colorspace) {
-            case AVCOL_SPC_SMPTE240M:
-                self->yuv_colorspace = 240;
-                break;
-            case AVCOL_SPC_BT470BG:
-            case AVCOL_SPC_SMPTE170M:
-                self->yuv_colorspace = 601;
-                break;
-            case AVCOL_SPC_BT709:
-                self->yuv_colorspace = 709;
-                break;
-            case AVCOL_SPC_BT2020_NCL:
-                self->yuv_colorspace = 2020;
-                break;
-            case AVCOL_SPC_BT2020_CL:
-                self->yuv_colorspace = 2021;
-                break;
-            default:
-                // This is a heuristic Charles Poynton suggests in "Digital Video and HDTV"
-                self->yuv_colorspace = self->video_codec->width * self->video_codec->height > 750000
-                                           ? 709
-                                           : 601;
-                break;
-            }
-        }
-        // Let apps get chosen colorspace
+        const char *force_colorspace_str = mlt_properties_get(properties, "force_colorspace");
+        if (force_colorspace_str)
+            self->yuv_colorspace = mlt_image_colorspace_id(force_colorspace_str);
+        if (!force_colorspace_str || self->yuv_colorspace == mlt_colorspace_invalid)
+            self->yuv_colorspace = av_to_mlt_colorspace(self->video_codec->colorspace,
+                                                        self->video_codec->width,
+                                                        self->video_codec->height);
         mlt_properties_set_int(properties, "meta.media.colorspace", self->yuv_colorspace);
 
         // Get the color transfer characteristic (gamma).

--- a/src/modules/core/link_timeremap.c
+++ b/src/modules/core/link_timeremap.c
@@ -113,8 +113,10 @@ static void change_movit_format(mlt_frame frame, mlt_frame src_frame, mlt_image_
         } else {
             // Use a 10-bit output if the end consumer wants it.
             // TODO add a "consumer.format" property to find other criteria for 10-bit
-            const char *trc = mlt_properties_get(MLT_FRAME_PROPERTIES(frame), "consumer.color_trc");
-            *format = (trc && !strcmp("arib-std-b67", trc)) ? mlt_image_yuv444p10 : mlt_image_rgba;
+            const char *trc_str = mlt_properties_get(MLT_FRAME_PROPERTIES(frame),
+                                                     "consumer.color_trc");
+            mlt_color_trc trc = mlt_image_color_trc_id(trc_str);
+            *format = trc == mlt_color_trc_arib_std_b67 ? mlt_image_yuv444p10 : mlt_image_rgba;
         }
     }
 }

--- a/src/modules/core/producer_colour.c
+++ b/src/modules/core/producer_colour.c
@@ -143,7 +143,7 @@ static int producer_get_image(mlt_frame frame,
                 memset(p + 0, y, plane_size);
                 memset(p + plane_size, u, plane_size / 4);
                 memset(p + plane_size + plane_size / 4, v, plane_size / 4);
-                mlt_properties_set_int(properties, "colorspace", 601);
+                mlt_properties_set_int(properties, "colorspace", mlt_colorspace_bt601);
                 break;
             }
             case mlt_image_yuv422: {
@@ -166,7 +166,7 @@ static int producer_get_image(mlt_frame frame,
                         *p++ = u;
                     }
                 }
-                mlt_properties_set_int(properties, "colorspace", 601);
+                mlt_properties_set_int(properties, "colorspace", mlt_colorspace_bt601);
                 break;
             }
             case mlt_image_rgb:

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -690,58 +690,53 @@ protected:
                 frameMeta->SetInt(bmdDeckLinkFrameMetadataColorspace, colorspace);
 
                 // Set HDR a transfer function
-                if (mlt_properties_exists(consumer_properties, "color_trc")) {
-                    if (!strcmp("arib-std-b67",
-                                mlt_properties_get(consumer_properties, "color_trc"))) {
-                        frameMeta->SetInt(bmdDeckLinkFrameMetadataHDRElectroOpticalTransferFunc,
-                                          EOTF_HLG);
-                        decklinkFrame->SetFlags(decklinkFrame->GetFlags()
-                                                & ~bmdFrameContainsHDRMetadata);
-                    } else if (!strcmp("smpte2084",
-                                       mlt_properties_get(consumer_properties, "color_trc"))) {
-                        frameMeta->SetInt(bmdDeckLinkFrameMetadataHDRElectroOpticalTransferFunc,
-                                          EOTF_PQ);
-                        // CEA/SMPTE HDR metadata
-                        // TODO: document and provide defaults for these
-                        decklinkFrame->SetFlags(decklinkFrame->GetFlags()
-                                                | bmdFrameContainsHDRMetadata);
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesRedX,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_red_x"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesRedY,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_red_y"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesGreenX,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_green_x"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesGreenY,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr.green_y"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesBlueX,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_blue_x"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesBlueY,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_blue_y"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRWhitePointX,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_white_x"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRWhitePointY,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_white_y"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMaxDisplayMasteringLuminance,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_max_luminance"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMinDisplayMasteringLuminance,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_min_luminance"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMaximumContentLightLevel,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_max_cll"));
-                        frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMaximumFrameAverageLightLevel,
-                                            mlt_properties_get_double(consumer_properties,
-                                                                      "hdr_max_fall"));
-                    }
+                const char *trc_str = mlt_properties_get(consumer_properties, "consumer.color_trc");
+                mlt_color_trc trc = mlt_image_color_trc_id(trc_str);
+                if (trc == mlt_color_trc_arib_std_b67) {
+                    frameMeta->SetInt(bmdDeckLinkFrameMetadataHDRElectroOpticalTransferFunc,
+                                      EOTF_HLG);
+                    decklinkFrame->SetFlags(decklinkFrame->GetFlags()
+                                            & ~bmdFrameContainsHDRMetadata);
+                } else if (trc == mlt_color_trc_smpte2084) {
+                    frameMeta->SetInt(bmdDeckLinkFrameMetadataHDRElectroOpticalTransferFunc,
+                                      EOTF_PQ);
+                    // CEA/SMPTE HDR metadata
+                    // TODO: document and provide defaults for these
+                    decklinkFrame->SetFlags(decklinkFrame->GetFlags() | bmdFrameContainsHDRMetadata);
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesRedX,
+                                        mlt_properties_get_double(consumer_properties, "hdr_red_x"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesRedY,
+                                        mlt_properties_get_double(consumer_properties, "hdr_red_y"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesGreenX,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_green_x"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesGreenY,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr.green_y"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesBlueX,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_blue_x"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRDisplayPrimariesBlueY,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_blue_y"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRWhitePointX,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_white_x"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRWhitePointY,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_white_y"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMaxDisplayMasteringLuminance,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_max_luminance"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMinDisplayMasteringLuminance,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_min_luminance"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMaximumContentLightLevel,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_max_cll"));
+                    frameMeta->SetFloat(bmdDeckLinkFrameMetadataHDRMaximumFrameAverageLightLevel,
+                                        mlt_properties_get_double(consumer_properties,
+                                                                  "hdr_max_fall"));
                 }
             }
 

--- a/src/modules/decklink/consumer_decklink.cpp
+++ b/src/modules/decklink/consumer_decklink.cpp
@@ -678,13 +678,16 @@ protected:
             if (decklinkFrame->QueryInterface(IID_IDeckLinkVideoFrameMutableMetadataExtensions,
                                               (void **) &frameMeta)
                 == S_OK) {
+                const char *colorspace_str = mlt_properties_get(consumer_properties, "colorspace");
                 auto colorspace = bmdColorspaceRec709;
-                switch (mlt_properties_get_int(consumer_properties, "colorspace")) {
-                case 601:
+                switch (mlt_image_colorspace_id(colorspace_str)) {
+                case mlt_colorspace_bt601:
                     colorspace = bmdColorspaceRec601;
                     break;
-                case 2020:
+                case mlt_colorspace_bt2020_ncl:
                     colorspace = bmdColorspaceRec2020;
+                    break;
+                default:
                     break;
                 }
                 frameMeta->SetInt(bmdDeckLinkFrameMetadataColorspace, colorspace);

--- a/src/modules/decklink/producer_decklink.cpp
+++ b/src/modules/decklink/producer_decklink.cpp
@@ -117,7 +117,7 @@ private:
     bool m_isBuffering;
     int m_topFieldFirst;
     BMDPixelFormat m_pixel_format;
-    int m_colorspace;
+    mlt_colorspace m_colorspace;
     int m_vancLines;
     mlt_cache m_cache;
     bool m_reprio;
@@ -138,7 +138,9 @@ private:
                 double fps = (double) timescale / duration;
                 int p = mode->GetFieldDominance() == bmdProgressiveFrame;
                 m_topFieldFirst = mode->GetFieldDominance() == bmdUpperFieldFirst;
-                m_colorspace = (mode->GetFlags() & bmdDisplayModeColorspaceRec709) ? 709 : 601;
+                m_colorspace = (mode->GetFlags() & bmdDisplayModeColorspaceRec709)
+                                   ? mlt_colorspace_bt709
+                                   : mlt_colorspace_bt601;
                 mlt_log_verbose(getProducer(),
                                 "BMD mode %dx%d %.3f fps prog %d tff %d\n",
                                 width,
@@ -728,8 +730,8 @@ public:
         }
         if (events & bmdVideoInputColorspaceChanged) {
             profile->colorspace = m_colorspace = (mode->GetFlags() & bmdDisplayModeColorspaceRec709)
-                                                     ? 709
-                                                     : 601;
+                                                     ? mlt_colorspace_bt709
+                                                     : mlt_colorspace_bt601;
             mlt_log_verbose(getProducer(), "colorspace changed %d\n", profile->colorspace);
         }
         return S_OK;

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -79,48 +79,21 @@ static void delete_chain(EffectChain *chain)
     delete chain;
 }
 
-// Copied from libavcodec, but we can not add that as a dependency to this module
-// simply for this.
-
-enum AVColorTransferCharacteristic {
-    AVCOL_TRC_BT709 = 1, ///< also ITU-R BT1361
-    AVCOL_TRC_UNSPECIFIED = 2,
-    AVCOL_TRC_GAMMA22 = 4, ///< also ITU-R BT470M / ITU-R BT1700 625 PAL & SECAM
-    AVCOL_TRC_GAMMA28 = 5, ///< also ITU-R BT470BG
-    AVCOL_TRC_SMPTE170M
-    = 6, ///< also ITU-R BT601-6 525 or 625 / ITU-R BT1358 525 or 625 / ITU-R BT1700 NTSC
-    AVCOL_TRC_SMPTE240M = 7,
-    AVCOL_TRC_LINEAR = 8,    ///< "Linear transfer characteristics"
-    AVCOL_TRC_LOG = 9,       ///< "Logarithmic transfer characteristic (100:1 range)"
-    AVCOL_TRC_LOG_SQRT = 10, ///< "Logarithmic transfer characteristic (100 * Sqrt( 10 ) : 1 range)"
-    AVCOL_TRC_IEC61966_2_4 = 11, ///< IEC 61966-2-4
-    AVCOL_TRC_BT1361_ECG = 12,   ///< ITU-R BT1361 Extended Colour Gamut
-    AVCOL_TRC_IEC61966_2_1 = 13, ///< IEC 61966-2-1 (sRGB or sYCC)
-    AVCOL_TRC_BT2020_10 = 14,    ///< ITU-R BT2020 for 10 bit system
-    AVCOL_TRC_BT2020_12 = 15,    ///< ITU-R BT2020 for 12 bit system
-    AVCOL_TRC_SMPTE2084 = 16,    ///< SMPTE ST 2084 for 10-, 12-, 14- and 16-bit systems
-    AVCOL_TRC_SMPTEST2084 = AVCOL_TRC_SMPTE2084,
-    AVCOL_TRC_SMPTE428 = 17, ///< SMPTE ST 428-1
-    AVCOL_TRC_SMPTEST428_1 = AVCOL_TRC_SMPTE428,
-    AVCOL_TRC_ARIB_STD_B67 = 18, ///< ARIB STD-B67, known as "Hybrid log-gamma"
-    AVCOL_TRC_NB,                ///< Not part of ABI
-};
-
 // Get the gamma from the frame "color_trc" property as set by producer or this filter.
-static GammaCurve getFrameGamma(int color_trc)
+static GammaCurve getFrameGamma(mlt_color_trc color_trc)
 {
     switch (color_trc) {
-    case AVCOL_TRC_LINEAR:
+    case mlt_color_trc_linear:
         return GAMMA_LINEAR;
-    case AVCOL_TRC_GAMMA22:
-    case AVCOL_TRC_IEC61966_2_1:
+    case mlt_color_trc_gamma22:
+    case mlt_color_trc_iec61966_2_1:
         return GAMMA_sRGB;
-    case AVCOL_TRC_BT2020_10:
+    case mlt_color_trc_bt2020_10:
         return GAMMA_REC_2020_10_BIT;
-    case AVCOL_TRC_BT2020_12:
+    case mlt_color_trc_bt2020_12:
         return GAMMA_REC_2020_12_BIT;
 #if MOVIT_VERSION >= 1037
-    case AVCOL_TRC_ARIB_STD_B67:
+    case mlt_color_trc_arib_std_b67:
         return GAMMA_HLG;
 #endif
     default:
@@ -132,54 +105,29 @@ static GammaCurve getFrameGamma(int color_trc)
 // Also, update the frame's color_trc property with the selection.
 static GammaCurve getOutputGamma(mlt_properties properties)
 {
-    const char *color_trc = mlt_properties_get(properties, "consumer.color_trc");
-    if (color_trc) {
-        // If specified with enum or int.
-        int n = mlt_properties_get_int(properties, "consumer.color_trc");
-        switch (n) {
-        case AVCOL_TRC_BT709:
-        case AVCOL_TRC_SMPTE170M:
-            mlt_properties_set_int(properties, "color_trc", n);
-            return GAMMA_REC_709;
-        case AVCOL_TRC_LINEAR:
-            mlt_properties_set_int(properties, "color_trc", n);
-            return GAMMA_LINEAR;
-        case AVCOL_TRC_BT2020_10:
-            mlt_properties_set_int(properties, "color_trc", n);
-            return GAMMA_REC_2020_10_BIT;
-        case AVCOL_TRC_BT2020_12:
-            mlt_properties_set_int(properties, "color_trc", n);
-            return GAMMA_REC_2020_12_BIT;
+    const char *color_trc_str = mlt_properties_get(properties, "consumer.color_trc");
+    mlt_color_trc color_trc = mlt_image_color_trc_id(color_trc_str);
+    switch (color_trc) {
+    case mlt_color_trc_bt709:
+    case mlt_color_trc_smpte170m:
+        mlt_properties_set(properties, "color_trc", color_trc_str);
+        return GAMMA_REC_709;
+    case mlt_color_trc_linear:
+        mlt_properties_set(properties, "color_trc", color_trc_str);
+        return GAMMA_LINEAR;
+    case mlt_color_trc_bt2020_10:
+        mlt_properties_set(properties, "color_trc", color_trc_str);
+        return GAMMA_REC_2020_10_BIT;
+    case mlt_color_trc_bt2020_12:
+        mlt_properties_set(properties, "color_trc", color_trc_str);
+        return GAMMA_REC_2020_12_BIT;
 #if MOVIT_VERSION >= 1037
-        case AVCOL_TRC_ARIB_STD_B67:
-            mlt_properties_set_int(properties, "color_trc", n);
-            return GAMMA_HLG;
+    case mlt_color_trc_arib_std_b67:
+        mlt_properties_set(properties, "color_trc", color_trc_str);
+        return GAMMA_HLG;
 #endif
-        default:
-            // If specified by string.
-            if (!strcmp(color_trc, "bt709")) {
-                mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_BT709);
-                return GAMMA_REC_709;
-            } else if (!strcmp(color_trc, "smpte170m")) {
-                mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_SMPTE170M);
-                return GAMMA_REC_709;
-            } else if (!strcmp(color_trc, "linear")) {
-                mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_LINEAR);
-                return GAMMA_LINEAR;
-            } else if (!strcmp(color_trc, "bt2020-10")) {
-                mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_BT2020_10);
-                return GAMMA_REC_2020_10_BIT;
-            } else if (!strcmp(color_trc, "bt2020-12")) {
-                mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_BT2020_12);
-                return GAMMA_REC_2020_12_BIT;
-#if MOVIT_VERSION >= 1037
-            } else if (!strcmp(color_trc, "arib-std-b67")) {
-                mlt_properties_set_int(properties, "color_trc", AVCOL_TRC_ARIB_STD_B67);
-                return GAMMA_HLG;
-#endif
-            }
-            break;
-        }
+    default:
+        break;
     }
     return GAMMA_INVALID;
 }
@@ -216,7 +164,9 @@ static void get_format_from_properties(mlt_properties properties,
             image_format->color_space = COLORSPACE_REC_709;
             break;
         }
-        image_format->gamma_curve = getFrameGamma(mlt_properties_get_int(properties, "color_trc"));
+        const char *color_trc_str = mlt_properties_get(properties, "color_trc");
+        mlt_color_trc color_trc = mlt_image_color_trc_id(color_trc_str);
+        image_format->gamma_curve = getFrameGamma(color_trc);
     }
 
     if (mlt_properties_get_int(properties, "force_full_luma")) {

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -136,13 +136,14 @@ static void get_format_from_properties(mlt_properties properties,
                                        ImageFormat *image_format,
                                        YCbCrFormat *ycbcr_format)
 {
-    switch (mlt_properties_get_int(properties, "colorspace")) {
-    case 601:
+    const char *colorspace_str = mlt_properties_get(properties, "colorspace");
+    switch (mlt_image_colorspace_id(colorspace_str)) {
+    case mlt_colorspace_bt601:
         ycbcr_format->luma_coefficients = YCBCR_REC_601;
         break;
-    case 2020:
+    case mlt_colorspace_bt2020_ncl:
         ycbcr_format->luma_coefficients = YCBCR_REC_2020;
-    case 709:
+    case mlt_colorspace_bt709:
     default:
         ycbcr_format->luma_coefficients = YCBCR_REC_709;
         break;

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -150,17 +150,18 @@ static void get_format_from_properties(mlt_properties properties,
     }
 
     if (image_format) {
-        switch (mlt_properties_get_int(properties, "color_primaries")) {
-        case 601625:
+        const char *color_pri_str = mlt_properties_get(properties, "color_primaries");
+        switch (mlt_image_color_pri_id(color_pri_str)) {
+        case mlt_color_pri_bt470bg:
             image_format->color_space = COLORSPACE_REC_601_625;
             break;
-        case 601525:
+        case mlt_color_pri_smpte170m:
             image_format->color_space = COLORSPACE_REC_601_525;
             break;
-        case 2020:
+        case mlt_color_pri_bt2020:
             image_format->color_space = COLORSPACE_REC_2020;
             break;
-        case 709:
+        case mlt_color_pri_bt709:
         default:
             image_format->color_space = COLORSPACE_REC_709;
             break;

--- a/src/tests/test_image/test_image.cpp
+++ b/src/tests/test_image/test_image.cpp
@@ -139,6 +139,20 @@ private Q_SLOTS:
         QCOMPARE(mlt_color_trc_bt709, mlt_image_color_trc_id("1"));
         QCOMPARE(mlt_color_trc_linear, mlt_image_color_trc_id("8"));
     }
+
+    void Colorspace()
+    {
+        // Test conversion from short name
+        QCOMPARE(mlt_image_colorspace_id("bt709"), mlt_colorspace_bt709);
+        QCOMPARE(mlt_image_colorspace_id("bt470bg"), mlt_colorspace_bt470bg);
+        QCOMPARE(mlt_image_colorspace_id("bt601"), mlt_colorspace_bt601);
+        QCOMPARE(mlt_image_colorspace_id("rgb"), mlt_colorspace_rgb);
+        // Test conversion from number
+        QCOMPARE(mlt_image_colorspace_id("709"), mlt_colorspace_bt709);
+        QCOMPARE(mlt_image_colorspace_id("470"), mlt_colorspace_bt470bg);
+        QCOMPARE(mlt_image_colorspace_id("601"), mlt_colorspace_bt601);
+        QCOMPARE(mlt_image_colorspace_id("0"), mlt_colorspace_rgb);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestImage)

--- a/src/tests/test_image/test_image.cpp
+++ b/src/tests/test_image/test_image.cpp
@@ -162,10 +162,10 @@ private Q_SLOTS:
         QCOMPARE(mlt_image_color_pri_id("smpte170m"), mlt_color_pri_smpte170m);
         QCOMPARE(mlt_image_color_pri_id("bt2020"), mlt_color_pri_bt2020);
         // Test conversion from number
-        QCOMPARE(mlt_image_color_pri_id("709"), mlt_color_pri_bt709);
-        QCOMPARE(mlt_image_color_pri_id("601625"), mlt_color_pri_bt470bg);
-        QCOMPARE(mlt_image_color_pri_id("601525"), mlt_color_pri_smpte170m);
-        QCOMPARE(mlt_image_color_pri_id("2020"), mlt_color_pri_bt2020);
+        QCOMPARE(mlt_image_color_pri_id("1"), mlt_color_pri_bt709);
+        QCOMPARE(mlt_image_color_pri_id("5"), mlt_color_pri_bt470bg);
+        QCOMPARE(mlt_image_color_pri_id("6"), mlt_color_pri_smpte170m);
+        QCOMPARE(mlt_image_color_pri_id("9"), mlt_color_pri_bt2020);
     }
 };
 

--- a/src/tests/test_image/test_image.cpp
+++ b/src/tests/test_image/test_image.cpp
@@ -153,6 +153,20 @@ private Q_SLOTS:
         QCOMPARE(mlt_image_colorspace_id("601"), mlt_colorspace_bt601);
         QCOMPARE(mlt_image_colorspace_id("0"), mlt_colorspace_rgb);
     }
+
+    void ColorPrimaries()
+    {
+        // Test conversion from short name
+        QCOMPARE(mlt_image_color_pri_id("bt709"), mlt_color_pri_bt709);
+        QCOMPARE(mlt_image_color_pri_id("bt470bg"), mlt_color_pri_bt470bg);
+        QCOMPARE(mlt_image_color_pri_id("smpte170m"), mlt_color_pri_smpte170m);
+        QCOMPARE(mlt_image_color_pri_id("bt2020"), mlt_color_pri_bt2020);
+        // Test conversion from number
+        QCOMPARE(mlt_image_color_pri_id("709"), mlt_color_pri_bt709);
+        QCOMPARE(mlt_image_color_pri_id("601625"), mlt_color_pri_bt470bg);
+        QCOMPARE(mlt_image_color_pri_id("601525"), mlt_color_pri_smpte170m);
+        QCOMPARE(mlt_image_color_pri_id("2020"), mlt_color_pri_bt2020);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestImage)

--- a/src/tests/test_image/test_image.cpp
+++ b/src/tests/test_image/test_image.cpp
@@ -129,6 +129,16 @@ private Q_SLOTS:
         i.init_alpha();
         QVERIFY(i.plane(3) != nullptr);
     }
+
+    void ColorTrc()
+    {
+        // Test conversion from short name
+        QCOMPARE(mlt_color_trc_bt709, mlt_image_color_trc_id("bt709"));
+        QCOMPARE(mlt_color_trc_linear, mlt_image_color_trc_id("linear"));
+        // Test conversion from number
+        QCOMPARE(mlt_color_trc_bt709, mlt_image_color_trc_id("1"));
+        QCOMPARE(mlt_color_trc_linear, mlt_image_color_trc_id("8"));
+    }
 };
 
 QTEST_APPLESS_MAIN(TestImage)


### PR DESCRIPTION
Formalize these values so their use can be more uniform in MLT as we add more color space conversion features.