### PR TITLE
add log for miss chain_normalizers.ini file result in convert_audio is null

### DIFF
--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -454,7 +454,10 @@ extern void mlt_chain_attach_normalizers(mlt_chain self)
         char temp[PATH_MAX];
         snprintf(temp, PATH_MAX, "%s/chain_normalizers.ini", mlt_environment("MLT_DATA"));
         normalisers = mlt_properties_load(temp);
-        mlt_factory_register_for_clean_up(normalisers, (mlt_destructor) mlt_properties_close);
+        if(normalisers)
+            mlt_factory_register_for_clean_up(normalisers, (mlt_destructor) mlt_properties_close);
+        else
+            mlt_log_error("Failed to load normalizers from %s\n", temp);
     }
 
     // Apply normalisers

--- a/src/framework/mlt_chain.c
+++ b/src/framework/mlt_chain.c
@@ -454,10 +454,10 @@ extern void mlt_chain_attach_normalizers(mlt_chain self)
         char temp[PATH_MAX];
         snprintf(temp, PATH_MAX, "%s/chain_normalizers.ini", mlt_environment("MLT_DATA"));
         normalisers = mlt_properties_load(temp);
-        if(normalisers)
+        if (normalisers)
             mlt_factory_register_for_clean_up(normalisers, (mlt_destructor) mlt_properties_close);
         else
-            mlt_log_error("Failed to load normalizers from %s\n", temp);
+            mlt_log_error(NULL, "Failed to load normalizers from %s\n", temp);
     }
 
     // Apply normalisers

--- a/src/framework/mlt_properties.c
+++ b/src/framework/mlt_properties.c
@@ -243,6 +243,8 @@ static int load_properties(mlt_properties self, const char *filename)
 
         // Close the file
         fclose(file);
+    } else {
+        mlt_log(NULL, MLT_LOG_WARNING, "Failed to open properties file: %s\n", filename);
     }
     return file ? 0 : errno;
 }

--- a/src/framework/mlt_properties.c
+++ b/src/framework/mlt_properties.c
@@ -244,7 +244,7 @@ static int load_properties(mlt_properties self, const char *filename)
         // Close the file
         fclose(file);
     } else {
-        mlt_log_warning(NULL, "Failed to open file %s for yaml parsing!\n", filename);
+        mlt_log_warning(NULL, "Failed to open properties file %s for parsing!\n", filename);
     }
     return file ? 0 : errno;
 }

--- a/src/framework/mlt_properties.c
+++ b/src/framework/mlt_properties.c
@@ -244,7 +244,7 @@ static int load_properties(mlt_properties self, const char *filename)
         // Close the file
         fclose(file);
     } else {
-        mlt_log(NULL, MLT_LOG_WARNING, "Failed to open properties file: %s\n", filename);
+        mlt_log_warning(NULL, "Failed to open file %s for yaml parsing!\n", filename);
     }
     return file ? 0 : errno;
 }


### PR DESCRIPTION
for https://github.com/mltframework/mlt/issues/1221#issue-4274955518

The new point log is convenient for beginners.