### PR TITLE
Fix #1156 Crackling sound when cutting pcm_s24le in mkv

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -3347,7 +3347,11 @@ static int decode_audio(producer_avformat self,
 
             if (req_pts > pts) {
                 // We are behind, so skip some
-                *ignore = lrint(timebase * (req_pts - pts) * codec_context->sample_rate);
+                int sample_error_margin = ceil(timebase * codec_context->sample_rate);
+                int sample_delta = lrint(timebase * (req_pts - pts) * codec_context->sample_rate);
+                if (sample_delta > sample_error_margin) {
+                    *ignore = sample_delta;
+                }
             } else if (self->audio_index != INT_MAX && int_position > req_position + ahead_threshold
                        && !self->is_audio_synchronizing) {
                 // We are ahead, so seek backwards some more.


### PR DESCRIPTION
For the provided test clip, Libav provides an audio timebase of 1000 ticks per second for the PTS. However, the sample rate is 48000 samples per second. That means each pts tick represents 48 audio samples. The PTS calculation is drived from muliple calculations including the profile frame rate. Those calculations create opportunities for rounding errors in the sample calculation. In this case, after an initial synchornization, the PTS calculation still would occasionally find an offset of 1 tick.

This change essentially changes the synchronization to not take action unless the offset is greater than 1 tick. When it does take action to synchronize, it uses all the precision that it has.