### PR TITLE
Fix multiple memory safety issues detected by ASan/UBSan/LeakSan

### DIFF
--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -486,6 +486,10 @@ double mlt_producer_get_fps(mlt_producer self)
 
 int mlt_producer_set_in_and_out(mlt_producer self, mlt_position in, mlt_position out)
 {
+
+    if (self == NULL) {
+        return 1;
+    }
     if (self->set_in_and_out) {
         return self->set_in_and_out(self, in, out);
     }

--- a/src/modules/avformat/filter_avcolour_space.c
+++ b/src/modules/avformat/filter_avcolour_space.c
@@ -348,10 +348,11 @@ static mlt_frame filter_process(mlt_filter filter, mlt_frame frame)
     // The producer may still change it during get_image.
     // This way we do not have to modify each producer to set a valid colorspace.
     mlt_properties properties = MLT_FRAME_PROPERTIES(frame);
-    if (mlt_properties_get_int(properties, "colorspace") <= 0)
-        mlt_properties_set_int(properties,
-                               "colorspace",
-                               mlt_service_profile(MLT_FILTER_SERVICE(filter))->colorspace);
+    if (mlt_properties_get_int(properties, "colorspace") <= 0) {
+        mlt_profile profile = mlt_service_profile(MLT_FILTER_SERVICE(filter));
+        int colorspace = profile ? profile->colorspace : mlt_colorspace_bt601;
+        mlt_properties_set_int(properties, "colorspace", colorspace);
+    }
 
     if (!frame->convert_image)
         frame->convert_image = convert_image;

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -759,11 +759,11 @@ static mlt_frame process(mlt_filter filter, mlt_frame frame)
     // The producer may still change it during get_image.
     // This way we do not have to modify each producer to set a valid colorspace.
     mlt_properties properties = MLT_FRAME_PROPERTIES(frame);
-    if (mlt_properties_get_int(properties, "colorspace") <= 0)
-        mlt_properties_set_int(properties,
-                               "colorspace",
-                               mlt_service_profile(MLT_FILTER_SERVICE(filter))->colorspace);
-
+    if (mlt_properties_get_int(properties, "colorspace") <= 0) {
+        mlt_profile profile = mlt_service_profile(MLT_FILTER_SERVICE(filter));
+        int colorspace = profile ? profile->colorspace : mlt_colorspace_bt601;
+        mlt_properties_set_int(properties, "colorspace", colorspace);
+    }
     frame->convert_image = convert_image;
 
     mlt_filter cpu_csc = (mlt_filter) mlt_properties_get_data(MLT_FILTER_PROPERTIES(filter),


### PR DESCRIPTION
- Fix null pointer dereference in filter_avcolour_space.c when profile is NULL
- Fix Pango/Fontconfig memory leak in producer_pango.c by adding instance counting
- Fix null pointer dereferences in producer_colour.c (two locations)
- Fix null pointer dereference in mlt_producer_set_in_and_out
- Fix null pointer dereference in filter_movit_convert.cpp
- Fix double-free in producer_xml.c by properly handling stack state All fixes have been verified with fuzzing tests. See FIXES_REPORT.md for details, and all of the crash is in the zip
[fixed_crashes.zip](https://github.com/user-attachments/files/23497459/fixed_crashes.zip)