### PR TITLE
Fix outline encroaches on text color

### DIFF
--- a/src/modules/qt/producer_qtext.cpp
+++ b/src/modules/qt/producer_qtext.cpp
@@ -323,16 +323,23 @@ static void generate_qimage(mlt_properties frame_properties)
 #endif
     );
 
-    QPen pen;
-    pen.setWidth(outline);
+    // Draw the outline first, and then draw the fill on top of it.
+    // This avoids the outline encroaching on the text fill.
+
+    // Draw the outline if requested
     if (outline) {
+        QPen pen;
+        pen.setWidth(outline);
         pen.setColor(QColor(ol_color.r, ol_color.g, ol_color.b, ol_color.a));
-    } else {
-        pen.setColor(QColor(bg_color.r, bg_color.g, bg_color.b, bg_color.a));
+        painter.setPen(pen);
+        painter.setBrush(Qt::NoBrush); // No brush needed for outline
+        painter.drawPath(*qPath);
     }
-    painter.setPen(pen);
+
+    // Fill the text area
     QBrush brush(QColor(fg_color.r, fg_color.g, fg_color.b, fg_color.a));
     painter.setBrush(brush);
+    painter.setPen(Qt::NoPen); // No pen needed for fill
     painter.drawPath(*qPath);
 }
 


### PR DESCRIPTION
As reported here: https://forum.shotcut.org/t/outline-outlining-text-in-filter-subtilte-burn-in-and-typewriter-with-unwanted-inline/50726

Posting this as a PR so we can consider if we need to do anything for backwards compatibility. I was thinking we could just push it out. But I want to make sure users would not be surprised.

I think this change significantly improves the outline.

Before:
<img width="1498" height="683" alt="before" src="https://github.com/user-attachments/assets/8af14b4c-43d8-4869-b02f-ba74c9b59d1d" />

After:
<img width="1498" height="683" alt="after" src="https://github.com/user-attachments/assets/08e166e9-5285-4fc6-a75d-42c5aea56d7e" />

Even the maximum outline size still preserves the text fill:
<img width="1498" height="683" alt="image" src="https://github.com/user-attachments/assets/ed86f594-99c0-4bab-a065-2063f4a571bb" />
