### PR TITLE
avformat: set stream.type to "subtitle" for subtitle streams

### DIFF
--- a/src/modules/avformat/producer_avformat.c
+++ b/src/modules/avformat/producer_avformat.c
@@ -477,6 +477,9 @@ static AVRational guess_frame_rate(producer_avformat self, AVStream *stream)
             frame_rate.num = 48000;
             frame_rate.den = 1001;
             break;
+        case AVMEDIA_TYPE_SUBTITLE:
+            mlt_properties_set(meta_media, key, "subtitle");
+            break;
         default:
             break;
         }


### PR DESCRIPTION
The switch statement in `producer_avformat.c` that sets `meta.media.X.stream.type` already handles `AVMEDIA_TYPE_VIDEO` and `AVMEDIA_TYPE_AUDIO`, but has no case for `AVMEDIA_TYPE_SUBTITLE`. This means subtitle streams in MKV files (and other containers) leave the `stream.type` property completely unset.

This patch adds the missing case:

```c
case AVMEDIA_TYPE_SUBTITLE:
    mlt_properties_set(meta_media, key, "subtitle");
    break;
```

This makes subtitle stream detection consistent with how video and audio streams are already reported, and allows applications using MLT to reliably detect subtitle streams by checking `meta.media.X.stream.type == "subtitle"` instead of having to fall back to inspecting codec names.

Tested with an MKV file containing an embedded SRT subtitle stream, `meta.media.2.stream.type` is now correctly set to `"subtitle"`.