### PR TITLE
Do not default Opus audio in SVT-AV1 preset to CBR

### DIFF
--- a/presets/consumer/avformat/ten_bit/SVT-AV1
+++ b/presets/consumer/avformat/ten_bit/SVT-AV1
@@ -3,7 +3,6 @@ f=webm
 acodec=libopus
 ar=48000
 ab=192k
-vbr=off
 
 vcodec=libsvtav1
 crf=32


### PR DESCRIPTION
Sync the 10-bit version to the 8-bit version