### PR TITLE
Fix bug #1228: Use a 0.85 mipMap to avoid jerky pan/zoom, also use MLT instead QImage for downsampling

### DIFF
--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -121,3 +121,31 @@ int create_image(mlt_frame frame,
 
     return error;
 }
+
+
+
+// Helper for mipmapping calculation shared in filter_qtblend and transition_qtblend
+void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height)
+{
+    double mltMipmapScale = 1.0;
+    while (mltMipmapScale * MLT_QT_MIPMAP_STEP >= scaleTarget && mltMipmapScale > 0.001) {
+        mltMipmapScale *= MLT_QT_MIPMAP_STEP;
+    }
+
+    if (mltMipmapScale < 1.0) {
+        *b_width = qRound(*b_width * mltMipmapScale);
+        *b_height = qRound(*b_height * mltMipmapScale);
+        *b_width = qMax(1, *b_width);
+        *b_height = qMax(1, *b_height);
+    }
+}
+
+
+// Normalize source dimensions to consumer PAR to handle anamorphic sources
+void normalize_mlt_source_size(double b_ar, double consumer_ar, int *b_width, int b_height)
+{
+    if (b_ar != consumer_ar && b_height > 0) {
+        *b_width = qRound(*b_width * b_ar / consumer_ar);
+        *b_width = qMax(1, *b_width);
+    }
+}

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -127,6 +127,9 @@ int create_image(mlt_frame frame,
 // Helper for mipmapping calculation shared in filter_qtblend and transition_qtblend
 void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height)
 {
+    if (!b_width || !b_height) {
+        return;
+    }
     double mltMipmapScale = 1.0;
     while (mltMipmapScale * MLT_QT_MIPMAP_STEP >= scaleTarget && mltMipmapScale > 0.001) {
         mltMipmapScale *= MLT_QT_MIPMAP_STEP;
@@ -144,6 +147,9 @@ void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height)
 // Normalize source dimensions to consumer PAR to handle anamorphic sources
 void normalize_mlt_source_size(double b_ar, double consumer_ar, int *b_width, int b_height)
 {
+    if (!b_width) {
+        return;
+    }
     if (b_ar > 0.0 && consumer_ar > 0.0 && b_ar != consumer_ar && b_height > 0) {
         *b_width = qRound(*b_width * b_ar / consumer_ar);
     }

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -144,8 +144,8 @@ void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height)
 // Normalize source dimensions to consumer PAR to handle anamorphic sources
 void normalize_mlt_source_size(double b_ar, double consumer_ar, int *b_width, int b_height)
 {
-    if (b_ar != consumer_ar && b_height > 0) {
+    if (b_ar > 0.0 && consumer_ar > 0.0 && b_ar != consumer_ar && b_height > 0) {
         *b_width = qRound(*b_width * b_ar / consumer_ar);
-        *b_width = qMax(1, *b_width);
     }
+    *b_width = qMax(1, *b_width);
 }

--- a/src/modules/qt/common.cpp
+++ b/src/modules/qt/common.cpp
@@ -122,8 +122,6 @@ int create_image(mlt_frame frame,
     return error;
 }
 
-
-
 // Helper for mipmapping calculation shared in filter_qtblend and transition_qtblend
 void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height)
 {
@@ -142,7 +140,6 @@ void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height)
         *b_height = qMax(1, *b_height);
     }
 }
-
 
 // Normalize source dimensions to consumer PAR to handle anamorphic sources
 void normalize_mlt_source_size(double b_ar, double consumer_ar, int *b_width, int b_height)

--- a/src/modules/qt/common.h
+++ b/src/modules/qt/common.h
@@ -21,6 +21,9 @@
 
 #include <framework/mlt.h>
 
+// The step size used for MLT mipmapping to ensure stable and high quality downscaling
+static constexpr double MLT_QT_MIPMAP_STEP = 0.85;
+
 class QImage;
 
 bool createQApplicationIfNeeded(mlt_service service);
@@ -34,5 +37,7 @@ int create_image(mlt_frame frame,
                  int *width,
                  int *height,
                  int writable);
+void adjust_mlt_mipmap_size(double scaleTarget, int *b_width, int *b_height);
+void normalize_mlt_source_size(double b_ar, double consumer_ar, int *b_width, int b_height);
 
 #endif // COMMON_H

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -165,8 +165,8 @@ static int filter_get_image(mlt_frame frame,
 
     // Apply MLT Mipmapping
     // Adjust requested dimension so MLT (libswscale) does the preliminary downscaling.
-    // Using a step of 0.85 provides a tight bound to target resolution (maximizing quality 
-    // and preventing QPainter aliasing) while keeping the requested dimensions stable 
+    // Using a step of 0.85 provides a tight bound to target resolution (maximizing quality
+    // and preventing QPainter aliasing) while keeping the requested dimensions stable
     // across small animation increments (preventing resampling jitter).
     double mltMipmapScale = 1.0;
     if (rect.w > 0 && rect.h > 0 && b_width > 0 && b_height > 0) {
@@ -181,11 +181,11 @@ static int filter_get_image(mlt_frame frame,
                 scaleTarget = rect.h / b_height;
             }
         }
-        
+
         while (mltMipmapScale * 0.85 >= scaleTarget && mltMipmapScale > 0.001) {
             mltMipmapScale *= 0.85;
         }
-        
+
         if (mltMipmapScale < 1.0) {
             b_width = qRound(b_width * mltMipmapScale);
             b_height = qRound(b_height * mltMipmapScale);
@@ -271,8 +271,7 @@ static int filter_get_image(mlt_frame frame,
             scale = rect.h / b_height;
         }
         // Center image in rect
-        transform.translate((rect.w - (b_width * scale)) / 2.0,
-                            (rect.h - (b_height * scale)) / 2.0);
+        transform.translate((rect.w - (b_width * scale)) / 2.0, (rect.h - (b_height * scale)) / 2.0);
         // Use QPainter scaling for everything
         transform.scale(scale, scale);
     }

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -156,6 +156,43 @@ static int filter_get_image(mlt_frame frame,
             rect.h *= scaley;
         }
     }
+
+    // Normalize source dimensions to consumer PAR to handle anamorphic sources
+    if (b_ar != consumer_ar && b_height > 0) {
+        b_width = qRound(b_width * b_ar / consumer_ar);
+    }
+
+    // Apply MLT Mipmapping
+    // Adjust requested dimension so MLT (libswscale) does the preliminary downscaling.
+    // Using a step of 0.85 provides a tight bound to target resolution (maximizing quality 
+    // and preventing QPainter aliasing) while keeping the requested dimensions stable 
+    // across small animation increments (preventing resampling jitter).
+    double mltMipmapScale = 1.0;
+    if (rect.w > 0 && rect.h > 0 && b_width > 0 && b_height > 0) {
+        double scaleTarget;
+        if (distort) {
+            scaleTarget = qMax(rect.w / b_width, rect.h / b_height);
+        } else {
+            double resize_dar = rect.w * consumer_ar / rect.h;
+            if (b_dar >= resize_dar) {
+                scaleTarget = rect.w / b_width;
+            } else {
+                scaleTarget = rect.h / b_height;
+            }
+        }
+        
+        while (mltMipmapScale * 0.85 >= scaleTarget && mltMipmapScale > 0.001) {
+            mltMipmapScale *= 0.85;
+        }
+        
+        if (mltMipmapScale < 1.0) {
+            b_width = qRound(b_width * mltMipmapScale);
+            b_height = qRound(b_height * mltMipmapScale);
+            b_width = qMax(1, b_width);
+            b_height = qMax(1, b_height);
+        }
+    }
+
     transform.translate(rect.x, rect.y);
     opacity = rect.o;
     hasAlpha = rect.o < 1 || rect.x != 0 || rect.y != 0 || rect.w != *width || rect.h != *height
@@ -220,20 +257,9 @@ static int filter_get_image(mlt_frame frame,
     bool hqPainting = interps && strcmp(interps, "nearest") && strcmp(interps, "neighbor");
 
     // resize to rect
-    bool scaled = false;
-    QImage scaledSource;
     if (distort) {
         if (rect.w != b_width || rect.h != b_height) {
-            if (rect.w < b_width || rect.h < b_height) {
-                scaled = true;
-                scaledSource = sourceImage.scaled(qRound(rect.w),
-                                                  qRound(rect.h),
-                                                  Qt::IgnoreAspectRatio,
-                                                  hqPainting ? Qt::SmoothTransformation
-                                                             : Qt::FastTransformation);
-            } else {
-                transform.scale(rect.w / b_width, rect.h / b_height);
-            }
+            transform.scale(rect.w / b_width, rect.h / b_height);
         }
     } else {
         double scale;
@@ -241,30 +267,13 @@ static int filter_get_image(mlt_frame frame,
         if (b_dar >= resize_dar) {
             scale = rect.w / b_width;
         } else {
-            scale = rect.h / b_height * b_ar;
+            scale = rect.h / b_height;
         }
-        if (scale < 1.) {
-            // Use higher quality QImage scaling
-            scaled = true;
-            const QSize finalSize(qRound(sourceImage.width() * scale),
-                                  qRound(sourceImage.height() * scale));
-            // Center image in rect
-            transform.translate((rect.w - finalSize.width()) / 2.0,
-                                (rect.h - finalSize.height()) / 2.0);
-            // Scale
-            scaledSource = sourceImage.scaled(finalSize,
-                                              Qt::IgnoreAspectRatio,
-                                              hqPainting ? Qt::SmoothTransformation
-                                                         : Qt::FastTransformation);
-        } else {
-            // Center image in rect
-            transform.translate((rect.w - (b_width * scale)) / 2.0,
-                                (rect.h - (b_height * scale)) / 2.0);
-            if (scale > 1.) {
-                // Use QPainter scaling
-                transform.scale(scale, scale);
-            }
-        }
+        // Center image in rect
+        transform.translate((rect.w - (b_width * scale)) / 2.0,
+                            (rect.h - (b_height * scale)) / 2.0);
+        // Use QPainter scaling for everything
+        transform.scale(scale, scale);
     }
 
     uint8_t *dest_image = NULL;
@@ -281,11 +290,7 @@ static int filter_get_image(mlt_frame frame,
     painter.setOpacity(opacity);
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform, hqPainting);
     // Composite top frame
-    if (scaled) {
-        painter.drawImage(0, 0, scaledSource);
-    } else {
-        painter.drawImage(0, 0, sourceImage);
-    }
+    painter.drawImage(0, 0, sourceImage);
     // finish Qt drawing
     painter.end();
 

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -160,7 +160,6 @@ static int filter_get_image(mlt_frame frame,
     // Normalize source dimensions to consumer PAR to handle anamorphic sources
     normalize_mlt_source_size(b_ar, consumer_ar, &b_width, b_height);
 
-
     // Fix for bug #1228 and optimization.
     // Adjust requested dimension so MLT (libswscale) does the preliminary downscaling.
     // Using a step defined by MLT_QT_MIPMAP_STEP provides a tight bound to target resolution

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -158,17 +158,14 @@ static int filter_get_image(mlt_frame frame,
     }
 
     // Normalize source dimensions to consumer PAR to handle anamorphic sources
-    if (b_ar != consumer_ar && b_height > 0) {
-        b_width = qRound(b_width * b_ar / consumer_ar);
-        b_width = qMax(1, b_width);
-    }
+    normalize_mlt_source_size(b_ar, consumer_ar, &b_width, b_height);
 
-    // Apply MLT Mipmapping
+
+    // Fix for bug #1228 and optimization.
     // Adjust requested dimension so MLT (libswscale) does the preliminary downscaling.
-    // Using a step of 0.85 provides a tight bound to target resolution (maximizing quality
-    // and preventing QPainter aliasing) while keeping the requested dimensions stable
-    // across small animation increments (preventing resampling jitter).
-    double mltMipmapScale = 1.0;
+    // Using a step defined by MLT_QT_MIPMAP_STEP provides a tight bound to target resolution
+    // (maximizing quality and preventing QPainter aliasing) while keeping the requested
+    // dimensions stable across small animation increments.
     if (rect.w > 0 && rect.h > 0 && b_width > 0 && b_height > 0) {
         double scaleTarget;
         if (distort) {
@@ -181,17 +178,7 @@ static int filter_get_image(mlt_frame frame,
                 scaleTarget = rect.h / b_height;
             }
         }
-
-        while (mltMipmapScale * 0.85 >= scaleTarget && mltMipmapScale > 0.001) {
-            mltMipmapScale *= 0.85;
-        }
-
-        if (mltMipmapScale < 1.0) {
-            b_width = qRound(b_width * mltMipmapScale);
-            b_height = qRound(b_height * mltMipmapScale);
-            b_width = qMax(1, b_width);
-            b_height = qMax(1, b_height);
-        }
+        adjust_mlt_mipmap_size(scaleTarget, &b_width, &b_height);
     }
 
     transform.translate(rect.x, rect.y);

--- a/src/modules/qt/filter_qtblend.cpp
+++ b/src/modules/qt/filter_qtblend.cpp
@@ -160,6 +160,7 @@ static int filter_get_image(mlt_frame frame,
     // Normalize source dimensions to consumer PAR to handle anamorphic sources
     if (b_ar != consumer_ar && b_height > 0) {
         b_width = qRound(b_width * b_ar / consumer_ar);
+        b_width = qMax(1, b_width);
     }
 
     // Apply MLT Mipmapping

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -162,7 +162,7 @@ static int get_image(mlt_frame a_frame,
         b_height = *height;
         b_width = *width;
     }*/
-    
+
     // Normalize source dimensions to consumer PAR to handle anamorphic sources
     if (b_ar != consumer_ar && b_height > 0) {
         b_width = qRound(b_width * b_ar / consumer_ar);
@@ -189,11 +189,11 @@ static int get_image(mlt_frame a_frame,
                 }
             }
         }
-        
+
         while (mltMipmapScale * 0.85 >= scaleTarget && mltMipmapScale > 0.001) {
             mltMipmapScale *= 0.85;
         }
-        
+
         if (mltMipmapScale < 1.0) {
             b_width = qRound(b_width * mltMipmapScale);
             b_height = qRound(b_height * mltMipmapScale);
@@ -310,8 +310,7 @@ static int get_image(mlt_frame a_frame,
             }
         }
         // Center image in rect
-        transform.translate((rect.w - (b_width * scale)) / 2.0,
-                            (rect.h - (b_height * scale)) / 2.0);
+        transform.translate((rect.w - (b_width * scale)) / 2.0, (rect.h - (b_height * scale)) / 2.0);
         // Use QPainter scaling for everything
         transform.scale(scale, scale);
     }

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -162,6 +162,45 @@ static int get_image(mlt_frame a_frame,
         b_height = *height;
         b_width = *width;
     }*/
+    
+    // Normalize source dimensions to consumer PAR to handle anamorphic sources
+    if (b_ar != consumer_ar && b_height > 0) {
+        b_width = qRound(b_width * b_ar / consumer_ar);
+    }
+
+    // Apply MLT Mipmapping
+    // Adjust requested dimension so MLT (libswscale) does the preliminary downscaling.
+    double mltMipmapScale = 1.0;
+    if (rect.w > 0 && rect.h > 0 && b_width > 0 && b_height > 0) {
+        double scaleTarget;
+        if (distort) {
+            scaleTarget = qMax(rect.w / b_width, rect.h / b_height);
+        } else {
+            double resize_dar = rect.w * consumer_ar / rect.h;
+            if (b_dar >= resize_dar) {
+                scaleTarget = rect.w / b_width;
+                if (b_dar < geometry_dar) {
+                    scaleTarget *= transformScale;
+                }
+            } else {
+                scaleTarget = rect.h / b_height;
+                if (b_dar > geometry_dar) {
+                    scaleTarget *= transformScale;
+                }
+            }
+        }
+        
+        while (mltMipmapScale * 0.85 >= scaleTarget && mltMipmapScale > 0.001) {
+            mltMipmapScale *= 0.85;
+        }
+        
+        if (mltMipmapScale < 1.0) {
+            b_width = qRound(b_width * mltMipmapScale);
+            b_height = qRound(b_height * mltMipmapScale);
+            b_width = qMax(1, b_width);
+            b_height = qMax(1, b_height);
+        }
+    }
 
     if (mlt_frame_get_aspect_ratio(b_frame) == 0) {
         mlt_frame_set_aspect_ratio(b_frame, consumer_ar);
@@ -243,9 +282,6 @@ static int get_image(mlt_frame a_frame,
     if (*format != mlt_image_rgba64)
         *format = mlt_image_rgba;
 
-    bool scaled = false;
-    QImage scaledSource;
-
     // We don't do subpixel smoothing for nearest neighbour interpolation
     // so people can use that to upscale pixel art and keep the hard edges.
     char *interps = mlt_properties_get(properties, "consumer.rescale");
@@ -257,21 +293,12 @@ static int get_image(mlt_frame a_frame,
 
     if (distort) {
         if (b_width != 0 && b_height != 0) {
-            if (rect.w < b_width || rect.h < b_height) {
-                scaled = true;
-                scaledSource = topImg.scaled(qRound(rect.w),
-                                             qRound(rect.h),
-                                             Qt::IgnoreAspectRatio,
-                                             hqPainting ? Qt::SmoothTransformation
-                                                        : Qt::FastTransformation);
-            } else {
-                transform.scale(rect.w / b_width, rect.h / b_height);
-            }
+            transform.scale(rect.w / b_width, rect.h / b_height);
         }
     } else if (rect.w > 0 && rect.h > 0) {
         double resize_dar = rect.w * consumer_ar / rect.h;
         double scale;
-        if (b_dar > resize_dar) {
+        if (b_dar >= resize_dar) {
             scale = rect.w / b_width;
             if (b_dar < geometry_dar) {
                 scale *= transformScale;
@@ -282,27 +309,11 @@ static int get_image(mlt_frame a_frame,
                 scale *= transformScale;
             }
         }
-        if (scale < 1.) {
-            // Use higher quality QImage scaling
-            scaled = true;
-            const QSize finalSize(qRound(topImg.width() * scale), qRound(topImg.height() * scale));
-            // Center image in rect
-            transform.translate((rect.w - finalSize.width()) / 2.0,
-                                (rect.h - finalSize.height()) / 2.0);
-            // Scale
-            scaledSource = topImg.scaled(finalSize,
-                                         Qt::IgnoreAspectRatio,
-                                         hqPainting ? Qt::SmoothTransformation
-                                                    : Qt::FastTransformation);
-        } else {
-            // Center image in rect
-            transform.translate((rect.w - (b_width * scale)) / 2.0,
-                                (rect.h - (b_height * scale)) / 2.0);
-            if (scale > 1.) {
-                // Use QPainter scaling
-                transform.scale(scale, scale);
-            }
-        }
+        // Center image in rect
+        transform.translate((rect.w - (b_width * scale)) / 2.0,
+                            (rect.h - (b_height * scale)) / 2.0);
+        // Use QPainter scaling for everything
+        transform.scale(scale, scale);
     }
 
     // Get bottom frame
@@ -330,11 +341,7 @@ static int get_image(mlt_frame a_frame,
     painter.setOpacity(opacity);
 
     // Composite top frame
-    if (scaled) {
-        painter.drawImage(0, 0, scaledSource);
-    } else {
-        painter.drawImage(0, 0, topImg);
-    }
+    painter.drawImage(0, 0, topImg);
 
     // finish Qt drawing
     painter.end();

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -164,13 +164,13 @@ static int get_image(mlt_frame a_frame,
     }*/
 
     // Normalize source dimensions to consumer PAR to handle anamorphic sources
-    if (b_ar != consumer_ar && b_height > 0) {
-        b_width = qRound(b_width * b_ar / consumer_ar);
-    }
+    normalize_mlt_source_size(b_ar, consumer_ar, &b_width, b_height);
 
-    // Apply MLT Mipmapping
+    // Fix for bug #1228 and optimization.
     // Adjust requested dimension so MLT (libswscale) does the preliminary downscaling.
-    double mltMipmapScale = 1.0;
+    // Using a step defined by MLT_QT_MIPMAP_STEP provides a tight bound to target resolution
+    // (maximizing quality and preventing QPainter aliasing) while keeping the requested
+    // dimensions stable across small animation increments.
     if (rect.w > 0 && rect.h > 0 && b_width > 0 && b_height > 0) {
         double scaleTarget;
         if (distort) {
@@ -189,17 +189,7 @@ static int get_image(mlt_frame a_frame,
                 }
             }
         }
-
-        while (mltMipmapScale * 0.85 >= scaleTarget && mltMipmapScale > 0.001) {
-            mltMipmapScale *= 0.85;
-        }
-
-        if (mltMipmapScale < 1.0) {
-            b_width = qRound(b_width * mltMipmapScale);
-            b_height = qRound(b_height * mltMipmapScale);
-            b_width = qMax(1, b_width);
-            b_height = qMax(1, b_height);
-        }
+        adjust_mlt_mipmap_size(scaleTarget, &b_width, &b_height);
     }
 
     if (mlt_frame_get_aspect_ratio(b_frame) == 0) {

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -196,7 +196,6 @@ static int get_image(mlt_frame a_frame,
         adjust_mlt_mipmap_size(scaleTarget, &b_width, &b_height);
     }
 
-
     if (mlt_properties_get(transition_properties, "rotation")) {
         double angle
             = mlt_properties_anim_get_double(transition_properties, "rotation", position, length);

--- a/src/modules/qt/transition_qtblend.cpp
+++ b/src/modules/qt/transition_qtblend.cpp
@@ -88,6 +88,10 @@ static int get_image(mlt_frame a_frame,
         b_width = *width;
         b_height = *height;
     }
+    // Special case - aspect_ratio = 0
+    if (mlt_frame_get_aspect_ratio(b_frame) == 0) {
+        mlt_frame_set_aspect_ratio(b_frame, consumer_ar);
+    }
     double b_ar = mlt_frame_get_aspect_ratio(b_frame);
     double b_dar = b_ar * b_width / b_height;
     double geometry_dar = consumer_ar * normalized_width / normalized_height;
@@ -192,9 +196,6 @@ static int get_image(mlt_frame a_frame,
         adjust_mlt_mipmap_size(scaleTarget, &b_width, &b_height);
     }
 
-    if (mlt_frame_get_aspect_ratio(b_frame) == 0) {
-        mlt_frame_set_aspect_ratio(b_frame, consumer_ar);
-    }
 
     if (mlt_properties_get(transition_properties, "rotation")) {
         double angle


### PR DESCRIPTION
A previous commit (`fe9ab9104beeef87c13f9e80ca1914276e0d4d1a`) introduced `QImage::scaled` to resolve 'awful' output when `QPainter` downscales significantly. 

Whilst this significantly improves the quality of the output image, also cause continuous animations (e.g., pan/zoom) to jerk in some circumstances (in my case, the original image is very large and the animation is very slow). See bug report #1228 for some examples.
This may be caused by an internal behaviour of `QPainter` which is disabled if it is used with scaling.

This patch attempts to solve the issue by using a mipmap: we calculate a `0.85` target (this 'magic number' is based on a series of tests using very large images, in order to maintain both quality and smoothness). The remaining scaling is handled by `QPainter`.

Also, instead of using `QImage` for downscaling, we request MLT a pre-downscaled frame directly from `mlt_frame_get_image`.
This is _at very least 2x_ faster and far less memory-consuming than `QImage`, whilst maintaining good output quality when properly configured (for example, by choosing Lanczos for interpolation in Kdenlive export window, but in my tests even bilinear interpolation doesn’t cause the problems I noticed with MLT 7.36)

The following are minor corrections: 

- normalize anamorphic source dimensions relative to the consumer PAR instead of use `* b_ar` multiplier.
- aspect ratio conditional operator (`>`) was synced to (`>=`) across both transition_qtblend and filter_qtblend.