### PR TITLE
xml: resolve relative root against document

### DIFF
--- a/src/modules/xml/producer_xml.c
+++ b/src/modules/xml/producer_xml.c
@@ -246,6 +246,27 @@ static inline int is_known_prefix(const char *resource)
     return 0;
 }
 
+static inline int is_absolute_path(const char *path)
+{
+    int drive_letter = strlen(path) > 3 && path[1] == ':' && (path[2] == '/' || path[2] == '\\');
+    return path[0] == '/' || path[0] == '\\' || drive_letter;
+}
+
+static void set_root_property(deserialise_context context, const char *root)
+{
+    const char *document_root = mlt_properties_get(context->producer_map, "root");
+
+    if (root && root[0] && document_root && document_root[0] && !is_absolute_path(root)
+        && !strchr(root, ':')) {
+        char *qualified = malloc(strlen(document_root) + strlen(root) + 2);
+        sprintf(qualified, "%s/%s", document_root, root);
+        mlt_properties_set_string(context->producer_map, "root", qualified);
+        free(qualified);
+    } else {
+        mlt_properties_set_string(context->producer_map, "root", root);
+    }
+}
+
 // Prepend the property value with the document root
 static inline void qualify_property(deserialise_context context,
                                     mlt_properties properties,
@@ -265,10 +286,7 @@ static inline void qualify_property(deserialise_context context,
         // Qualify file name properties
         if (root != NULL && strcmp(root, "")) {
             char *full_resource = calloc(1, n);
-            int drive_letter = strlen(resource) > 3 && resource[1] == ':'
-                               && (resource[2] == '/' || resource[2] == '\\');
-            if (resource[0] != '/' && resource[0] != '\\' && !drive_letter
-                && !is_known_prefix(resource)) {
+            if (!is_absolute_path(resource) && !is_known_prefix(resource)) {
                 if (prefix_size)
                     strncat(full_resource, resource_orig, prefix_size);
                 strcat(full_resource, root);
@@ -1631,10 +1649,14 @@ static void on_start_element(void *ctx, const xmlChar *name, const xmlChar **att
         on_start_consumer(context, name, atts);
     else if (xmlStrcmp(name, _x("westley")) == 0 || xmlStrcmp(name, _x("mlt")) == 0) {
         for (; atts != NULL && *atts != NULL; atts += 2) {
-            if (xmlStrcmp(atts[0], _x("LC_NUMERIC")))
+            if (xmlStrcmp(atts[0], _x("LC_NUMERIC")) == 0) {
+                if (!context->lc_numeric)
+                    context->lc_numeric = strdup(_s(atts[1]));
+            } else if (xmlStrcmp(atts[0], _x("root")) == 0) {
+                set_root_property(context, _s(atts[1]));
+            } else {
                 mlt_properties_set_string(context->producer_map, _s(atts[0]), _s(atts[1]));
-            else if (!context->lc_numeric)
-                context->lc_numeric = strdup(_s(atts[1]));
+            }
         }
     }
 }

--- a/src/tests/test_mod_avformat/test_mod_avformat.cpp
+++ b/src/tests/test_mod_avformat/test_mod_avformat.cpp
@@ -16,6 +16,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
 #include <QtTest>
 
 #include <mlt++/Mlt.h>
@@ -41,6 +44,33 @@ private Q_SLOTS:
     {
         Profile profile;
         Producer producer(profile, "avformat-novalidate:blue.mpg");
+    }
+
+    void XmlRelativeRootIsRelativeToDocument()
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+        QVERIFY(QDir(tempDir.path()).mkpath("subdir"));
+
+        const QString xmlPath = tempDir.filePath("subdir/project.mlt");
+        QFile xmlFile(xmlPath);
+        QVERIFY(xmlFile.open(QIODevice::WriteOnly | QIODevice::Text));
+        xmlFile.write(R"(<?xml version="1.0"?>
+<mlt root=".">
+  <producer id="producer0">
+    <property name="mlt_service">avformat-novalidate</property>
+    <property name="resource">../media.mp4</property>
+  </producer>
+</mlt>
+)");
+        xmlFile.close();
+
+        Profile profile;
+        Producer producer(profile, "xml", xmlPath.toUtf8().constData());
+
+        QVERIFY(producer.is_valid());
+        QCOMPARE(QString::fromUtf8(producer.get("resource")),
+                 QDir(tempDir.filePath("subdir")).filePath("./../media.mp4"));
     }
 };
 


### PR DESCRIPTION
## Summary

Resolve a relative `<mlt root="...">` against the directory of the XML document being parsed, instead of leaving it relative to the process current working directory.

This matters for portable MLT/Kdenlive projects opened from a GUI or another caller whose cwd is unrelated to the project file. For example, if `/tmp/project/output/repro.kdenlive` contains `root="."` and a media resource `../media.mp4`, the resource should resolve under `/tmp/project/output`, not under the caller's cwd.

The patch also reuses the same absolute-path helper for normal resource qualification and adds an avformat XML regression test using `avformat-novalidate`.

## Reproducer

I reproduced this with a Kdenlive/MLT project shaped like this:

- XML file: `/tmp/mlt-root-repro/output/repro.kdenlive`
- XML root: `<mlt root=".">`
- media resources: `../DJI_0884.MP4`, `3.400000:../DJI_0884.MP4`, and `../assets/audio/...`
- command launched from `/tmp`, deliberately not from the project directory

Current packaged MLT 7.38.0 resolves the paths against cwd and logs failures like:

```text
[producer_xml] failed to load producer "./../DJI_0884.MP4"
[producer_xml] failed to load producer "3.400000:./../DJI_0884.MP4"
```

In that repro I got 28 `failed to load producer` lines.

With this patch and the same system modules:

```sh
MLT_REPOSITORY=/tmp/mlt-root-repro/modules \
MLT_DATA=/usr/share/mlt-7 \
build/out/bin/melt /tmp/mlt-root-repro/output/repro.kdenlive \
  -consumer xml:/tmp/mlt-root-repro/new.xml
```

The command exits 0 and the same grep finds 0 `failed to load producer` lines. The resolved resources go through paths such as `/tmp/mlt-root-repro/output/./../DJI_0884.MP4`, which is the document-relative location.

## Validation

- `clang-format -i src/modules/xml/producer_xml.c src/tests/test_mod_avformat/test_mod_avformat.cpp`
- `cmake --build build -j$(nproc)`
- `git diff --check`
- Manual repro above: old packaged MLT fails to load the document-relative media; patched `libmltxml.so` resolves it correctly.

I could not run the new `test_mod_avformat` test locally because this machine lacks the FFmpeg development packages needed to configure `MOD_AVFORMAT=ON` in a fresh test build. The runtime repro used the patched XML module together with the system avformat module.
