### PR TITLE
melt: skip Qt preflight for XML-only consumers

### DIFF
--- a/src/melt/melt.c
+++ b/src/melt/melt.c
@@ -284,6 +284,13 @@ static mlt_consumer create_consumer(mlt_profile profile, char *id)
     return consumer;
 }
 
+static int consumer_is_xml(mlt_consumer consumer)
+{
+    mlt_properties properties = consumer ? MLT_CONSUMER_PROPERTIES(consumer) : NULL;
+    const char *service = properties ? mlt_properties_get(properties, "mlt_service") : NULL;
+    return service && !strcmp(service, "xml");
+}
+
 static int load_consumer(mlt_consumer *consumer, mlt_profile profile, int argc, char **argv)
 {
     int i;
@@ -955,11 +962,13 @@ int main(int argc, char **argv)
     // Look for the consumer option to load profile settings from consumer properties
     backup_profile = mlt_profile_clone(profile);
 
-    // Try to initialize QApplication on the main thread to prevent crash
-    mlt_filter_close(mlt_factory_filter(profile, "qtcrop", NULL));
-
     if (load_consumer(&consumer, profile, argc, argv) != EXIT_SUCCESS)
         return error;
+
+    // The XML consumer serializes the graph and should not instantiate Qt filters here.
+    // Other paths keep the main-thread Qt preflight for filters used during rendering.
+    if (!consumer_is_xml(consumer))
+        mlt_filter_close(mlt_factory_filter(profile, "qtcrop", NULL));
 
     // If the consumer changed the profile, then it is explicit.
     if (backup_profile && !profile->is_explicit


### PR DESCRIPTION
## Summary

Move melt's Qt filter preflight until after the requested consumer is known, and skip it for the direct `xml` consumer.

The `xml` consumer serializes the MLT service graph instead of rendering frames, so `melt <input> -consumer xml` should not eagerly instantiate `qtcrop` only to pre-initialize Qt. Rendering and default/unknown consumer paths still keep the existing main-thread Qt preflight.

This was motivated by an observed Fixer-captured local `melt-7` abort whose stack reached `filter_qtcrop_init` through the Qt preflight while an XML consumer command was involved. I have not independently reproduced the exact original crash from a clean MLT checkout, so this should be read as a narrow cleanup for a valid XML serialization path rather than a proven broad crash fix.

## Recovered context

The command came from a small generated Kdenlive workflow for a personal drone-footage edit. The local project generator was using `melt ... -consumer xml` as part of validating/inspecting generated `.kdenlive` projects.

After digging into that project, the strongest project-side issue I found was malformed Kdenlive structure: timeline-only `hold`/`timewarp`/route-title producers were originally being given bin clip identity (`kdenlive:id`, `kdenlive:folderid`, `kdenlive:clip_type`, `kdenlive:clipname`) and some timeline entries also carried `kdenlive:id`. That made Kdenlive treat internal timeline fragments as bin clips, matching the later `Clip Problems` / invalid preview-producer symptoms. The project generator has since been fixed and linted for that.

That project-side problem is separate from this MLT change. I narrowed this PR accordingly and removed the earlier extra `multi`/`qglsl` handling.

## Validation

- Configured and built a reduced local tree with Qt6 and XML enabled:

  `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DMOD_AVFORMAT=OFF -DMOD_QT6=ON -DMOD_XML=ON -DMOD_KDENLIVE=ON -DMOD_RESAMPLE=OFF -DMOD_RUBBERBAND=OFF -DUSE_LV2=OFF -DUSE_VST2=OFF -DMOD_NORMALIZE=OFF -DMOD_GLAXNIMATE_QT6=OFF -DMOD_MOVIT=OFF -DMOD_OPENCV=OFF -DMOD_DECKLINK=OFF -DMOD_NDI=OFF -DMOD_FREI0R=OFF -DMOD_GDK=OFF -DMOD_JACKRACK=OFF -DMOD_OLDFILM=OFF -DMOD_OPENFX=OFF -DMOD_PLUSGPL=OFF -DMOD_RTAUDIO=OFF -DMOD_SDL2=OFF -DMOD_SOX=OFF -DMOD_VIDSTAB=OFF -DMOD_VORBIS=OFF -DMOD_XINE=OFF`
- `cmake --build build -j$(nproc)`
- `MLT_REPOSITORY=$PWD/build/out/lib/mlt MLT_DATA=$PWD/build/out/share/mlt QT_QPA_PLATFORM=offscreen build/out/bin/melt color:red out=1 -consumer xml` produced XML successfully
- `MLT_REPOSITORY=$PWD/build/out/lib/mlt MLT_DATA=$PWD/build/out/share/mlt QT_QPA_PLATFORM=offscreen build/out/bin/melt color:red -consumer null real_time=-1 terminate_on_pause=1` completed successfully
- `git diff --check`

A full avformat build was not possible on this machine because FFmpeg development packages were unavailable, so the exact DJI MP4 command was not rerun against this local MLT checkout.
