### PR TITLE
Add audio and image format fields to metadata

### DIFF
--- a/src/framework/metaschema.yaml
+++ b/src/framework/metaschema.yaml
@@ -1,5 +1,5 @@
 --- # A metadata schema in Kwalify: http://www.kuwata-lab.com/kwalify/
-# Version: 7.1
+# Version: 7.2
 type: map
 mapping:
   "schema_version": # This should match the version comment above
@@ -58,6 +58,36 @@ mapping:
     type: seq
     sequence:
       - type: str # Can be a sentence or paragraph, preferably not a hyperlink
+  "audio_formats": # The audio formats the service accepts or produces
+    type: seq
+    required: no
+    sequence:
+      - type: str
+        enum:
+          - none
+          - s16
+          - s32
+          - s32le
+          - float
+          - f32le
+          - u8
+  "image_formats": # The image formats the service accepts or produces
+    type: seq
+    required: no
+    sequence:
+      - type: str
+        enum:
+          - none
+          - rgb
+          - rgba
+          - yuv422
+          - yuv420p
+          - glsl
+          - opengl_texture
+          - yuv422p16
+          - yuv420p10
+          - yuv444p10
+          - rgba64
   "parameters": # A list of all of the options for the service
     type: seq
     sequence:

--- a/src/modules/avformat/CMakeLists.txt
+++ b/src/modules/avformat/CMakeLists.txt
@@ -70,6 +70,7 @@ install(FILES
   link_swresample.yml
   producer_avformat.yml
   producer_avformat-novalidate.yml
+  filter_info.yml
   resolution_scale.yml
   blacklist.txt
   yuv_only.txt

--- a/src/modules/avformat/consumer_avformat.yml
+++ b/src/modules/avformat/consumer_avformat.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: consumer
 identifier: avformat
 title: FFmpeg Output
-version: 6
+version: 7
 copyright: Copyright (C) 2003-2019 Meltytech, LLC
 license: LGPL
 language: en
@@ -33,6 +33,22 @@ notes: >
   Please note that the exact options depend on the version of libavformat and
   libavcodec on your system.
 
+audio_formats:
+  - s16
+  - s32
+  - s32le
+  - float
+  - f32le
+  - u8
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv422p16
+  - yuv444p10
 parameters:
   - identifier: target
     argument: yes

--- a/src/modules/avformat/factory.c
+++ b/src/modules/avformat/factory.c
@@ -260,6 +260,19 @@ static void add_parameters(mlt_properties params,
     }
 }
 
+static void copy_list_property(mlt_properties dest, const char *name, mlt_properties source)
+{
+    if (!dest || !name || !source || !mlt_properties_count(source))
+        return;
+
+    mlt_properties list = mlt_properties_new();
+    if (!list)
+        return;
+
+    mlt_properties_inherit(list, source);
+    mlt_properties_set_data(dest, name, list, 0, (mlt_destructor) mlt_properties_close, NULL);
+}
+
 static mlt_properties avformat_metadata(mlt_service_type type, const char *id, void *data)
 {
     char file[PATH_MAX];
@@ -331,11 +344,14 @@ static mlt_properties avformat_metadata(mlt_service_type type, const char *id, v
 static mlt_properties avfilter_metadata(mlt_service_type type, const char *id, void *name)
 {
     AVFilter *f = (AVFilter *) avfilter_get_by_name(name);
+    mlt_properties filter_info = mlt_properties_get_data(mlt_global_properties(),
+                                                         "avfilter.filter_info",
+                                                         NULL);
     if (!f)
         return NULL;
 
     mlt_properties metadata = mlt_properties_new();
-    mlt_properties_set_double(metadata, "schema_version", 0.3);
+    mlt_properties_set_double(metadata, "schema_version", 7.2);
     mlt_properties_set(metadata, "title", f->name);
     mlt_properties_set(metadata, "version", LIBAVFILTER_IDENT);
     mlt_properties_set(metadata, "identifier", id);
@@ -362,7 +378,17 @@ static mlt_properties avfilter_metadata(mlt_service_type type, const char *id, v
     if (avfilter_pad_get_type(f->inputs, 0) == AVMEDIA_TYPE_AUDIO) {
         mlt_properties_set(tags, "0", "Audio");
     }
-
+    if (filter_info) {
+        mlt_properties info = mlt_properties_get_data(filter_info, f->name, NULL);
+        if (info) {
+            copy_list_property(metadata,
+                               "audio_formats",
+                               mlt_properties_get_data(info, "audio_formats", NULL));
+            copy_list_property(metadata,
+                               "image_formats",
+                               mlt_properties_get_data(info, "image_formats", NULL));
+        }
+    }
     if (f->priv_class) {
         mlt_properties params = mlt_properties_new();
         mlt_properties_set_data(metadata,
@@ -484,6 +510,15 @@ MLTAVFORMAT_EXPORT MLT_REPOSITORY
     mlt_properties_set_data(mlt_global_properties(),
                             "avfilter.yuv_only",
                             mlt_properties_load(dirname),
+                            0,
+                            (mlt_destructor) mlt_properties_close,
+                            NULL);
+
+    // Load per-filter format and metadata info into global properties.
+    snprintf(dirname, PATH_MAX, "%s/avformat/filter_info.yml", mlt_environment("MLT_DATA"));
+    mlt_properties_set_data(mlt_global_properties(),
+                            "avfilter.filter_info",
+                            mlt_properties_parse_yaml(dirname),
                             0,
                             (mlt_destructor) mlt_properties_close,
                             NULL);

--- a/src/modules/avformat/filter_avcolour_space.yml
+++ b/src/modules/avformat/filter_avcolour_space.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: avcolor_space
 title: FFmpeg Image Converter
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -14,3 +14,12 @@ description: Converts the colorspace and pixel format.
 notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it if it is available to set the convert_image function pointer on frames.
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - yuv422p16
+  - yuv420p10
+  - yuv444p10
+  - rgba64

--- a/src/modules/avformat/filter_avdeinterlace.yml
+++ b/src/modules/avformat/filter_avdeinterlace.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: avdeinterlace
 title: Legacy FFmpeg Deinterlacer (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,3 +15,5 @@ notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it if it is available to set deinterlace interlaced input when the
   consumer or profile is set to progressive.
+image_formats:
+  - yuv422

--- a/src/modules/avformat/filter_info.yml
+++ b/src/modules/avformat/filter_info.yml
@@ -1,0 +1,2180 @@
+# FFmpeg filter supported MLT formats
+# Filters without known formats are placeholders encoded as "" (not empty maps).
+# Filters marked as 'metadata only' process metadata only, passing data unchanged.
+# Filters marked as 'format agnostic' accept all formats dynamically with no static restrictions.
+# Filters marked as 'hardware only' accept only hardware/GPU formats not directly supported by MLT.
+
+aap:
+  audio_formats:
+    - f32le
+abench: ""  # metadata only
+acompressor:
+  audio_formats:
+    - f32le
+acontrast:
+  audio_formats:
+    - f32le
+acopy: ""  # metadata only
+acrossfade:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+acrossover:
+  audio_formats:
+    - f32le
+acrusher:
+  audio_formats:
+    - f32le
+acue: ""  # metadata only
+addroi: ""  # metadata only
+adeclick:
+  audio_formats:
+    - f32le
+adeclip:
+  audio_formats:
+    - f32le
+adecorrelate:
+  audio_formats:
+    - f32le
+adelay:
+  audio_formats:
+    - u8
+    - s16
+    - s32le
+    - f32le
+adenorm:
+  audio_formats:
+    - f32le
+aderivative:
+  audio_formats:
+    - s16
+    - f32le
+    - s32le
+adrc:
+  audio_formats:
+    - f32le
+adynamicequalizer:
+  audio_formats:
+    - f32le
+adynamicsmooth:
+  audio_formats:
+    - f32le
+aecho:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+aemphasis:
+  audio_formats:
+    - f32le
+aeval:
+  audio_formats:
+    - f32le
+aexciter:
+  audio_formats:
+    - f32le
+afade:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+afftdn:
+  audio_formats:
+    - f32le
+afftfilt:
+  audio_formats:
+    - f32le
+afir:
+  audio_formats:
+    - f32le
+aformat: ""  # metadata only
+afreqshift:
+  audio_formats:
+    - f32le
+afwtdn:
+  audio_formats:
+    - f32le
+agate:
+  audio_formats:
+    - f32le
+aiir:
+  image_formats:
+    - rgb
+aintegral:
+  audio_formats:
+    - s16
+    - f32le
+    - s32le
+ainterleave: ""  # format agnostic
+alatency: ""  # format agnostic
+alimiter:
+  audio_formats:
+    - f32le
+allpass:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+aloop: ""  # format agnostic
+alphaextract:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+alphamerge:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgba
+    - rgb
+amerge:
+  audio_formats:
+    - u8
+    - s16
+    - s32le
+    - f32le
+ametadata: ""  # format agnostic
+amix:
+  audio_formats:
+    - f32le
+amplify:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+amultiply:
+  audio_formats:
+    - f32le
+anequalizer:
+  audio_formats:
+    - f32le
+  image_formats:
+    - rgba
+anlmdn:
+  audio_formats:
+    - f32le
+anlmf:
+  audio_formats:
+    - f32le
+anlms:
+  audio_formats:
+    - f32le
+anull: ""  # metadata only
+apad: ""  # format agnostic
+aperms: ""  # format agnostic
+aphaser:
+  audio_formats:
+    - f32le
+    - s32le
+    - s16
+aphaseshift:
+  audio_formats:
+    - f32le
+apsnr: ""  # metadata only
+apsyclip:
+  audio_formats:
+    - f32le
+apulsator:
+  audio_formats:
+    - f32le
+arealtime: ""  # metadata only
+aresample: ""  # format agnostic
+areverse: ""  # format agnostic
+arls:
+  audio_formats:
+    - f32le
+arnndn:
+  audio_formats:
+    - f32le
+asdr: ""  # metadata only
+asegment: ""  # format agnostic
+aselect:
+  image_formats:
+    - rgb
+    - rgba
+    - yuv420p
+    - yuv422
+    - yuv420p10
+asendcmd: ""  # metadata only
+asetnsamples: ""  # format agnostic
+asetpts: ""  # metadata only
+asetrate: ""  # metadata only
+asettb: ""  # metadata only
+ashowinfo: ""  # metadata only
+asidedata: ""  # format agnostic
+asisdr: ""  # metadata only
+asoftclip:
+  audio_formats:
+    - f32le
+aspectralstats:
+  audio_formats:
+    - f32le
+asplit: ""  # format agnostic
+asr: ""  # metadata only
+ass: ""  # format agnostic
+astats:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+astreamselect: ""  # format agnostic
+asubboost:
+  audio_formats:
+    - f32le
+asubcut:
+  audio_formats:
+    - f32le
+asupercut:
+  audio_formats:
+    - f32le
+asuperpass:
+  audio_formats:
+    - f32le
+asuperstop:
+  audio_formats:
+    - f32le
+atadenoise:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+atempo:
+  audio_formats:
+    - u8
+    - s16
+    - s32le
+    - f32le
+atilt:
+  audio_formats:
+    - f32le
+atrim: ""  # metadata only
+avgblur:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+avgblur_opencl: ""  # hardware only
+avgblur_vulkan: ""  # hardware only
+axcorrelate:
+  audio_formats:
+    - f32le
+azmq: ""  # format agnostic
+backgroundkey:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+    - rgba
+    - rgba64
+bandpass:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+bandreject:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+bass:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+bbox:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+bench: ""  # metadata only
+bilateral:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+bilateral_cuda:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+    - yuv444p10
+biquad:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+bitplanenoise:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgb
+    - rgba64
+blackdetect:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv422p16
+    - yuv420p10
+    - rgb
+    - rgba64
+blackdetect_vulkan: ""  # hardware only
+blackframe: ""  # metadata only
+blend:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+    - yuv420p10
+    - yuv422p16
+    - rgba64
+blend_vulkan: ""  # hardware only
+blockdetect: ""  # metadata only
+blurdetect: ""  # metadata only
+bm3d:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+boxblur: ""  # format agnostic
+boxblur_opencl: ""  # hardware only
+bs2b:
+  audio_formats:
+    - u8
+    - s16
+    - s32le
+    - f32le
+bwdif:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+bwdif_cuda: ""  # hardware only
+bwdif_vulkan: ""  # hardware only
+cas:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+ccrepack: ""  # format agnostic
+channelmap: ""  # format agnostic
+channelsplit: ""  # format agnostic
+chorus:
+  audio_formats:
+    - f32le
+chromaber_vulkan: ""  # hardware only
+chromahold:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+chromakey:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+chromakey_cuda:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+chromanr:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+chromashift:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba
+    - rgba64
+ciescope:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+codecview:
+  image_formats:
+    - yuv420p
+colorbalance:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+colorchannelmixer:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+colorcontrast:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+colorcorrect:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+colordetect: ""  # format agnostic
+colorhold:
+  image_formats:
+    - rgba
+    - rgba64
+colorize:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+colorkey:
+  image_formats:
+    - rgba
+    - rgba64
+colorkey_opencl: ""  # hardware only
+colorlevels:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+colormap:
+  image_formats:
+    - rgba64
+colormatrix:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+colorspace:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+colorspace_cuda:
+  image_formats:
+    - yuv420p10
+    - yuv420p
+    - yuv444p10
+colortemperature:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+compand:
+  audio_formats:
+    - f32le
+compensationdelay:
+  audio_formats:
+    - f32le
+convolution:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+convolution_opencl: ""  # hardware only
+convolve:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+copy: ""  # metadata only
+coreimage: ""  # hardware only
+corr:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv444p10
+    - yuv422
+    - rgba
+cover_rect:
+  image_formats:
+    - yuv420p
+crop: ""  # format agnostic
+cropdetect:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - rgb
+    - yuv420p10
+    - yuv422p16
+    - rgba
+crossfeed:
+  audio_formats:
+    - f32le
+crystalizer:
+  audio_formats:
+    - f32le
+cue: ""  # metadata only
+curves:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+datascope: ""  # format agnostic
+dblur:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+dcshift:
+  audio_formats:
+    - s32le
+dctdnoiz:
+  image_formats:
+    - rgb
+deband:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv420p10
+    - yuv422p16
+    - rgba
+deblock:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+decimate:
+  image_formats:
+    - yuv420p10
+    - yuv420p
+    - yuv444p10
+    - yuv422
+    - rgb
+    - rgba64
+deconvolve:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+dedot:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+deesser:
+  audio_formats:
+    - f32le
+deflate:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+deflicker:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+deinterlace_qsv: ""  # hardware only
+deinterlace_vaapi: ""  # format agnostic
+dejudder: ""  # format agnostic
+delogo:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+denoise_vaapi: ""  # format agnostic
+derain:
+  image_formats:
+    - rgb
+deshake:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+deshake_opencl: ""  # hardware only
+despill:
+  image_formats:
+    - rgba
+detelecine: ""  # format agnostic
+dialoguenhance:
+  audio_formats:
+    - f32le
+dilation:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+dilation_opencl: ""  # hardware only
+displace:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+dnn_classify:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+dnn_detect:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+dnn_processing:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+doubleweave: ""  # format agnostic
+drawbox:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+drawbox_vaapi: ""  # format agnostic
+drawgraph:
+  image_formats:
+    - rgba
+drawgrid:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+drawtext: ""  # format agnostic
+drmeter: ""  # metadata only
+dynaudnorm:
+  audio_formats:
+    - f32le
+earwax:
+  audio_formats:
+    - s16
+ebur128:
+  audio_formats:
+    - f32le
+  image_formats:
+    - rgb
+edgedetect:
+  image_formats:
+    - rgb
+    - yuv420p
+    - yuv422
+    - yuv444p10
+elbg:
+  image_formats:
+    - rgba
+    - rgb
+entropy:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgb
+    - rgba64
+epx:
+  image_formats:
+    - rgba
+eq:
+  image_formats:
+    - rgb
+    - yuv444p10
+    - yuv420p
+    - yuv422
+equalizer:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+erosion:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+erosion_opencl: ""  # hardware only
+estdif:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+exposure:
+  image_formats:
+    - rgba64
+extractplanes:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+extrastereo:
+  audio_formats:
+    - f32le
+fade:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+    - yuv420p10
+    - yuv422p16
+feedback: ""  # format agnostic
+fftdnoiz:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+fftfilt:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+field: ""  # format agnostic
+fieldhint: ""  # format agnostic
+fieldmatch:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv420p10
+    - yuv422p16
+fieldorder: ""  # format agnostic
+fillborders:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+find_rect: ""  # metadata only
+firequalizer:
+  audio_formats:
+    - f32le
+flanger:
+  audio_formats:
+    - f32le
+flip_vulkan: ""  # hardware only
+floodfill:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - rgba
+format: ""  # metadata only
+fps: ""  # metadata only
+framepack:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+framerate:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+framestep: ""  # format agnostic
+freezedetect: ""  # metadata only
+freezeframes: ""  # format agnostic
+frei0r:
+  image_formats:
+    - rgba
+fspp:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+fsync: ""  # metadata only
+gblur:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+gblur_vulkan: ""  # hardware only
+geq:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - yuv422p16
+    - yuv420p10
+    - rgba64
+    - rgba
+gradfun:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - rgb
+    - yuv422
+graphmonitor:
+  image_formats:
+    - rgba
+grayworld:
+  image_formats:
+    - rgba64
+greyedge:
+  image_formats:
+    - rgb
+guided:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+haas:
+  audio_formats:
+    - f32le
+haldclut:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+hdcd:
+  audio_formats:
+    - s16
+    - s32le
+headphone:
+  audio_formats:
+    - f32le
+hflip: ""  # format agnostic
+hflip_vulkan: ""  # hardware only
+highpass:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+highshelf:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+histeq:
+  image_formats:
+    - rgba
+    - rgb
+histogram:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+    - rgba
+    - rgb
+    - rgba64
+hqdn3d:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+hqx: ""  # hardware only
+hstack: ""  # format agnostic
+hstack_qsv: ""  # hardware only
+hstack_vaapi: ""  # hardware only
+hsvhold:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+hsvkey:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+hue:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+huesaturation:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+hwdownload: ""  # format agnostic
+hwmap: ""  # format agnostic
+hwupload: ""  # format agnostic
+hwupload_cuda:
+  image_formats:
+    - yuv420p10
+    - yuv420p
+    - yuv444p10
+hysteresis:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+iccdetect: ""  # metadata only
+iccgen: ""  # metadata only
+identity:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv444p10
+    - yuv422
+    - rgba
+idet: ""  # metadata only
+il: ""  # format agnostic
+inflate:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+interlace:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+    - rgb
+interlace_vulkan: ""  # hardware only
+interleave: ""  # format agnostic
+join: ""  # format agnostic
+kerndeint:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - rgba
+    - rgb
+kirsch:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+ladspa:
+  audio_formats:
+    - f32le
+lagfun:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+latency: ""  # format agnostic
+lcevc:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+    - rgb
+    - rgba64
+lenscorrection:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+lensfun:
+  image_formats:
+    - rgb
+libplacebo: ""  # format agnostic
+libvmaf:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+libvmaf_cuda:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+limitdiff:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+limiter:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+loop: ""  # format agnostic
+loudnorm:
+  audio_formats:
+    - f32le
+lowpass:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+lowshelf:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+lumakey:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+lut:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgba
+    - rgb
+    - rgba64
+lut1d:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+lut2:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+lut3d:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+lutrgb:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgba
+    - rgb
+    - rgba64
+lutyuv:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgba
+    - rgb
+    - rgba64
+lv2:
+  audio_formats:
+    - f32le
+maskedclamp:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+maskedmax:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+maskedmerge:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+maskedmin:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+maskedthreshold:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+maskfun:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+mcdeint:
+  image_formats:
+    - yuv420p
+    - yuv444p10
+mcompand:
+  audio_formats:
+    - f32le
+median:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+mergeplanes: ""  # format agnostic
+mestimate: ""  # metadata only
+metadata: ""  # format agnostic
+midequalizer:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+minterpolate:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+mix: ""  # format agnostic
+monochrome:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+morpho:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+mpdecimate:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+msad:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv444p10
+    - yuv422
+    - rgba
+multiply:
+  image_formats:
+    - rgba64
+negate:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgba
+    - rgb
+    - rgba64
+nlmeans:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+nlmeans_opencl:
+  image_formats:
+    - yuv420p
+    - yuv444p10
+    - rgb
+nlmeans_vulkan: ""  # hardware only
+nnedi:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgba
+    - yuv420p10
+    - yuv422p16
+noformat: ""  # metadata only
+noise: ""  # format agnostic
+normalize:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+null: ""  # metadata only
+ocr: ""  # metadata only
+ocv:
+  image_formats:
+    - rgb
+    - rgba
+oscilloscope: ""  # format agnostic
+overlay:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+    - rgba
+    - rgb
+overlay_cuda:
+  image_formats:
+    - yuv420p10
+    - yuv420p
+overlay_opencl: ""  # hardware only
+overlay_qsv:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+    - yuv422
+overlay_vaapi: ""  # hardware only
+overlay_vulkan: ""  # hardware only
+owdenoise:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv420p10
+    - yuv422p16
+pad: ""  # format agnostic
+pad_cuda:
+  image_formats:
+    - yuv420p
+    - yuv444p10
+    - yuv420p10
+pad_opencl: ""  # hardware only
+pad_vaapi: ""  # format agnostic
+palettegen: ""  # hardware only
+paletteuse:
+  image_formats:
+    - rgba
+pan: ""  # format agnostic
+perms: ""  # format agnostic
+perspective:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+phase:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+photosensitivity:
+  image_formats:
+    - rgb
+pixdesctest: ""  # format agnostic
+pixelize:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+pixscope: ""  # format agnostic
+pp7:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+premultiply:
+  image_formats:
+    - yuv444p10
+    - rgb
+    - rgba64
+    - rgba
+prewitt:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+prewitt_opencl: ""  # hardware only
+procamp_vaapi: ""  # format agnostic
+program_opencl: ""  # hardware only
+pseudocolor:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - rgba
+    - yuv422p16
+    - yuv420p10
+psnr:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv444p10
+    - yuv422
+    - rgba
+pullup:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+qp: ""  # format agnostic
+qrencode: ""  # format agnostic
+quirc:
+  image_formats:
+    - rgb
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+random: ""  # format agnostic
+readeia608:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+readvitc: ""  # metadata only
+realtime: ""  # metadata only
+remap:
+  image_formats:
+    - yuv444p10
+    - rgb
+    - rgba
+    - rgba64
+remap_opencl: ""  # hardware only
+removegrain:
+  image_formats:
+    - rgb
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - rgba
+removelogo:
+  image_formats:
+    - yuv420p
+repeatfields:
+  image_formats:
+    - rgb
+    - yuv444p10
+    - yuv420p
+    - yuv422
+replaygain: ""  # metadata only
+reverse: ""  # format agnostic
+rgbashift:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba
+    - rgba64
+roberts:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+roberts_opencl: ""  # hardware only
+rotate:
+  image_formats:
+    - rgb
+    - rgba
+    - yuv444p10
+    - yuv420p
+    - yuv420p10
+rubberband:
+  audio_formats:
+    - f32le
+sab:
+  image_formats:
+    - yuv420p
+    - yuv444p10
+    - yuv422
+scale: ""  # format agnostic
+scale2ref: ""  # format agnostic
+scale2ref_npp:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+    - yuv444p10
+scale_cuda:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+    - yuv444p10
+scale_d3d11: ""  # hardware only
+scale_npp:
+  image_formats:
+    - yuv420p
+    - yuv420p10
+    - yuv444p10
+scale_qsv: ""  # hardware only
+scale_vaapi: ""  # format agnostic
+scale_vt: ""  # hardware only
+scale_vulkan: ""  # hardware only
+scdet: ""  # metadata only
+scdet_vulkan: ""  # hardware only
+scharr:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+scroll:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+segment: ""  # format agnostic
+select:
+  image_formats:
+    - rgb
+    - rgba
+    - yuv420p
+    - yuv422
+    - yuv420p10
+selectivecolor:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+sendcmd: ""  # metadata only
+separatefields: ""  # format agnostic
+setdar: ""  # metadata only
+setfield: ""  # metadata only
+setparams: ""  # metadata only
+setpts: ""  # metadata only
+setrange: ""  # metadata only
+setsar: ""  # metadata only
+settb: ""  # metadata only
+sharpen_npp:
+  image_formats:
+    - yuv420p
+    - yuv444p10
+sharpness_vaapi: ""  # format agnostic
+shear:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+showinfo: ""  # metadata only
+showpalette:
+  image_formats:
+    - rgba
+shuffleframes: ""  # format agnostic
+shufflepixels:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - rgba
+shuffleplanes: ""  # format agnostic
+sidechaincompress:
+  audio_formats:
+    - f32le
+sidechaingate:
+  audio_formats:
+    - f32le
+sidedata: ""  # format agnostic
+signalstats:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+signature:
+  image_formats:
+    - rgb
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+silencedetect: ""  # metadata only
+silenceremove:
+  audio_formats:
+    - f32le
+siti: ""  # metadata only
+smartblur:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+sobel:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+sobel_opencl: ""  # hardware only
+sofalizer:
+  audio_formats:
+    - f32le
+speechnorm:
+  audio_formats:
+    - f32le
+split: ""  # format agnostic
+spp:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - yuv422p16
+    - yuv420p10
+    - rgb
+    - rgba64
+sr:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - rgb
+sr_amf:
+  image_formats:
+    - yuv420p10
+    - rgba
+    - rgba64
+ssim:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv444p10
+ssim360:
+  image_formats:
+    - rgb
+    - yuv420p
+    - yuv422
+    - yuv444p10
+stereo3d:
+  image_formats:
+    - rgb
+    - rgba64
+    - rgba
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+stereotools:
+  audio_formats:
+    - f32le
+stereowiden:
+  audio_formats:
+    - f32le
+streamselect: ""  # format agnostic
+subtitles: ""  # format agnostic
+super2xsai:
+  image_formats:
+    - rgba
+    - rgb
+superequalizer:
+  audio_formats:
+    - f32le
+surround:
+  audio_formats:
+    - f32le
+swaprect: ""  # format agnostic
+swapuv: ""  # format agnostic
+tblend:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+    - yuv420p10
+    - yuv422p16
+    - rgba64
+telecine: ""  # format agnostic
+thistogram:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+    - rgba
+    - rgb
+    - rgba64
+threshold:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+thumbnail:
+  image_formats:
+    - rgb
+    - rgba
+thumbnail_cuda:
+  image_formats:
+    - yuv420p10
+    - yuv420p
+    - yuv444p10
+tile: ""  # format agnostic
+tiltandshift:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+tiltshelf:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+tinterlace:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv420p10
+    - yuv422p16
+    - rgb
+tlut2:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+tmedian:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+tmidequalizer:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+tmix: ""  # format agnostic
+tonemap:
+  image_formats:
+    - rgba64
+tonemap_opencl: ""  # hardware only
+tonemap_vaapi: ""  # format agnostic
+tpad: ""  # format agnostic
+transpose: ""  # format agnostic
+transpose_npp:
+  image_formats:
+    - yuv420p
+    - yuv444p10
+transpose_opencl: ""  # hardware only
+transpose_vaapi: ""  # format agnostic
+transpose_vt: ""  # hardware only
+transpose_vulkan: ""  # hardware only
+treble:
+  audio_formats:
+    - s16
+    - s32le
+    - f32le
+tremolo:
+  audio_formats:
+    - f32le
+trim: ""  # metadata only
+unpremultiply:
+  image_formats:
+    - yuv444p10
+    - rgb
+    - rgba64
+    - rgba
+unsharp:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - yuv422p16
+    - yuv420p10
+unsharp_opencl: ""  # hardware only
+untile: ""  # format agnostic
+uspp:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - rgb
+v360:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv422p16
+    - yuv420p
+    - yuv420p10
+    - rgb
+    - rgba64
+    - rgba
+vaguedenoiser:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+varblur:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+vectorscope:
+  image_formats:
+    - yuv444p10
+    - rgba
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+vflip: ""  # format agnostic
+vflip_vulkan: ""  # hardware only
+vfrdet: ""  # metadata only
+vibrance:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+vibrato:
+  audio_formats:
+    - f32le
+vidstabdetect: ""  # metadata only
+vidstabtransform: ""  # format agnostic
+vif:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv422
+    - yuv444p10
+vignette:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+virtualbass:
+  audio_formats:
+    - f32le
+vmafmotion: ""  # metadata only
+volume:
+  audio_formats:
+    - u8
+    - s16
+    - s32le
+    - f32le
+volumedetect: ""  # metadata only
+vpp_amf:
+  image_formats:
+    - yuv420p10
+    - rgb
+    - rgba
+    - yuv420p
+    - yuv422
+vpp_qsv: ""  # hardware only
+vstack: ""  # format agnostic
+vstack_qsv: ""  # hardware only
+vstack_vaapi: ""  # hardware only
+w3fdif:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - rgb
+    - rgba
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+waveform:
+  image_formats:
+    - rgb
+    - rgba
+    - rgba64
+    - yuv422
+    - yuv420p
+    - yuv444p10
+    - yuv422p16
+    - yuv420p10
+weave: ""  # format agnostic
+whisper: ""  # metadata only
+xbr: ""  # hardware only
+xcorrelate:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+xfade:
+  image_formats:
+    - yuv444p10
+    - rgb
+    - rgba
+    - rgba64
+xfade_opencl: ""  # hardware only
+xfade_vulkan: ""  # hardware only
+xmedian:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgba
+xpsnr:
+  image_formats:
+    - rgb
+    - rgba64
+    - yuv420p
+    - yuv444p10
+    - yuv422
+    - rgba
+xstack: ""  # format agnostic
+xstack_qsv: ""  # hardware only
+xstack_vaapi: ""  # hardware only
+yadif:
+  image_formats:
+    - yuv420p
+    - yuv422
+    - yuv444p10
+    - rgb
+    - rgba64
+    - yuv420p10
+    - yuv422p16
+    - rgba
+yadif_cuda: ""  # hardware only
+yadif_videotoolbox: ""  # hardware only
+yaepblur:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba
+zmq: ""  # format agnostic
+zoompan:
+  image_formats:
+    - yuv444p10
+    - yuv422
+    - yuv420p
+    - rgb
+    - rgba
+zscale:
+  image_formats:
+    - yuv444p10
+    - yuv420p
+    - yuv422
+    - yuv420p10
+    - yuv422p16
+    - rgb
+    - rgba64
+    - rgba

--- a/src/modules/avformat/filter_swresample.yml
+++ b/src/modules/avformat/filter_swresample.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: swresample
 title: FFmpeg Audio Resampler
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,3 +15,10 @@ notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it if it is available to set the audio resampler to normalize inputs
   to the consumer audio frequency.
+audio_formats:
+  - s16
+  - s32
+  - s32le
+  - float
+  - f32le
+  - u8

--- a/src/modules/avformat/filter_sws_colortransform.yml
+++ b/src/modules/avformat/filter_sws_colortransform.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: sws_colortransform
 title: libswscale Color Transform
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -13,7 +13,15 @@ description: >
   Convert image to and from linear color transfer characteristics using libswscale.
   This filter is designed to work with the color_transform filter to provide
   efficient linear color space conversion.
-
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv422p16
+  - yuv444p10
 parameters:
   - identifier: transfer
     title: Target Transfer Characteristic

--- a/src/modules/avformat/filter_swscale.yml
+++ b/src/modules/avformat/filter_swscale.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: swscale
 title: FFmpeg Image Scaler
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,3 +15,12 @@ notes: >
   This is not intended to be created directly. Rather, the rescale filter
   loads it if it is available to normalize video and image inputs to the
   consumer/profile resolution.
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv422p16
+  - yuv444p10

--- a/src/modules/avformat/generate_filter_info.py
+++ b/src/modules/avformat/generate_filter_info.py
@@ -1,0 +1,1172 @@
+#!/usr/bin/env python3
+"""
+Script to generate filter_info.yml
+
+Usage:
+  python3 generate_filter_info.py --ffmpeg-dir PATH --output-yml PATH
+"""
+import argparse
+import os
+import re
+import sys
+
+# Will be set by parse_args()
+FFMPEG_DIR = None
+ALLFILTERS = None
+OUT_YML = None
+
+# =========================================================================
+# Command-line argument parsing
+# =========================================================================
+def parse_args():
+    """Parse and validate command-line arguments"""
+    global FFMPEG_DIR, ALLFILTERS, OUT_YML
+    
+    parser = argparse.ArgumentParser(
+        description="Parse FFmpeg libavfilter source and generate filter_info.yml with MLT format mappings"
+    )
+    parser.add_argument(
+        "--ffmpeg-dir",
+        required=True,
+        help="Path to FFmpeg libavfilter directory"
+    )
+    parser.add_argument(
+        "--output-yml",
+        required=True,
+        help="Output YAML file path"
+    )
+    
+    args = parser.parse_args()
+    
+    # Set global variables
+    FFMPEG_DIR = args.ffmpeg_dir
+    ALLFILTERS = os.path.join(args.ffmpeg_dir, "allfilters.c")
+    OUT_YML = args.output_yml
+    
+    # Validate paths
+    if not os.path.isdir(FFMPEG_DIR):
+        print(f"Error: FFmpeg directory not found: {FFMPEG_DIR}", file=sys.stderr)
+        sys.exit(1)
+    
+    if not os.path.exists(ALLFILTERS):
+        print(f"Error: allfilters.c not found: {ALLFILTERS}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Create output directory if needed
+    output_dir = os.path.dirname(OUT_YML)
+    if output_dir and not os.path.isdir(output_dir):
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+        except OSError as e:
+            print(f"Error: Could not create output directory {output_dir}: {e}", file=sys.stderr)
+            sys.exit(1)
+    
+    return args
+
+
+# =========================================================================
+# EMBEDDED MAPPINGS: FFmpeg -> MLT format mapping
+# =========================================================================
+FFMPEG_TO_MLT_MAPPINGS = {
+    "audio_mapping": {
+        "dbl": "f32le",
+        "dblp": "f32le",
+        "flt": "f32le",
+        "fltp": "f32le",
+        "none": "none",
+        "s16": "s16",
+        "s16p": "s16",
+        "s32": "s32le",
+        "s32p": "s32le",
+        "s64": "s32le",
+        "s64p": "s32le",
+        "u8": "u8",
+        "u8p": "u8",
+    },
+    "video_mapping": {
+        "0bgr": "rgb",
+        "0rgb": "rgb",
+        "abgr": "rgba",
+        "amf_surface": "none",
+        "argb": "rgba",
+        "ayuv": "yuv444p10",
+        "ayuv64be": "yuv444p10",
+        "ayuv64le": "yuv444p10",
+        "bayer_bggr16be": "rgba64",
+        "bayer_bggr16le": "rgba64",
+        "bayer_bggr8": "rgb",
+        "bayer_gbrg16be": "rgba64",
+        "bayer_gbrg16le": "rgba64",
+        "bayer_gbrg8": "rgb",
+        "bayer_grbg16be": "rgba64",
+        "bayer_grbg16le": "rgba64",
+        "bayer_grbg8": "rgb",
+        "bayer_rggb16be": "rgba64",
+        "bayer_rggb16le": "rgba64",
+        "bayer_rggb8": "rgb",
+        "bgr0": "rgb",
+        "bgr24": "rgb",
+        "bgr4": "rgb",
+        "bgr444be": "rgb",
+        "bgr444le": "rgb",
+        "bgr48be": "rgba64",
+        "bgr48le": "rgba64",
+        "bgr4_byte": "rgb",
+        "bgr555be": "rgb",
+        "bgr555le": "rgb",
+        "bgr565be": "rgb",
+        "bgr565le": "rgb",
+        "bgr8": "rgb",
+        "bgra": "rgba",
+        "bgra64be": "rgba64",
+        "bgra64le": "rgba64",
+        "cuda": "none",
+        "d3d11": "none",
+        "d3d11va_vld": "none",
+        "d3d12": "none",
+        "drm_prime": "none",
+        "dxva2_vld": "none",
+        "gbr24p": "rgb",
+        "gbrap": "rgba",
+        "gbrap10be": "rgba64",
+        "gbrap10le": "rgba64",
+        "gbrap12be": "rgba64",
+        "gbrap12le": "rgba64",
+        "gbrap14be": "rgba64",
+        "gbrap14le": "rgba64",
+        "gbrap16be": "rgba64",
+        "gbrap16le": "rgba64",
+        "gbrap32be": "rgba64",
+        "gbrap32le": "rgba64",
+        "gbrapf16be": "rgba64",
+        "gbrapf16le": "rgba64",
+        "gbrapf32be": "rgba64",
+        "gbrapf32le": "rgba64",
+        "gbrp": "rgb",
+        "gbrp10be": "rgba64",
+        "gbrp10le": "rgba64",
+        "gbrp10msbbe": "rgba64",
+        "gbrp10msble": "rgba64",
+        "gbrp12be": "rgba64",
+        "gbrp12le": "rgba64",
+        "gbrp12msbbe": "rgba64",
+        "gbrp12msble": "rgba64",
+        "gbrp14be": "rgba64",
+        "gbrp14le": "rgba64",
+        "gbrp16be": "rgba64",
+        "gbrp16le": "rgba64",
+        "gbrp9be": "rgba64",
+        "gbrp9le": "rgba64",
+        "gbrpf16be": "rgba64",
+        "gbrpf16le": "rgba64",
+        "gbrpf32be": "rgba64",
+        "gbrpf32le": "rgba64",
+        "gray10be": "rgba64",
+        "gray10le": "rgba64",
+        "gray12be": "rgba64",
+        "gray12le": "rgba64",
+        "gray14be": "rgba64",
+        "gray14le": "rgba64",
+        "gray16be": "rgba64",
+        "gray16le": "rgba64",
+        "gray32be": "rgba64",
+        "gray32le": "rgba64",
+        "gray8": "rgb",
+        "gray8a": "rgb",
+        "gray9be": "rgba64",
+        "gray9le": "rgba64",
+        "grayf16be": "rgba64",
+        "grayf16le": "rgba64",
+        "grayf32be": "rgba64",
+        "grayf32le": "rgba64",
+        "mediacodec": "none",
+        "mmal": "none",
+        "monoblack": "rgb",
+        "monowhite": "rgb",
+        "none": "none",
+        "nv12": "yuv420p10",
+        "nv16": "yuv422p16",
+        "nv20be": "yuv422",
+        "nv20le": "yuv422",
+        "nv21": "yuv420p",
+        "nv24": "yuv420p",
+        "nv42": "yuv420p",
+        "ohcodec": "none",
+        "opencl": "none",
+        "p010be": "yuv420p10",
+        "p010le": "yuv420p10",
+        "p012be": "yuv420p10",
+        "p012le": "yuv420p10",
+        "p016be": "yuv420p10",
+        "p016le": "yuv420p10",
+        "p210be": "yuv422p16",
+        "p210le": "yuv422p16",
+        "p212be": "yuv420p",
+        "p212le": "yuv420p",
+        "p216be": "yuv422p16",
+        "p216le": "yuv422p16",
+        "p410be": "none",
+        "p410le": "none",
+        "p412be": "none",
+        "p412le": "none",
+        "p416be": "none",
+        "p416le": "none",
+        "pal8": "rgba",
+        "qsv": "none",
+        "rgb0": "rgb",
+        "rgb24": "rgb",
+        "rgb4": "rgb",
+        "rgb444be": "rgb",
+        "rgb444le": "rgb",
+        "rgb48be": "rgba64",
+        "rgb48le": "rgba64",
+        "rgb4_byte": "rgb",
+        "rgb555be": "rgb",
+        "rgb555le": "rgb",
+        "rgb565be": "rgb",
+        "rgb565le": "rgb",
+        "rgb8": "rgb",
+        "rgb96be": "rgba64",
+        "rgb96le": "rgba64",
+        "rgba": "rgba",
+        "rgba128be": "rgba64",
+        "rgba128le": "rgba64",
+        "rgba64be": "rgba64",
+        "rgba64le": "rgba64",
+        "rgbaf16be": "rgba64",
+        "rgbaf16le": "rgba64",
+        "rgbaf32be": "rgba64",
+        "rgbaf32le": "rgba64",
+        "rgbf16be": "rgba64",
+        "rgbf16le": "rgba64",
+        "rgbf32be": "rgba64",
+        "rgbf32le": "rgba64",
+        "uyva": "none",
+        "uyvy422": "yuv422",
+        "uyyvyy411": "none",
+        "v30xbe": "none",
+        "v30xle": "none",
+        "vaapi": "none",
+        "vdpau": "none",
+        "videotoolbox": "none",
+        "vulkan": "none",
+        "vuya": "none",
+        "vuyx": "none",
+        "vyu444": "none",
+        "x2bgr10be": "rgba64",
+        "x2bgr10le": "rgba64",
+        "x2rgb10be": "rgba64",
+        "x2rgb10le": "rgba64",
+        "xv30be": "none",
+        "xv30le": "none",
+        "xv36be": "none",
+        "xv36le": "none",
+        "xv48be": "none",
+        "xv48le": "none",
+        "xyz12be": "rgba64",
+        "xyz12le": "rgba64",
+        "y210be": "yuv422p16",
+        "y210le": "yuv422p16",
+        "y212be": "yuv422p16",
+        "y212le": "yuv422p16",
+        "y216be": "yuv422p16",
+        "y216le": "yuv422p16",
+        "y400a": "rgb",
+        "ya16be": "rgba64",
+        "ya16le": "rgba64",
+        "ya8": "rgb",
+        "yaf16be": "rgba64",
+        "yaf16le": "rgba64",
+        "yaf32be": "rgba64",
+        "yaf32le": "rgba64",
+        "yuv410p": "yuv420p",
+        "yuv411p": "yuv422",
+        "yuv420p": "yuv420p",
+        "yuv420p10be": "yuv420p10",
+        "yuv420p10le": "yuv420p10",
+        "yuv420p12be": "yuv420p10",
+        "yuv420p12le": "yuv420p10",
+        "yuv420p14be": "yuv420p10",
+        "yuv420p14le": "yuv420p10",
+        "yuv420p16be": "yuv420p10",
+        "yuv420p16le": "yuv420p10",
+        "yuv420p9be": "yuv420p10",
+        "yuv420p9le": "yuv420p10",
+        "yuv422p": "yuv422",
+        "yuv422p10be": "yuv422p16",
+        "yuv422p10le": "yuv422p16",
+        "yuv422p12be": "yuv422p16",
+        "yuv422p12le": "yuv422p16",
+        "yuv422p14be": "yuv422p16",
+        "yuv422p14le": "yuv422p16",
+        "yuv422p16be": "yuv422p16",
+        "yuv422p16le": "yuv422p16",
+        "yuv422p9be": "yuv422p16",
+        "yuv422p9le": "yuv422p16",
+        "yuv440p": "yuv422",
+        "yuv440p10be": "yuv422p16",
+        "yuv440p10le": "yuv422p16",
+        "yuv440p12be": "yuv422p16",
+        "yuv440p12le": "yuv422p16",
+        "yuv444p": "yuv444p10",
+        "yuv444p10be": "yuv444p10",
+        "yuv444p10le": "yuv444p10",
+        "yuv444p10msbbe": "yuv444p10",
+        "yuv444p10msble": "yuv444p10",
+        "yuv444p12be": "yuv444p10",
+        "yuv444p12le": "yuv444p10",
+        "yuv444p12msbbe": "yuv444p10",
+        "yuv444p12msble": "yuv444p10",
+        "yuv444p14be": "yuv444p10",
+        "yuv444p14le": "yuv444p10",
+        "yuv444p16be": "yuv444p10",
+        "yuv444p16le": "yuv444p10",
+        "yuv444p9be": "yuv444p10",
+        "yuv444p9le": "yuv444p10",
+        "yuva420p": "yuv420p",
+        "yuva420p10be": "yuv420p10",
+        "yuva420p10le": "yuv420p10",
+        "yuva420p16be": "yuv420p10",
+        "yuva420p16le": "yuv420p10",
+        "yuva420p9be": "yuv420p10",
+        "yuva420p9le": "yuv420p10",
+        "yuva422p": "yuv422",
+        "yuva422p10be": "yuv422p16",
+        "yuva422p10le": "yuv422p16",
+        "yuva422p12be": "yuv422p16",
+        "yuva422p12le": "yuv422p16",
+        "yuva422p16be": "yuv422p16",
+        "yuva422p16le": "yuv422p16",
+        "yuva422p9be": "yuv422p16",
+        "yuva422p9le": "yuv422p16",
+        "yuva444p": "yuv444p10",
+        "yuva444p10be": "yuv444p10",
+        "yuva444p10le": "yuv444p10",
+        "yuva444p12be": "yuv444p10",
+        "yuva444p12le": "yuv444p10",
+        "yuva444p16be": "yuv444p10",
+        "yuva444p16le": "yuv444p10",
+    },
+}
+
+# =========================================================================
+# EMBEDDED DATA: FFmpeg audio/video formats comprehensive
+# =========================================================================
+FFMPEG_AUDIO_FORMATS = [
+    "AV_SAMPLE_FMT_DBL",
+    "AV_SAMPLE_FMT_DBLP",
+    "AV_SAMPLE_FMT_FLT",
+    "AV_SAMPLE_FMT_FLTP",
+    "AV_SAMPLE_FMT_NONE",
+    "AV_SAMPLE_FMT_S16",
+    "AV_SAMPLE_FMT_S16P",
+    "AV_SAMPLE_FMT_S32",
+    "AV_SAMPLE_FMT_S32P",
+    "AV_SAMPLE_FMT_S64",
+    "AV_SAMPLE_FMT_S64P",
+    "AV_SAMPLE_FMT_U8",
+    "AV_SAMPLE_FMT_U8P",
+]
+
+FFMPEG_VIDEO_FORMATS = [
+    "AV_PIX_FMT_0BGR",
+    "AV_PIX_FMT_0RGB",
+    "AV_PIX_FMT_ABGR",
+    "AV_PIX_FMT_AMF_SURFACE",
+    "AV_PIX_FMT_ARGB",
+    "AV_PIX_FMT_AYUV",
+    "AV_PIX_FMT_AYUV64BE",
+    "AV_PIX_FMT_AYUV64LE",
+    "AV_PIX_FMT_BAYER_BGGR16BE",
+    "AV_PIX_FMT_BAYER_BGGR16LE",
+    "AV_PIX_FMT_BAYER_BGGR8",
+    "AV_PIX_FMT_BAYER_GBRG16BE",
+    "AV_PIX_FMT_BAYER_GBRG16LE",
+    "AV_PIX_FMT_BAYER_GBRG8",
+    "AV_PIX_FMT_BAYER_GRBG16BE",
+    "AV_PIX_FMT_BAYER_GRBG16LE",
+    "AV_PIX_FMT_BAYER_GRBG8",
+    "AV_PIX_FMT_BAYER_RGGB16BE",
+    "AV_PIX_FMT_BAYER_RGGB16LE",
+    "AV_PIX_FMT_BAYER_RGGB8",
+    "AV_PIX_FMT_BGR0",
+    "AV_PIX_FMT_BGR24",
+    "AV_PIX_FMT_BGR4",
+    "AV_PIX_FMT_BGR444BE",
+    "AV_PIX_FMT_BGR444LE",
+    "AV_PIX_FMT_BGR48BE",
+    "AV_PIX_FMT_BGR48LE",
+    "AV_PIX_FMT_BGR4_BYTE",
+    "AV_PIX_FMT_BGR555BE",
+    "AV_PIX_FMT_BGR555LE",
+    "AV_PIX_FMT_BGR565BE",
+    "AV_PIX_FMT_BGR565LE",
+    "AV_PIX_FMT_BGR8",
+    "AV_PIX_FMT_BGRA",
+    "AV_PIX_FMT_BGRA64BE",
+    "AV_PIX_FMT_BGRA64LE",
+    "AV_PIX_FMT_CUDA",
+    "AV_PIX_FMT_D3D11",
+    "AV_PIX_FMT_D3D11VA_VLD",
+    "AV_PIX_FMT_D3D12",
+    "AV_PIX_FMT_DRM_PRIME",
+    "AV_PIX_FMT_DXVA2_VLD",
+    "AV_PIX_FMT_GBR24P",
+    "AV_PIX_FMT_GBRAP",
+    "AV_PIX_FMT_GBRAP10BE",
+    "AV_PIX_FMT_GBRAP10LE",
+    "AV_PIX_FMT_GBRAP12BE",
+    "AV_PIX_FMT_GBRAP12LE",
+    "AV_PIX_FMT_GBRAP14BE",
+    "AV_PIX_FMT_GBRAP14LE",
+    "AV_PIX_FMT_GBRAP16BE",
+    "AV_PIX_FMT_GBRAP16LE",
+    "AV_PIX_FMT_GBRAP32BE",
+    "AV_PIX_FMT_GBRAP32LE",
+    "AV_PIX_FMT_GBRAPF16BE",
+    "AV_PIX_FMT_GBRAPF16LE",
+    "AV_PIX_FMT_GBRAPF32BE",
+    "AV_PIX_FMT_GBRAPF32LE",
+    "AV_PIX_FMT_GBRP",
+    "AV_PIX_FMT_GBRP10BE",
+    "AV_PIX_FMT_GBRP10LE",
+    "AV_PIX_FMT_GBRP10MSBBE",
+    "AV_PIX_FMT_GBRP10MSBLE",
+    "AV_PIX_FMT_GBRP12BE",
+    "AV_PIX_FMT_GBRP12LE",
+    "AV_PIX_FMT_GBRP12MSBBE",
+    "AV_PIX_FMT_GBRP12MSBLE",
+    "AV_PIX_FMT_GBRP14BE",
+    "AV_PIX_FMT_GBRP14LE",
+    "AV_PIX_FMT_GBRP16BE",
+    "AV_PIX_FMT_GBRP16LE",
+    "AV_PIX_FMT_GBRP9BE",
+    "AV_PIX_FMT_GBRP9LE",
+    "AV_PIX_FMT_GBRPF16BE",
+    "AV_PIX_FMT_GBRPF16LE",
+    "AV_PIX_FMT_GBRPF32BE",
+    "AV_PIX_FMT_GBRPF32LE",
+    "AV_PIX_FMT_GRAY10BE",
+    "AV_PIX_FMT_GRAY10LE",
+    "AV_PIX_FMT_GRAY12BE",
+    "AV_PIX_FMT_GRAY12LE",
+    "AV_PIX_FMT_GRAY14BE",
+    "AV_PIX_FMT_GRAY14LE",
+    "AV_PIX_FMT_GRAY16BE",
+    "AV_PIX_FMT_GRAY16LE",
+    "AV_PIX_FMT_GRAY32BE",
+    "AV_PIX_FMT_GRAY32LE",
+    "AV_PIX_FMT_GRAY8",
+    "AV_PIX_FMT_GRAY8A",
+    "AV_PIX_FMT_GRAY9BE",
+    "AV_PIX_FMT_GRAY9LE",
+    "AV_PIX_FMT_GRAYF16BE",
+    "AV_PIX_FMT_GRAYF16LE",
+    "AV_PIX_FMT_GRAYF32BE",
+    "AV_PIX_FMT_GRAYF32LE",
+    "AV_PIX_FMT_MEDIACODEC",
+    "AV_PIX_FMT_MMAL",
+    "AV_PIX_FMT_MONOBLACK",
+    "AV_PIX_FMT_MONOWHITE",
+    "AV_PIX_FMT_NONE",
+    "AV_PIX_FMT_NV12",
+    "AV_PIX_FMT_NV16",
+    "AV_PIX_FMT_NV20BE",
+    "AV_PIX_FMT_NV20LE",
+    "AV_PIX_FMT_NV21",
+    "AV_PIX_FMT_NV24",
+    "AV_PIX_FMT_NV42",
+    "AV_PIX_FMT_OHCODEC",
+    "AV_PIX_FMT_OPENCL",
+    "AV_PIX_FMT_P010BE",
+    "AV_PIX_FMT_P010LE",
+    "AV_PIX_FMT_P012BE",
+    "AV_PIX_FMT_P012LE",
+    "AV_PIX_FMT_P016BE",
+    "AV_PIX_FMT_P016LE",
+    "AV_PIX_FMT_P210BE",
+    "AV_PIX_FMT_P210LE",
+    "AV_PIX_FMT_P212BE",
+    "AV_PIX_FMT_P212LE",
+    "AV_PIX_FMT_P216BE",
+    "AV_PIX_FMT_P216LE",
+    "AV_PIX_FMT_P410BE",
+    "AV_PIX_FMT_P410LE",
+    "AV_PIX_FMT_P412BE",
+    "AV_PIX_FMT_P412LE",
+    "AV_PIX_FMT_P416BE",
+    "AV_PIX_FMT_P416LE",
+    "AV_PIX_FMT_PAL8",
+    "AV_PIX_FMT_QSV",
+    "AV_PIX_FMT_RGB0",
+    "AV_PIX_FMT_RGB24",
+    "AV_PIX_FMT_RGB4",
+    "AV_PIX_FMT_RGB444BE",
+    "AV_PIX_FMT_RGB444LE",
+    "AV_PIX_FMT_RGB48BE",
+    "AV_PIX_FMT_RGB48LE",
+    "AV_PIX_FMT_RGB4_BYTE",
+    "AV_PIX_FMT_RGB555BE",
+    "AV_PIX_FMT_RGB555LE",
+    "AV_PIX_FMT_RGB565BE",
+    "AV_PIX_FMT_RGB565LE",
+    "AV_PIX_FMT_RGB8",
+    "AV_PIX_FMT_RGB96BE",
+    "AV_PIX_FMT_RGB96LE",
+    "AV_PIX_FMT_RGBA",
+    "AV_PIX_FMT_RGBA128BE",
+    "AV_PIX_FMT_RGBA128LE",
+    "AV_PIX_FMT_RGBA64BE",
+    "AV_PIX_FMT_RGBA64LE",
+    "AV_PIX_FMT_RGBAF16BE",
+    "AV_PIX_FMT_RGBAF16LE",
+    "AV_PIX_FMT_RGBAF32BE",
+    "AV_PIX_FMT_RGBAF32LE",
+    "AV_PIX_FMT_RGBF16BE",
+    "AV_PIX_FMT_RGBF16LE",
+    "AV_PIX_FMT_RGBF32BE",
+    "AV_PIX_FMT_RGBF32LE",
+    "AV_PIX_FMT_UYVA",
+    "AV_PIX_FMT_UYVY422",
+    "AV_PIX_FMT_UYYVYY411",
+    "AV_PIX_FMT_V30XBE",
+    "AV_PIX_FMT_V30XLE",
+    "AV_PIX_FMT_VAAPI",
+    "AV_PIX_FMT_VDPAU",
+    "AV_PIX_FMT_VIDEOTOOLBOX",
+    "AV_PIX_FMT_VULKAN",
+    "AV_PIX_FMT_VUYA",
+    "AV_PIX_FMT_VUYX",
+    "AV_PIX_FMT_VYU444",
+    "AV_PIX_FMT_X2BGR10BE",
+    "AV_PIX_FMT_X2BGR10LE",
+    "AV_PIX_FMT_X2RGB10BE",
+    "AV_PIX_FMT_X2RGB10LE",
+    "AV_PIX_FMT_XV30BE",
+    "AV_PIX_FMT_XV30LE",
+    "AV_PIX_FMT_XV36BE",
+    "AV_PIX_FMT_XV36LE",
+    "AV_PIX_FMT_XV48BE",
+    "AV_PIX_FMT_XV48LE",
+    "AV_PIX_FMT_XYZ12BE",
+    "AV_PIX_FMT_XYZ12LE",
+    "AV_PIX_FMT_Y210BE",
+    "AV_PIX_FMT_Y210LE",
+    "AV_PIX_FMT_Y212BE",
+    "AV_PIX_FMT_Y212LE",
+    "AV_PIX_FMT_Y216BE",
+    "AV_PIX_FMT_Y216LE",
+    "AV_PIX_FMT_Y400A",
+    "AV_PIX_FMT_YA16BE",
+    "AV_PIX_FMT_YA16LE",
+    "AV_PIX_FMT_YA8",
+    "AV_PIX_FMT_YAF16BE",
+    "AV_PIX_FMT_YAF16LE",
+    "AV_PIX_FMT_YAF32BE",
+    "AV_PIX_FMT_YAF32LE",
+    "AV_PIX_FMT_YUV410P",
+    "AV_PIX_FMT_YUV411P",
+    "AV_PIX_FMT_YUV420P",
+    "AV_PIX_FMT_YUV420P10BE",
+    "AV_PIX_FMT_YUV420P10LE",
+    "AV_PIX_FMT_YUV420P12BE",
+    "AV_PIX_FMT_YUV420P12LE",
+    "AV_PIX_FMT_YUV420P14BE",
+    "AV_PIX_FMT_YUV420P14LE",
+    "AV_PIX_FMT_YUV420P16BE",
+    "AV_PIX_FMT_YUV420P16LE",
+    "AV_PIX_FMT_YUV420P9BE",
+    "AV_PIX_FMT_YUV420P9LE",
+    "AV_PIX_FMT_YUV422P",
+    "AV_PIX_FMT_YUV422P10BE",
+    "AV_PIX_FMT_YUV422P10LE",
+    "AV_PIX_FMT_YUV422P12BE",
+    "AV_PIX_FMT_YUV422P12LE",
+    "AV_PIX_FMT_YUV422P14BE",
+    "AV_PIX_FMT_YUV422P14LE",
+    "AV_PIX_FMT_YUV422P16BE",
+    "AV_PIX_FMT_YUV422P16LE",
+    "AV_PIX_FMT_YUV422P9BE",
+    "AV_PIX_FMT_YUV422P9LE",
+    "AV_PIX_FMT_YUV440P",
+    "AV_PIX_FMT_YUV440P10BE",
+    "AV_PIX_FMT_YUV440P10LE",
+    "AV_PIX_FMT_YUV440P12BE",
+    "AV_PIX_FMT_YUV440P12LE",
+    "AV_PIX_FMT_YUV444P",
+    "AV_PIX_FMT_YUV444P10BE",
+    "AV_PIX_FMT_YUV444P10LE",
+    "AV_PIX_FMT_YUV444P10MSBBE",
+    "AV_PIX_FMT_YUV444P10MSBLE",
+    "AV_PIX_FMT_YUV444P12BE",
+    "AV_PIX_FMT_YUV444P12LE",
+    "AV_PIX_FMT_YUV444P12MSBBE",
+    "AV_PIX_FMT_YUV444P12MSBLE",
+    "AV_PIX_FMT_YUV444P14BE",
+    "AV_PIX_FMT_YUV444P14LE",
+    "AV_PIX_FMT_YUV444P16BE",
+    "AV_PIX_FMT_YUV444P16LE",
+    "AV_PIX_FMT_YUV444P9BE",
+    "AV_PIX_FMT_YUV444P9LE",
+    "AV_PIX_FMT_YUVA420P",
+    "AV_PIX_FMT_YUVA420P10BE",
+    "AV_PIX_FMT_YUVA420P10LE",
+    "AV_PIX_FMT_YUVA420P16BE",
+    "AV_PIX_FMT_YUVA420P16LE",
+    "AV_PIX_FMT_YUVA420P9BE",
+    "AV_PIX_FMT_YUVA420P9LE",
+    "AV_PIX_FMT_YUVA422P",
+    "AV_PIX_FMT_YUVA422P10BE",
+    "AV_PIX_FMT_YUVA422P10LE",
+    "AV_PIX_FMT_YUVA422P12BE",
+    "AV_PIX_FMT_YUVA422P12LE",
+    "AV_PIX_FMT_YUVA422P16BE",
+    "AV_PIX_FMT_YUVA422P16LE",
+    "AV_PIX_FMT_YUVA422P9BE",
+    "AV_PIX_FMT_YUVA422P9LE",
+    "AV_PIX_FMT_YUVA444P",
+    "AV_PIX_FMT_YUVA444P10BE",
+    "AV_PIX_FMT_YUVA444P10LE",
+    "AV_PIX_FMT_YUVA444P12BE",
+    "AV_PIX_FMT_YUVA444P12LE",
+    "AV_PIX_FMT_YUVA444P16BE",
+    "AV_PIX_FMT_YUVA444P16LE",
+]
+
+# =========================================================================
+# EMBEDDED DATA: FFmpeg audio/video filters comprehensive list
+# =========================================================================
+FFMPEG_FILTERS = [
+    "aap", "abench", "acompressor", "acontrast", "acopy", "acrossfade", "acrossover",
+    "acrusher", "acue", "addroi", "adeclick", "adeclip", "adecorrelate", "adelay",
+    "adenorm", "aderivative", "adrc", "adynamicequalizer", "adynamicsmooth", "aecho",
+    "aemphasis", "aeval", "aexciter", "afade", "afftdn", "afftfilt", "afir", "aformat",
+    "afreqshift", "afwtdn", "agate", "aiir", "aintegral", "ainterleave", "alatency",
+    "alimiter", "allpass", "aloop", "alphaextract", "alphamerge", "amerge", "ametadata",
+    "amix", "amplify", "amultiply", "anequalizer", "anlmdn", "anlmf", "anlms", "anull",
+    "apad", "aperms", "aphaser", "aphaseshift", "apsnr", "apsyclip", "apulsator",
+    "arealtime", "aresample", "areverse", "arls", "arnndn", "asdr", "asegment", "aselect",
+    "asendcmd", "asetnsamples", "asetpts", "asetrate", "asettb", "ashowinfo", "asidedata",
+    "asisdr", "asoftclip", "aspectralstats", "asplit", "asr", "ass", "astats",
+    "astreamselect", "asubboost", "asubcut", "asupercut", "asuperpass", "asuperstop",
+    "atadenoise", "atempo", "atilt", "atrim", "avgblur", "avgblur_opencl", "avgblur_vulkan",
+    "axcorrelate", "azmq", "backgroundkey", "bandpass", "bandreject", "bass", "bbox", "bench",
+    "bilateral", "bilateral_cuda", "biquad", "bitplanenoise", "blackdetect",
+    "blackdetect_vulkan", "blackframe", "blend", "blend_vulkan", "blockdetect", "blurdetect",
+    "bm3d", "boxblur", "boxblur_opencl", "bs2b", "bwdif", "bwdif_cuda", "bwdif_vulkan", "cas",
+    "ccrepack", "channelmap", "channelsplit", "chorus", "chromaber_vulkan", "chromahold",
+    "chromakey", "chromakey_cuda", "chromanr", "chromashift", "ciescope", "codecview",
+    "colorbalance", "colorchannelmixer", "colorcontrast", "colorcorrect", "colordetect",
+    "colorhold", "colorize", "colorkey", "colorkey_opencl", "colorlevels", "colormap",
+    "colormatrix", "colorspace", "colorspace_cuda", "colortemperature", "compand",
+    "compensationdelay", "convolution", "convolution_opencl", "convolve", "copy", "coreimage",
+    "corr", "cover_rect", "crop", "cropdetect", "crossfeed", "crystalizer", "cue", "curves",
+    "datascope", "dblur", "dcshift", "dctdnoiz", "deband", "deblock", "decimate", "deconvolve",
+    "dedot", "deesser", "deflate", "deflicker", "deinterlace_qsv", "deinterlace_vaapi",
+    "dejudder", "delogo", "denoise_vaapi", "derain", "deshake", "deshake_opencl", "despill",
+    "detelecine", "dialoguenhance", "dilation", "dilation_opencl", "displace", "dnn_classify",
+    "dnn_detect", "dnn_processing", "doubleweave", "drawbox", "drawbox_vaapi", "drawgraph",
+    "drawgrid", "drawtext", "drmeter", "dynaudnorm", "earwax", "ebur128", "edgedetect", "elbg",
+    "entropy", "epx", "eq", "equalizer", "erosion", "erosion_opencl", "estdif", "exposure",
+    "extractplanes", "extrastereo", "fade", "feedback", "fftdnoiz", "fftfilt", "field",
+    "fieldhint", "fieldmatch", "fieldorder", "fillborders", "find_rect", "firequalizer",
+    "flanger", "flip_vulkan", "floodfill", "format", "fps", "framepack", "framerate",
+    "framestep", "freezedetect", "freezeframes", "frei0r", "fspp", "fsync", "gblur",
+    "gblur_vulkan", "geq", "gradfun", "graphmonitor", "grayworld", "greyedge", "guided", "haas",
+    "haldclut", "hdcd", "headphone", "hflip", "hflip_vulkan", "highpass", "highshelf", "histeq",
+    "histogram", "hqdn3d", "hqx", "hstack", "hstack_qsv", "hstack_vaapi", "hsvhold", "hsvkey",
+    "hue", "huesaturation", "hwdownload", "hwmap", "hwupload", "hwupload_cuda", "hysteresis",
+    "iccdetect", "iccgen", "identity", "idet", "il", "inflate", "interlace", "interlace_vulkan",
+    "interleave", "join", "kerndeint", "kirsch", "ladspa", "lagfun", "latency", "lcevc",
+    "lenscorrection", "lensfun", "libplacebo", "libvmaf", "libvmaf_cuda", "limitdiff", "limiter",
+    "loop", "loudnorm", "lowpass", "lowshelf", "lumakey", "lut", "lut1d", "lut2", "lut3d",
+    "lutrgb", "lutyuv", "lv2", "maskedclamp", "maskedmax", "maskedmerge", "maskedmin",
+    "maskedthreshold", "maskfun", "mcdeint", "mcompand", "median", "mergeplanes", "mestimate",
+    "metadata", "midequalizer", "minterpolate", "mix", "monochrome", "morpho", "mpdecimate",
+    "msad", "multiply", "negate", "nlmeans", "nlmeans_opencl", "nlmeans_vulkan", "nnedi",
+    "noformat", "noise", "normalize", "null", "ocr", "ocv", "oscilloscope", "overlay",
+    "overlay_cuda", "overlay_opencl", "overlay_qsv", "overlay_vaapi", "overlay_vulkan",
+    "owdenoise", "pad", "pad_cuda", "pad_opencl", "pad_vaapi", "palettegen", "paletteuse",
+    "pan", "perms", "perspective", "phase", "photosensitivity", "pixdesctest", "pixelize",
+    "pixscope", "pp7", "premultiply", "prewitt", "prewitt_opencl", "procamp_vaapi",
+    "program_opencl", "pseudocolor", "psnr", "pullup", "qp", "qrencode", "quirc", "random",
+    "readeia608", "readvitc", "realtime", "remap", "remap_opencl", "removegrain", "removelogo",
+    "repeatfields", "replaygain", "reverse", "rgbashift", "roberts", "roberts_opencl", "rotate",
+    "rubberband", "sab", "scale", "scale2ref", "scale2ref_npp", "scale_cuda", "scale_d3d11",
+    "scale_npp", "scale_qsv", "scale_vaapi", "scale_vt", "scale_vulkan", "scdet",
+    "scdet_vulkan", "scharr", "scroll", "segment", "select", "selectivecolor", "sendcmd",
+    "separatefields", "setdar", "setfield", "setparams", "setpts", "setrange", "setsar", "settb",
+    "sharpen_npp", "sharpness_vaapi", "shear", "showinfo", "showpalette", "shuffleframes",
+    "shufflepixels", "shuffleplanes", "sidechaincompress", "sidechaingate", "sidedata",
+    "signalstats", "signature", "silencedetect", "silenceremove", "siti", "smartblur", "sobel",
+    "sobel_opencl", "sofalizer", "speechnorm", "split", "spp", "sr", "sr_amf", "ssim", "ssim360",
+    "stereo3d", "stereotools", "stereowiden", "streamselect", "subtitles", "super2xsai",
+    "superequalizer", "surround", "swaprect", "swapuv", "tblend", "telecine", "thistogram",
+    "threshold", "thumbnail", "thumbnail_cuda", "tile", "tiltandshift", "tiltshelf", "tinterlace",
+    "tlut2", "tmedian", "tmidequalizer", "tmix", "tonemap", "tonemap_opencl", "tonemap_vaapi",
+    "tpad", "transpose", "transpose_npp", "transpose_opencl", "transpose_vaapi", "transpose_vt",
+    "transpose_vulkan", "treble", "tremolo", "trim", "unpremultiply", "unsharp", "unsharp_opencl",
+    "untile", "uspp", "v360", "vaguedenoiser", "varblur", "vectorscope", "vflip", "vflip_vulkan",
+    "vfrdet", "vibrance", "vibrato", "vidstabdetect", "vidstabtransform", "vif", "vignette",
+    "virtualbass", "vmafmotion", "volume", "volumedetect", "vpp_amf", "vpp_qsv", "vstack",
+    "vstack_qsv", "vstack_vaapi", "w3fdif", "waveform", "weave", "whisper", "xbr", "xcorrelate",
+    "xfade", "xfade_opencl", "xfade_vulkan", "xmedian", "xpsnr", "xstack", "xstack_qsv",
+    "xstack_vaapi", "yadif", "yadif_cuda", "yadif_videotoolbox", "yaepblur", "zmq", "zoompan",
+    "zscale",
+]
+
+# =========================================================================
+# Extract format mappings from embedded data
+# =========================================================================
+def load_ffmpeg_mlt_mapping():
+    """Extract mappings from embedded data"""
+    audio_map = FFMPEG_TO_MLT_MAPPINGS["audio_mapping"]
+    video_map = FFMPEG_TO_MLT_MAPPINGS["video_mapping"]
+    return audio_map, video_map
+
+
+# =========================================================================
+# Load filter list (embedded)
+# =========================================================================
+def load_filter_list():
+    """Return embedded FFmpeg filter list"""
+    return FFMPEG_FILTERS
+
+
+# =========================================================================
+# Build symbol -> source file map
+# Parse allfilters.c for extern declarations to get symbol names,
+# then find defining .c file.
+# =========================================================================
+def build_symbol_to_file_map():
+    """Returns symbol_name -> filepath, e.g. 'ff_vf_colorbalance' -> '...vf_colorbalance.c'
+    Also builds a map of all source file texts for macro-generated filter lookups."""
+    sym_to_file = {}
+    pattern = re.compile(r'const\s+FFFilter\s+(ff_\w+)\s*=')
+    global _src_cache
+    _src_cache = {}
+    for fname in os.listdir(FFMPEG_DIR):
+        if not fname.endswith('.c'):
+            continue
+        fpath = os.path.join(FFMPEG_DIR, fname)
+        try:
+            text = open(fpath).read()
+        except Exception:
+            continue
+        _src_cache[fpath] = text
+        for m in pattern.finditer(text):
+            sym_to_file[m.group(1)] = fpath
+    return sym_to_file
+
+
+_src_cache = {}
+
+
+def find_file_for_filter_name(filter_name):
+    """Fallback: find source file where filter_name is defined via a DEFINE_*_FILTER macro
+    or as .name = "filter_name" in an AVFilter struct."""
+    # Match DEFINE_*FILTER(filter_name, ...) or .name = "filter_name"
+    pattern = re.compile(
+        r'DEFINE_\w+\s*\(\s*' + re.escape(filter_name) + r'\s*,'
+        r'|\.name\s*=\s*"' + re.escape(filter_name) + r'"'
+    )
+    for fpath, text in _src_cache.items():
+        if pattern.search(text):
+            return fpath
+    return None
+
+
+# =========================================================================
+# Parse allfilters.c to get filter_name -> symbol mapping
+# =========================================================================
+def parse_allfilters():
+    """Returns filter_name -> symbol, e.g. 'colorbalance' -> 'ff_vf_colorbalance'"""
+    name_to_sym = {}
+    # extern declarations like: extern const FFFilter ff_vf_colorbalance;
+    pattern = re.compile(r'extern\s+const\s+FFFilter\s+(ff_\w+)\s*;')
+    text = open(ALLFILTERS).read()
+    for m in pattern.finditer(text):
+        sym = m.group(1)
+        # strip prefix ff_Xt_ where Xt is 2-3 char type code
+        # e.g. ff_vf_colorbalance -> colorbalance
+        # ff_af_acompressor -> acompressor
+        # ff_avf_concat -> concat
+        # ff_src_color -> color
+        # ff_asrc_anullsrc -> anullsrc
+        # ff_bsf_... -> skip (bitstream filters, not in our list)
+        parts = sym.split('_', 2)  # ['ff', 'vf', 'colorbalance']
+        if len(parts) >= 3:
+            name = parts[2]
+        else:
+            name = sym[3:]  # fallback
+        # Handle multi-segment names: ff_ff_filter -> keep as-is
+        name_to_sym[name] = sym
+    return name_to_sym
+
+
+# =========================================================================
+# Extract format lists from a source file
+# Handles:
+#   static const enum AVPixelFormat pix_fmts[] = { ... };
+#   static const enum AVSampleFormat sample_fmts[] = { ... };
+#   FILTER_PIXFMTS(AV_PIX_FMT_X, ...)
+#   FILTER_SAMPLEFMTS(AV_SAMPLE_FMT_X, ...)
+#   FILTER_PIXFMTS_ARRAY(pix_fmts)  -> resolves to the array
+#   FILTER_SAMPLEFMTS_ARRAY(sample_fmts) -> resolves to the array
+# Returns (pix_fmts: list[str], sample_fmts: list[str]) with raw FFmpeg names
+# =========================================================================
+
+
+def extract_raw_brace_block(text, start_pos):
+    """Extract the raw text content of a { ... } block starting at start_pos."""
+    depth = 0
+    i = start_pos
+    buf = []
+    while i < len(text):
+        c = text[i]
+        if c == '{':
+            depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                break
+        elif depth > 0:
+            buf.append(c)
+        i += 1
+    return ''.join(buf)
+
+
+def extract_enum_values_from_brace_block(text, start_pos):
+    """Extract comma-separated C enum values from a { ... } block starting at start_pos."""
+    block = extract_raw_brace_block(text, start_pos)
+    return re.findall(r'AV_(?:PIX_FMT|SAMPLE_FMT)_\w+', block)
+
+
+def is_metadata_only_filter(filepath, filter_name):
+    """
+    Check if a filter is flagged with AVFILTER_FLAG_METADATA_ONLY.
+    This means the filter only modifies metadata, not pixel data.
+    """
+    try:
+        text = open(filepath).read()
+    except Exception:
+        return False
+
+    # Look for AVFILTER_FLAG_METADATA_ONLY in the FFFilter struct for this filter
+    # Match patterns like: const FFFilter ff_af_acue = { ... .p.flags = AVFILTER_FLAG_METADATA_ONLY ... }
+    pattern = re.compile(
+        r'const\s+FFFilter\s+ff_\w+\s*=\s*\{[^}]*\.p\.flags\s*=\s*AVFILTER_FLAG_METADATA_ONLY'
+    )
+    if pattern.search(text):
+        return True
+    return False
+
+
+def extract_formats_from_file(filepath):
+    """
+    Returns (pix_fmt_set, sample_fmt_set) or (None, None) if formats are dynamic.
+    An empty list means 'no static formats found'.
+    None means 'dynamic / accepts all' - leave blank.
+    """
+    try:
+        text = open(filepath).read()
+    except Exception:
+        return None, None
+
+    # --- Step 0: Build a macro expansion map for macros containing AV_*_FMT_* ---
+    macro_expansions = {}  # macro_name -> list of AV_*_FMT_* values
+    # Match #define NAME \ followed by lines with AV_PIX_FMT_* or AV_SAMPLE_FMT_*
+    macro_re = re.compile(
+        r'#\s*define\s+(\w+)\s+((?:[^\n\\]*\\\n)*[^\n\\]*)',
+        re.MULTILINE
+    )
+    for m in macro_re.finditer(text):
+        name = m.group(1)
+        body = m.group(2).replace('\\\n', ' ')
+        fmts = re.findall(r'AV_(?:PIX_FMT|SAMPLE_FMT)_\w+', body)
+        if fmts:
+            macro_expansions[name] = fmts
+
+    def expand_block(block):
+        """Extract AV_*_FMT_* values from a block, expanding known macros."""
+        results = re.findall(r'AV_(?:PIX_FMT|SAMPLE_FMT)_\w+', block)
+        # Also expand any macro names that appear in the block
+        for word in re.findall(r'\b([A-Z][A-Z0-9_]+)\b', block):
+            if word in macro_expansions:
+                results.extend(macro_expansions[word])
+        return results
+
+    pix_fmt_enums = []
+    sample_fmt_enums = []
+
+    # Match static pix_fmts arrays, including multidimensional declarations
+    # like: sample_fmts[3][3] = { ... } used by filters such as aap.
+    for m in re.finditer(
+        r'static\s+const\s+enum\s+AVPixelFormat\s+\w+(?:\s*\[[^\]]*\])+\s*=\s*\{', text
+    ):
+        vals = expand_block(
+            extract_raw_brace_block(text, m.end() - 1)
+        )
+        pix_fmt_enums.extend(vals)
+
+    # Match static sample_fmts arrays, including multidimensional declarations.
+    for m in re.finditer(
+        r'static\s+const\s+enum\s+AVSampleFormat\s+\w+(?:\s*\[[^\]]*\])+\s*=\s*\{', text
+    ):
+        vals = expand_block(
+            extract_raw_brace_block(text, m.end() - 1)
+        )
+        sample_fmt_enums.extend(vals)
+
+    # FILTER_PIXFMTS(...) macro - inline list
+    for m in re.finditer(r'FILTER_PIXFMTS\s*\(', text):
+        i = m.end()
+        depth = 1
+        buf = []
+        while i < len(text) and depth > 0:
+            if text[i] == '(': depth += 1
+            elif text[i] == ')': depth -= 1
+            if depth > 0: buf.append(text[i])
+            i += 1
+        pix_fmt_enums.extend(expand_block(''.join(buf)))
+
+    # FILTER_SINGLE_PIXFMT(...) macro - one explicit pixel format
+    for m in re.finditer(r'FILTER_SINGLE_PIXFMT\s*\(', text):
+        i = m.end()
+        depth = 1
+        buf = []
+        while i < len(text) and depth > 0:
+            if text[i] == '(':
+                depth += 1
+            elif text[i] == ')':
+                depth -= 1
+            if depth > 0:
+                buf.append(text[i])
+            i += 1
+        pix_fmt_enums.extend(expand_block(''.join(buf)))
+
+    # FILTER_SAMPLEFMTS(...) macro - inline list
+    for m in re.finditer(r'FILTER_SAMPLEFMTS\s*\(', text):
+        i = m.end()
+        depth = 1
+        buf = []
+        while i < len(text) and depth > 0:
+            if text[i] == '(': depth += 1
+            elif text[i] == ')': depth -= 1
+            if depth > 0: buf.append(text[i])
+            i += 1
+        sample_fmt_enums.extend(expand_block(''.join(buf)))
+
+    # FILTER_SINGLE_SAMPLEFMT(...) macro - one explicit sample format
+    for m in re.finditer(r'FILTER_SINGLE_SAMPLEFMT\s*\(', text):
+        i = m.end()
+        depth = 1
+        buf = []
+        while i < len(text) and depth > 0:
+            if text[i] == '(':
+                depth += 1
+            elif text[i] == ')':
+                depth -= 1
+            if depth > 0:
+                buf.append(text[i])
+            i += 1
+        sample_fmt_enums.extend(expand_block(''.join(buf)))
+
+    # Dynamic query_formats - if present and no static formats found, signal dynamic
+    has_dynamic = bool(re.search(r'FILTER_QUERY_FUNC|query_formats\s*\(', text))
+    has_all_formats = bool(re.search(r'ff_all_formats\b|ff_all_samplefmts\b', text))
+
+    pix_fmts = None
+    sample_fmts = None
+
+    if pix_fmt_enums:
+        pix_fmts = list(dict.fromkeys(pix_fmt_enums))
+    elif has_all_formats or (has_dynamic and not sample_fmt_enums):
+        pix_fmts = None
+
+    if sample_fmt_enums:
+        sample_fmts = list(dict.fromkeys(sample_fmt_enums))
+    elif has_all_formats or (has_dynamic and not pix_fmt_enums):
+        sample_fmts = None
+
+    return pix_fmts, sample_fmts
+
+
+# =========================================================================
+# Map FFmpeg format enum to MLT format name
+# =========================================================================
+def ffmpeg_fmt_to_key(fmt_enum):
+    """Convert AV_PIX_FMT_YUV420P -> yuv420p, AV_SAMPLE_FMT_FLT -> flt"""
+    if fmt_enum.startswith('AV_PIX_FMT_'):
+        return fmt_enum[len('AV_PIX_FMT_'):].lower()
+    if fmt_enum.startswith('AV_SAMPLE_FMT_'):
+        return fmt_enum[len('AV_SAMPLE_FMT_'):].lower()
+    return fmt_enum.lower()
+
+
+def map_formats(ffmpeg_enums, mapping):
+    """Map a list of AV_*_FMT_* names to deduplicated MLT format names.
+    Handles native-endian aliases (e.g. AV_PIX_FMT_RGB48 -> try 'rgb48be' fallback)."""
+    mlt_fmts = []
+    for e in ffmpeg_enums:
+        key = ffmpeg_fmt_to_key(e)
+        mlt = mapping.get(key)
+        # Fallback: try with 'be'/'le' suffix for native-endian aliases
+        if not mlt:
+            mlt = mapping.get(key + 'be') or mapping.get(key + 'le')
+        if mlt and mlt != 'none' and mlt not in mlt_fmts:
+            mlt_fmts.append(mlt)
+    return mlt_fmts
+
+
+# =========================================================================
+# Check if a filter is likely hardware-accelerated based on name pattern
+# =========================================================================
+def is_likely_hardware_filter(filter_name):
+    """Heuristic: check if filter name suggests hardware acceleration."""
+    hw_patterns = ['_qsv', '_vaapi', '_videotoolbox', '_cuda', '_opencl', '_vulkan', 'coreimage']
+    return any(pattern in filter_name for pattern in hw_patterns)
+
+
+# =========================================================================
+# Main
+# =========================================================================
+def main():
+    global FFMPEG_DIR, ALLFILTERS, OUT_YML
+    
+    # Parse command-line arguments
+    args = parse_args()
+    
+    print(f"Using FFmpeg directory: {FFMPEG_DIR}")
+    print(f"Output YAML file: {OUT_YML}")
+    
+    audio_map, video_map = load_ffmpeg_mlt_mapping()
+    filter_names = load_filter_list()
+    print(f"Loaded {len(filter_names)} filters, {len(audio_map)} audio mappings, {len(video_map)} video mappings")
+
+    name_to_sym = parse_allfilters()
+    sym_to_file = build_symbol_to_file_map()
+    print(f"Parsed {len(name_to_sym)} filter symbols, {len(sym_to_file)} source files")
+
+    results = {}  # filter_name -> {'audio_formats': [...], 'image_formats': [...], 'metadata_only': bool, 'format_agnostic': bool, 'hardware_only': bool}
+    stats = {'static_pix': 0, 'static_samp': 0, 'dynamic': 0, 'not_found': 0, 'metadata_only': 0, 'format_agnostic': 0, 'hardware_only': 0}
+
+    for name in filter_names:
+        sym = name_to_sym.get(name)
+        src_file = sym_to_file.get(sym) if sym else None
+
+        if not src_file:
+            # Fallback for macro-generated filters (e.g. biquad family, lut family)
+            src_file = find_file_for_filter_name(name)
+
+        if not src_file:
+            # Could not find source file - check if it's likely hardware-accelerated
+            # based on naming pattern
+            entry = {'metadata_only': False, 'format_agnostic': False, 'hardware_only': False}
+            if is_likely_hardware_filter(name):
+                entry['hardware_only'] = True
+                stats['hardware_only'] += 1
+            else:
+                stats['not_found'] += 1
+            results[name] = entry
+            continue
+
+        # Check if this filter is metadata-only
+        is_metadata_only = is_metadata_only_filter(src_file, name)
+
+        entry = {'metadata_only': is_metadata_only, 'format_agnostic': False, 'hardware_only': False}
+        if is_metadata_only:
+            stats['metadata_only'] += 1
+        else:
+            pix_enums, samp_enums = extract_formats_from_file(src_file)
+
+            # If both audio and video format enums are None (not empty lists, but None),
+            # it means the filter accepts all formats dynamically - mark as format_agnostic
+            if pix_enums is None and samp_enums is None:
+                entry['format_agnostic'] = True
+                stats['format_agnostic'] += 1
+            else:
+                # Try to map the extracted formats
+                mlt_img = map_formats(pix_enums, video_map) if pix_enums is not None else []
+                mlt_aud = map_formats(samp_enums, audio_map) if samp_enums is not None else []
+
+                # Check if we extracted formats but couldn't map any of them
+                # This indicates hardware-only or unsupported formats
+                has_extracted_pix = pix_enums is not None and len(pix_enums) > 0
+                has_extracted_samp = samp_enums is not None and len(samp_enums) > 0
+                has_mapped_pix = len(mlt_img) > 0
+                has_mapped_samp = len(mlt_aud) > 0
+
+                # If we extracted formats but couldn't map them, it's hardware-only
+                if (has_extracted_pix and not has_mapped_pix) or (has_extracted_samp and not has_mapped_samp):
+                    entry['hardware_only'] = True
+                    stats['hardware_only'] += 1
+                else:
+                    # Normal case: add whatever we could map
+                    if mlt_img:
+                        entry['image_formats'] = mlt_img
+                        stats['static_pix'] += 1
+                    if mlt_aud:
+                        entry['audio_formats'] = mlt_aud
+                        stats['static_samp'] += 1
+
+        results[name] = entry
+
+    print(f"Stats: static_pix={stats['static_pix']}, static_samp={stats['static_samp']}, "
+          f"dynamic/all={stats['dynamic']}, metadata_only={stats['metadata_only']}, "
+          f"format_agnostic={stats['format_agnostic']}, hardware_only={stats['hardware_only']}, not_found={stats['not_found']}")
+    print(f"Filters with image_formats: {sum(1 for v in results.values() if 'image_formats' in v)}")
+    print(f"Filters with audio_formats: {sum(1 for v in results.values() if 'audio_formats' in v)}")
+
+    # Write YAML (manually, to avoid dependency on PyYAML)
+    lines = [
+        "# FFmpeg filter supported MLT formats",
+        "# One entry per filter. audio_formats/image_formats populated from FFmpeg source.",
+        "# Filters without known formats are placeholders encoded as \"\" (not empty maps).",
+        "# Filters marked as 'metadata only' process metadata only, passing data unchanged.",
+        "# Filters marked as 'format agnostic' accept all formats dynamically with no static restrictions.",
+        "# Filters marked as 'hardware only' accept only hardware/GPU formats not directly supported by MLT.",
+        "",
+    ]
+    for name in filter_names:
+        entry = results.get(name, {})
+        is_metadata_only = entry.get('metadata_only', False)
+        is_format_agnostic = entry.get('format_agnostic', False)
+        is_hardware_only = entry.get('hardware_only', False)
+
+        if not entry or (is_metadata_only and 'audio_formats' not in entry and 'image_formats' not in entry) \
+           or (is_format_agnostic and 'audio_formats' not in entry and 'image_formats' not in entry) \
+           or (is_hardware_only and 'audio_formats' not in entry and 'image_formats' not in entry):
+            if is_metadata_only:
+                lines.append(f'{name}: ""  # metadata only')
+            elif is_hardware_only:
+                lines.append(f'{name}: ""  # hardware only')
+            elif is_format_agnostic:
+                lines.append(f'{name}: ""  # format agnostic')
+            else:
+                lines.append(f'{name}: ""')
+        else:
+            lines.append(f'{name}:')
+            if 'audio_formats' in entry:
+                lines.append('  audio_formats:')
+                for fmt in entry['audio_formats']:
+                    lines.append(f'    - {fmt}')
+            if 'image_formats' in entry:
+                lines.append('  image_formats:')
+                for fmt in entry['image_formats']:
+                    lines.append(f'    - {fmt}')
+            if is_metadata_only:
+                lines.append('  # metadata only')
+            elif is_hardware_only:
+                lines.append('  # hardware only')
+            elif is_format_agnostic:
+                lines.append('  # format agnostic')
+
+    with open(OUT_YML, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+
+    print(f"Written: {OUT_YML}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/modules/avformat/link_avdeinterlace.yml
+++ b/src/modules/avformat/link_avdeinterlace.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: link
 identifier: avdeinterlace
 title: FFmpeg Deinterlacer
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,4 +15,12 @@ description: >
   
   This link can be added to a chain to normalize video from the producer to
   provide deinterlaced images if requested by the consumer.
-  
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv422p16
+  - yuv444p10

--- a/src/modules/avformat/link_swresample.yml
+++ b/src/modules/avformat/link_swresample.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: link
 identifier: swresample
 title: FFmpeg Audio Resampler
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,3 +15,10 @@ description: >
   
   This link can be added to a chain to normalize audio from the producer to
   provide the rate, channels and format requested by the consumer.
+audio_formats:
+  - s16
+  - s32
+  - s32le
+  - float
+  - f32le
+  - u8

--- a/src/modules/avformat/producer_avformat-novalidate.yml
+++ b/src/modules/avformat/producer_avformat-novalidate.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: avformat-novalidate
 title: Non-validating FFmpeg Reader
-version: 3
+version: 4
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -18,3 +18,19 @@ notes: >
   validation also determines the length property, you should set that yourself
   on this producer after having learned it from the normal avformat producer.
   See the documentation for the normal avformat producer for more information.
+audio_formats:
+  - s16
+  - s32
+  - s32le
+  - float
+  - f32le
+  - u8
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv422p16
+  - yuv444p10

--- a/src/modules/avformat/producer_avformat.yml
+++ b/src/modules/avformat/producer_avformat.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: producer
 identifier: avformat
 title: FFmpeg Reader
-version: 6
+version: 7
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -43,6 +43,22 @@ bugs:
   - >
     More than 2 channels of audio more than 16 bits is not supported.
 
+audio_formats:
+  - s16
+  - s32
+  - s32le
+  - float
+  - f32le
+  - u8
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv422p16
+  - yuv444p10
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/core/consumer_multi.yml
+++ b/src/modules/core/consumer_multi.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: consumer
 identifier: multi
 title: Multiple outputs
-version: 1
+version: 2
 copyright: Copyright (C) 2011-2014 Meltytech, LLC
 license: LGPL
 language: en
@@ -28,6 +28,8 @@ notes: |
   This is also the recommended way for applications to interact with this
   consumer, which is how melt and the XML producer support multiple consumers.
 
+audio_formats:
+  - s16
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/core/filter_audiochannels.yml
+++ b/src/modules/core/filter_audiochannels.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: audiochannels
 title: Convert Audio Channel Count
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -13,3 +13,10 @@ notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it if it is available to automatically all inputs to have the number
   of audio channels requested by the consumer.
+audio_formats:
+  - f32le
+  - float
+  - s16
+  - s32
+  - s32le
+  - u8

--- a/src/modules/core/filter_audioconvert.yml
+++ b/src/modules/core/filter_audioconvert.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: audioconvert
 title: Audio Sample Format Converter
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -12,3 +12,10 @@ description: Converts the audio sample format.
 notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it to set the convert_audio function pointer on frames.
+audio_formats:
+  - f32le
+  - float
+  - s16
+  - s32
+  - s32le
+  - u8

--- a/src/modules/core/filter_audiomap.yml
+++ b/src/modules/core/filter_audiomap.yml
@@ -1,8 +1,8 @@
-schema_version: 0.2
+schema_version: 7.2
 type: filter
 identifier: audiomap
 title: Remap Channels
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Maksym Veremeyenko
 license: LGPLv2.1
@@ -10,6 +10,13 @@ language: en
 tags:
   - Audio
 description: Copy/swap channels according to given mapping.
+audio_formats:
+  - f32le
+  - float
+  - s16
+  - s32
+  - s32le
+  - u8
 parameters:
   - identifier: '0'
     title: Source of channel 0

--- a/src/modules/core/filter_audioseam.yml
+++ b/src/modules/core/filter_audioseam.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: audioseam
 title: Audio Seam
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -14,7 +14,8 @@ description: >
   Uses the "meta.playlist.clip_position" and "meta.playlist.clip_length"
   properties that are added by the playlist producer to determine where
   the seams between clips occur.
-
+audio_formats:
+  - f32le
 parameters:
   - identifier: discontinuity_threshold
     title: Discontinuity Threshold

--- a/src/modules/core/filter_audiowave.yml
+++ b/src/modules/core/filter_audiowave.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: audiowave
 title: Audio Waveform (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -17,3 +17,5 @@ bugs:
     This does not work alone on audio-only clips. It must have video to overwrite.
     A workaround is to apply this to a multitrack with a color generator.
   - The quality of the waveforms is not so good especially for high definition video.
+image_formats:
+  - yuv422

--- a/src/modules/core/filter_autofade.yml
+++ b/src/modules/core/filter_autofade.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: autofade
 title: Auto Fade
-version: 3
+version: 4
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -16,7 +16,11 @@ description: >
   Uses the "meta.playlist.clip_position" and "meta.playlist.clip_length"
   properties that are added by the playlist producer to determine where
   the splices between clips occur.
-
+audio_formats:
+  - f32le
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: fade_duration
     title: Fade Duration

--- a/src/modules/core/filter_box_blur.yml
+++ b/src/modules/core/filter_box_blur.yml
@@ -1,13 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: box_blur
 title: Box Blur
-version: 3
+version: 4
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgba
+  - rgba64
 parameters:
 
   - identifier: hradius

--- a/src/modules/core/filter_brightness.yml
+++ b/src/modules/core/filter_brightness.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: brightness
 title: Brightness
-version: 5
+version: 6
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -10,6 +10,10 @@ language: en
 description: Adjust the brightness and opacity of the image.
 tags:
   - Video
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
 parameters:
   - identifier: start
     title: Start level (*DEPRECATED*)

--- a/src/modules/core/filter_channelcopy.yml
+++ b/src/modules/core/filter_channelcopy.yml
@@ -1,8 +1,8 @@
-schema_version: 0.2
+schema_version: 7.2
 type: filter
 identifier: channelcopy
 title: Copy Channels
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -10,6 +10,13 @@ language: en
 tags:
   - Audio
 description: Copy one audio channel to another.
+audio_formats:
+  - f32le
+  - float
+  - s16
+  - s32
+  - s32le
+  - u8
 parameters:
   - identifier: to
     title: To

--- a/src/modules/core/filter_choppy.yml
+++ b/src/modules/core/filter_choppy.yml
@@ -1,14 +1,23 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: choppy
 title: Choppy
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - yuv422p16
+  - yuv420p10
+  - yuv444p10
+  - rgba64
 parameters:
   - identifier: amount
     title: Repeat

--- a/src/modules/core/filter_color_transform.yml
+++ b/src/modules/core/filter_color_transform.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: color_transform
 title: Colorspace & Transfer Characteristics
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -16,6 +16,15 @@ description: >
   the output trc to be "force_trc";
   Otherwise, if a property "consumer.mlt_color_trc" exists on the frame, then it
   normalizes the image to the trc requested by the consumer.
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - yuv422p16
+  - yuv420p10
+  - yuv444p10
+  - rgba64
 parameters:
   - identifier: method
     argument: yes

--- a/src/modules/core/filter_crop.yml
+++ b/src/modules/core/filter_crop.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: crop
 title: Crop
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -16,6 +16,11 @@ notes: >
   stack and can request the full resolution of the source image. Then, a
   second instance of the filter may be applied to set the parameters of the
   crop operation.
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - rgba64
 parameters:
   - identifier: active
     argument: yes

--- a/src/modules/core/filter_fieldorder.yml
+++ b/src/modules/core/filter_fieldorder.yml
@@ -1,9 +1,9 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: fieldorder
 title: Field order
 description: Correct the field order of interlaced video.
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy <dan@dennedy.org>
 license: LGPLv2.1
@@ -20,3 +20,8 @@ notes: >
   If you set the property meta.swap_fields=1 on the producer, then this filter
   swaps the fields of an interlaced frame in addition to any field order
   correction by shifting the image.
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - rgba64

--- a/src/modules/core/filter_gamma.yml
+++ b/src/modules/core/filter_gamma.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: gamma
 title: Gamma
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -10,6 +10,8 @@ language: en
 tags:
   - Video
 description: Adjust image luma using a non-linear power-law curve.
+image_formats:
+  - yuv422
 parameters:
   - identifier: gamma
     argument: yes

--- a/src/modules/core/filter_greyscale.yml
+++ b/src/modules/core/filter_greyscale.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: greyscale
 title: Greyscale
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -10,3 +10,5 @@ language: en
 tags:
   - Video
 description: Convert colour image to greyscale
+image_formats:
+  - yuv422

--- a/src/modules/core/filter_imageconvert.yml
+++ b/src/modules/core/filter_imageconvert.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: imageconvert
 title: Basic Image Converter
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -14,3 +14,8 @@ notes: >
   loads it if it is available to set the convert_image function pointer on frames.
   This implementation is old and naive by assuming all YCbCr video is ITU-R BT.601
   and all RGB is sRGB.
+image_formats:
+  - rgb
+  - rgba
+  - yuv420p
+  - yuv422

--- a/src/modules/core/filter_luma.yml
+++ b/src/modules/core/filter_luma.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: luma
 title: Wipe
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -12,6 +12,8 @@ tags:
 description: >
   Applies a luma transition between the current and next frames. Useful for 
   transitions from a slideshow created using producer pixbuf.
+image_formats:
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/core/filter_mask_apply.yml
+++ b/src/modules/core/filter_mask_apply.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: mask_apply
 title: Apply a filter mask
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -13,6 +13,12 @@ description: >
   This filter works in conjunction with the mask_start filter, which makes a
   snapshot of the frame. There can be other filters between the two, which
   are masked by the alpha channel via this filter's compositing transition.
+
+image_formats:
+  - yuv422
+  - rgb
+  - rgba
+  - rgba64
 
 parameters:
   - identifier: transition

--- a/src/modules/core/filter_mask_start.yml
+++ b/src/modules/core/filter_mask_start.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: mask_start
 title: Setup a filter mask
-version: 4
+version: 5
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -16,7 +16,11 @@ description: >
   the mask_apply filter uses a transition to composite the current frame's
   image over the snapshot. The typical use case is to add filters in the
   following sequence: mask_start, zero or more filters, mask_apply.
-
+image_formats:
+  - yuv422
+  - rgb
+  - rgba
+  - rgba64
 parameters:
   - identifier: filter
     title: Filter

--- a/src/modules/core/filter_mirror.yml
+++ b/src/modules/core/filter_mirror.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: mirror
 title: Mirror
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -11,6 +11,8 @@ tags:
   - Video
 description: >
   Provides various mirror and image reversing effects.
+image_formats:
+  - yuv422
 parameters:
   - identifier: mirror
     argument: yes

--- a/src/modules/core/filter_mono.yml
+++ b/src/modules/core/filter_mono.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: mono
 title: Mixdown
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -11,6 +11,13 @@ tags:
   - Audio
 description: >
   Mix all channels of audio into a mono signal and output it as N channels.
+audio_formats:
+  - f32le
+  - float
+  - s16
+  - s32
+  - s32le
+  - u8
 parameters:
   - identifier: channels
     argument: yes

--- a/src/modules/core/filter_obscure.yml
+++ b/src/modules/core/filter_obscure.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: obscure
 title: Obscure (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -11,6 +11,8 @@ tags:
   - Video
 description: >
    Obscuring filter.
+image_formats:
+  - yuv422
 parameters:
   - identifier: start
     argument: yes

--- a/src/modules/core/filter_panner.yml
+++ b/src/modules/core/filter_panner.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: panner
 title: Audio Pan
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -11,6 +11,8 @@ tags:
   - Audio
 description: Pan an audio channel, adjust balance, or adjust fade.
 notes: Only handles up to 6 channels. Needs more work balance for surround and other channel layouts.
+audio_formats:
+  - f32le
 parameters:
   - identifier: start (*deprecated*)
     title: Start

--- a/src/modules/core/filter_pillar_echo.yml
+++ b/src/modules/core/filter_pillar_echo.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: pillar_echo
 title: Pillar Echo
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -13,6 +13,9 @@ description: >
   
   The area of interest is scaled to fill the image, then blurred. Then the
   original image is replaced back on top.
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: rect
     title: Rectangle

--- a/src/modules/core/filter_rescale.yml
+++ b/src/modules/core/filter_rescale.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: rescale
 title: Rescale
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy <dan@dennedy.org>
 license: LGPLv2.1
@@ -24,3 +24,11 @@ bugs:
   - > 
     It only implements a nearest neighbour scaling - it is used as the base 
     class for the gtkrescale and swscale filters.
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv420p10
+  - yuv422
+  - yuv444p10

--- a/src/modules/core/filter_resize.yml
+++ b/src/modules/core/filter_resize.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: resize
 title: Pad
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Charles Yates <charles.yates@pandora.be>
 license: LGPLv2.1
@@ -16,3 +16,8 @@ notes: >
   requested after an upstream rescale filter first scales the image to maximise 
   usage of the image area. This filter is automatically invoked by the loader
   as part of image normalization.
+image_formats:
+  - rgb
+  - rgba
+  - yuv420p
+  - yuv422

--- a/src/modules/core/link_timeremap.yml
+++ b/src/modules/core/link_timeremap.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: link
 identifier: timeremap
 title: Time Remap
-version: 3
+version: 4
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -10,6 +10,14 @@ tags:
   - Audio
   - Video
 description: Remap frames in time.
+audio_formats:
+  - float
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - rgba64
 parameters:
   - identifier: time_map
     title: Time Map

--- a/src/modules/core/producer_colour.yml
+++ b/src/modules/core/producer_colour.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: producer
 identifier: colour
 title: Color
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -10,6 +10,12 @@ language: en
 tags:
   - Video
 description: A simple color generator.
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/core/producer_noise.yml
+++ b/src/modules/core/producer_noise.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: producer
 identifier: noise
 title: Noise
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -11,3 +11,7 @@ tags:
   - Audio
   - Video
 description: White noise producer
+audio_formats:
+  - s16
+image_formats:
+  - yuv422

--- a/src/modules/core/producer_tone.yml
+++ b/src/modules/core/producer_tone.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: producer
 identifier: tone
 title: Tone
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -10,6 +10,8 @@ tags:
   - Audio
 description: >
   Generate audio tones.
+audio_formats:
+  - float
 parameters:
   - identifier: frequency
     title: Frequency

--- a/src/modules/core/transition_composite.yml
+++ b/src/modules/core/transition_composite.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: transition
 identifier: composite
 title: Composite (*DEPRECATED*)
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -23,6 +23,8 @@ notes: >
   "progressive" is set to 1.
 bugs:
   - Assumes lower field first during field rendering.
+image_formats:
+  - yuv422
 parameters:
   - identifier: factory
     title: Factory

--- a/src/modules/core/transition_luma.yml
+++ b/src/modules/core/transition_luma.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: transition
 identifier: luma
 title: Wipe
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -21,6 +21,10 @@ description: >
   "consumer_progressive" or the transition property "progressive" is set to 1.
 bugs:
   - Assumes lower field first output.
+image_formats:
+  - rgba
+  - rgba64
+  - yuv422
 parameters:
   - identifier: resource
     title: Luma map file

--- a/src/modules/core/transition_matte.yml
+++ b/src/modules/core/transition_matte.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: transition
 identifier: matte
 title: Matte
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Maksym Veremeyenko
 license: LGPLv2.1
@@ -48,3 +48,5 @@ notes: |
   melt sg_gm_2013_clip_title.matte_full.mp4 -track noise: -track \
     sg_gm_2013_clip_title.fill.mp4 -transition matte a_track=2 \
     b_track=0 -transition qtblend a_track=1 b_track=2
+image_formats:
+  - yuv422

--- a/src/modules/core/transition_mix.yml
+++ b/src/modules/core/transition_mix.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: transition
 identifier: mix
 title: Mix
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -12,6 +12,8 @@ tags:
 description: Mix two audio tracks.
 bugs:
   - Samples from the longer of the two frames are discarded.
+audio_formats:
+  - f32le
 parameters:
   - identifier: start
     title: Start

--- a/src/modules/decklink/consumer_decklink.yml
+++ b/src/modules/decklink/consumer_decklink.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: consumer
 identifier: decklink
 title: Blackmagic Design DeckLink Output
-version: 3
+version: 4
 copyright: Copyright (C) 2010-2025 Meltytech, LLC
 license: LGPL
 language: en
@@ -19,6 +19,11 @@ notes: >
 bugs:
   - Only internal keying is supported at this time.
   - Only 8-bit Y'CbCr or RGBA (key) is supported at this time.
+audio_formats:
+  - s16
+image_formats:
+  - rgba
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/decklink/producer_decklink.yml
+++ b/src/modules/decklink/producer_decklink.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: decklink
 title: Blackmagic Design DeckLink Capture
-version: 3
+version: 4
 copyright: Copyright (C) 2011-2025 Meltytech, LLC
 license: LGPL
 language: en
@@ -24,6 +24,11 @@ bugs:
   - Transport controls such as seeking has no affect.
   - External deck control is not implemented.
   - Only 8-bit Y'CbCr is supported at this time.
+audio_formats:
+  - s16
+image_formats:
+  - yuv422
+  - yuv422p16
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/frei0r/factory.c
+++ b/src/modules/frei0r/factory.c
@@ -99,6 +99,46 @@ static void check_thread_safe(mlt_properties properties, const char *name)
     mlt_properties_close(not_thread_safe);
 }
 
+static void add_metadata_formats(mlt_properties metadata,
+                                 mlt_service_type type,
+                                 const char *service_name)
+{
+    const char *plugin_name = service_name;
+
+    if (!metadata)
+        return;
+
+    if (type != mlt_service_producer_type && type != mlt_service_filter_type
+        && type != mlt_service_transition_type) {
+        return;
+    }
+
+    mlt_properties image_formats = mlt_properties_new();
+    if (!image_formats)
+        return;
+
+    mlt_properties_set(image_formats, "0", "rgba");
+
+    if (plugin_name && !strncmp(plugin_name, "frei0r.", 7))
+        plugin_name += 7;
+
+    if (type == mlt_service_filter_type) {
+        mlt_properties alpha_only = mlt_properties_get_data(mlt_global_properties(),
+                                                            "frei0r.alpha_only",
+                                                            NULL);
+        if (alpha_only && plugin_name && mlt_properties_exists(alpha_only, plugin_name)) {
+            mlt_properties_set(image_formats, "1", "rgba64");
+        }
+    }
+
+    mlt_properties_set_data(metadata,
+                            "image_formats",
+                            image_formats,
+                            0,
+                            (mlt_destructor) mlt_properties_close,
+                            NULL);
+}
+
 static mlt_properties fill_param_info(mlt_service_type type, const char *service_name, char *name)
 {
     char file[PATH_MAX];
@@ -164,7 +204,7 @@ static mlt_properties fill_param_info(mlt_service_type type, const char *service
     }
     plginfo(&info);
     snprintf(string, sizeof(string), "%d", info.minor_version);
-    mlt_properties_set(metadata, "schema_version", "7.0");
+    mlt_properties_set(metadata, "schema_version", "7.2");
     mlt_properties_set(metadata, "title", info.name);
     mlt_properties_set_double(metadata,
                               "version",
@@ -190,6 +230,7 @@ static mlt_properties fill_param_info(mlt_service_type type, const char *service
     mlt_properties tags = mlt_properties_new();
     mlt_properties_set_data(metadata, "tags", tags, 0, (mlt_destructor) mlt_properties_close, NULL);
     mlt_properties_set(tags, "0", "Video");
+    add_metadata_formats(metadata, type, service_name);
 
     mlt_properties parameter = mlt_properties_new();
     mlt_properties_set_data(metadata,

--- a/src/modules/gdk/filter_rescale.yml
+++ b/src/modules/gdk/filter_rescale.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: gtkrescale
 title: Gtk Rescale
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy <dan@dennedy.org>
 license: LGPLv2.1
@@ -20,6 +20,10 @@ notes: >
   option works best in conjunction with the resize filter. This behavior can be 
   disabled by another service by either removing the property, setting it to 
   zero, or setting frame property "distort" to 1.
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
 parameters:
   - identifier: interpolation
     argument: yes

--- a/src/modules/gdk/producer_pango.yml
+++ b/src/modules/gdk/producer_pango.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: producer
 identifier: pango
 title: Pango
-version: 3
+version: 4
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -37,8 +37,9 @@ notes: >
         mlt_producer_close(producer);
         mlt_profile_close(profile);
     };
-
-
+image_formats:
+  - rgb
+  - rgba
 parameters:
   - identifier: resource
     title: File

--- a/src/modules/gdk/producer_pixbuf.yml
+++ b/src/modules/gdk/producer_pixbuf.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: producer
 identifier: pixbuf
 title: GDK-PixBuf
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -18,7 +18,9 @@ notes: >
   height that maintains the image aspect.
   Environment variable MLT_PIXBUF_PRODUCER_CACHE could be used to to override
   /increase the number of cached converted images for simultaneous use.
-
+image_formats:
+  - rgb
+  - rgba
 parameters:
   - identifier: resource
     title: File

--- a/src/modules/glaxnimate/producer_glaxnimate.yml
+++ b/src/modules/glaxnimate/producer_glaxnimate.yml
@@ -1,14 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: glaxnimate
 title: Glaxnimate Animation
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: GPLv3
 language: en
 tags:
   - Video
 description: Reads a variety of 2D animations
+image_formats:
+  - rgba
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/jackrack/consumer_jack.yml
+++ b/src/modules/jackrack/consumer_jack.yml
@@ -1,14 +1,16 @@
-schema_version: 0.1
+schema_version: 7.2
 type: consumer
 identifier: jack
 title: JACK
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
 language: en
 tags:
   - Audio
+audio_formats:
+  - float
 parameters:
   - identifier: channels
     title: Channels

--- a/src/modules/jackrack/filter_jack.yml
+++ b/src/modules/jackrack/filter_jack.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: jack
 title: JACK
-version: 1
+version: 2
 copyright: Copyright (C) 2004-2018 Meltytech, LLC
 license: GPLv2
 language: en
@@ -27,7 +27,8 @@ bugs:
     Please make sure they are configured the same.
   - Does not automatically reconfigure to the number of channels requested by consumer.
   - Some effects have a temporal side-effect that may not work well.
-
+audio_formats:
+  - float
 parameters:
   - identifier: client_name
     title: JACK client name

--- a/src/modules/jackrack/filter_jackrack.yml
+++ b/src/modules/jackrack/filter_jackrack.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: jackrack
 title: JACK Rack XML (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Copyright (C) 2004-2018 Meltytech, LLC
 license: GPLv2
 language: en
@@ -27,7 +27,8 @@ bugs:
     Please make sure they are configured the same.
   - Does not automatically reconfigure to the number of channels requested by consumer.
   - Some effects have a temporal side-effect that may not work well.
-
+audio_formats:
+  - float
 parameters:
   - identifier: src
     title: JACK Rack file

--- a/src/modules/jackrack/filter_ladspa.yml
+++ b/src/modules/jackrack/filter_ladspa.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: ladspa
 title: LADSPA
-version: 2
+version: 3
 license: GPLv2
 language: en
 url: http://www.ladspa.org/
@@ -14,7 +14,8 @@ notes: >
   Automatically adapts to the number of channels and sampling rate of the consumer.
 bugs:
   - Some effects have a temporal side-effect that may not work well.
-
+audio_formats:
+  - float
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/jackrack/filter_lv2.yml
+++ b/src/modules/jackrack/filter_lv2.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: lv2
 title: LV2
-version: 2
+version: 3
 license: GPLv2
 language: en
 url: http://www.lv2.org/
@@ -12,7 +12,8 @@ tags:
 description: Process audio using LV2 plugins.
 notes: >
   Automatically adapts to the number of channels and sampling rate of the consumer.
-
+audio_formats:
+  - float
 parameters:
   - identifier: channel_mask
     title: Channel Mask

--- a/src/modules/jackrack/filter_vst2.yml
+++ b/src/modules/jackrack/filter_vst2.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: vst2
 title: VST2
-version: 2
+version: 3
 license: GPLv2
 language: en
 url: https://www.steinberg.net/en/company/technologies.html
@@ -12,7 +12,8 @@ tags:
 description: Process audio using VST2 plugins.
 notes: >
   Automatically adapts to the number of channels and sampling rate of the consumer.
-
+audio_formats:
+  - float
 parameters:
   - identifier: channel_mask
     title: Channel Mask

--- a/src/modules/jackrack/producer_ladspa.yml
+++ b/src/modules/jackrack/producer_ladspa.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: ladspa
 title: LADSPA
-version: 1
+version: 2
 license: GPLv2
 language: en
 tags:
@@ -10,4 +10,5 @@ tags:
 description: Generate audio using LADSPA plugins.
 notes: >
   Automatically adapts to the number of channels and sampling rate of the consumer.
-
+audio_formats:
+  - float

--- a/src/modules/jackrack/producer_lv2.yml
+++ b/src/modules/jackrack/producer_lv2.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: lv2
 title: LV2
-version: 1
+version: 2
 license: GPLv2
 language: en
 tags:
@@ -10,4 +10,5 @@ tags:
 description: Generate audio using LV2 plugins.
 notes: >
   Automatically adapts to the number of channels and sampling rate of the consumer.
-
+audio_formats:
+  - float

--- a/src/modules/jackrack/producer_vst2.yml
+++ b/src/modules/jackrack/producer_vst2.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: vst2
 title: VST2
-version: 1
+version: 2
 license: GPLv2
 language: en
 tags:
@@ -10,4 +10,5 @@ tags:
 description: Generate audio using VST2 plugins.
 notes: >
   Automatically adapts to the number of channels and sampling rate of the consumer.
-
+audio_formats:
+  - float

--- a/src/modules/kdenlive/filter_boxblur.yml
+++ b/src/modules/kdenlive/filter_boxblur.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: boxblur
 title: Box Blur (*DEPRECATED*)
-version: 3
+version: 4
 copyright: Leny Grisel, Jean-Baptiste Mardelle
 creator: Leny Grisel, Jean-Baptiste Mardelle
 license: LGPLv2.1
@@ -11,6 +11,8 @@ notes: >
     This filter is deprecated and will eventually be removed. Use the box_blur filter instead.
 tags:
   - Video
+image_formats:
+  - rgba
 parameters:
   - identifier: start (*DEPRECATED*)
     title: Size

--- a/src/modules/kdenlive/filter_freeze.yml
+++ b/src/modules/kdenlive/filter_freeze.yml
@@ -1,14 +1,23 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: freeze
 title: Freeze frame
-version: 1
+version: 2
 copyright: Jean-Baptiste Mardelle
 creator: Jean-Baptiste Mardelle
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - yuv422p16
+  - yuv420p10
+  - yuv444p10
+  - rgba64
 parameters:
   - identifier: frame
     title: Frame

--- a/src/modules/kdenlive/filter_wave.yml
+++ b/src/modules/kdenlive/filter_wave.yml
@@ -1,14 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: wave
 title: Wave
-version: 2
+version: 3
 copyright: Leny Grisel, Jean-Baptiste Mardelle
 creator: Leny Grisel, Jean-Baptiste Mardelle
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - yuv422
 parameters:
   - identifier: start (*DEPRECATED*)
     title: Amplitude

--- a/src/modules/kdenlive/producer_framebuffer.yml
+++ b/src/modules/kdenlive/producer_framebuffer.yml
@@ -1,11 +1,20 @@
-schema_version: 0.1
+schema_version: 7.2
 type: producer
 identifier: framebuffer
 title: Speed
-version: 1
+version: 2
 copyright: Jean-Baptiste Mardelle
 creator: Jean-Baptiste Mardelle
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - yuv422p16
+  - yuv420p10
+  - yuv444p10
+  - rgba64

--- a/src/modules/movit/consumer_xgl.yml
+++ b/src/modules/movit/consumer_xgl.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: consumer
 identifier: xgl
 title: OpenGL Video (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Christophe Thommeret
 license: LGPLv2.1
 language: en
@@ -12,3 +12,5 @@ description: Display the video only in a X11 window using OpenGL.
 notes: >
   The window is a fixed size 1280x720 regardless the profile or consumer
   width and height properties.
+image_formats:
+  - opengl_texture

--- a/src/modules/movit/filter_glsl_manager.yml
+++ b/src/modules/movit/filter_glsl_manager.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: glsl.manager
 title: GLSL Manager
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -13,3 +13,7 @@ description: >
 tags:
   - Video
   - Hidden
+image_formats:
+  - rgba
+  - rgba64
+  - yuv444p10

--- a/src/modules/movit/filter_movit_blur.yml
+++ b/src/modules/movit/filter_movit_blur.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.blur
 title: Blur (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -14,6 +14,8 @@ description: >
   and convolution (essentially giving a convolution with a piecewise linear
   approximation to the true impulse response).
 
+image_formats:
+  - glsl
 parameters:
   - identifier: radius
     title: Radius

--- a/src/modules/movit/filter_movit_convert.yml
+++ b/src/modules/movit/filter_movit_convert.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.convert
 title: Image Converter (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -15,3 +15,8 @@ description: Converts the colorspace and pixel format.
 notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it if it is available to set the convert_image function pointer on frames.
+image_formats:
+  - rgba
+  - rgba64
+  - yuv420p10
+  - yuv444p10

--- a/src/modules/movit/filter_movit_crop.yml
+++ b/src/modules/movit/filter_movit_crop.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.crop
 title: Crop (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -15,3 +15,5 @@ notes: >
   automatically by the loader so that cropping occurs early in the processing
   stack and can request the full resolution of the source image. Then, the core
   crop filter can be use to set the parameters of the crop operation.
+image_formats:
+  - glsl

--- a/src/modules/movit/filter_movit_deconvolution_sharpen.yml
+++ b/src/modules/movit/filter_movit_deconvolution_sharpen.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.sharpen
 title: Deconvolution Sharpen (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -18,7 +18,8 @@ description: >
   The effect gives generally better results than unsharp masking, but can be very
   GPU intensive, and requires a fair bit of tweaking to get good results without
   ringing and/or excessive noise.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: matrix_size
     title: Matrix Size

--- a/src/modules/movit/filter_movit_diffusion.yml
+++ b/src/modules/movit/filter_movit_diffusion.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.diffusion
 title: Diffusion (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -19,7 +19,8 @@ description: >
   We do a relatively simple version, sometimes known as "white diffusion",
   where we first blur the picture, and then overlay it on the original
   using the original as a matte.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: radius
     title: Blur Radius

--- a/src/modules/movit/filter_movit_flip.yml
+++ b/src/modules/movit/filter_movit_flip.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: movit.flip
 title: Flip (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -10,3 +10,5 @@ language: en
 description: A simple vertical flip.
 tags:
   - Video
+image_formats:
+  - glsl

--- a/src/modules/movit/filter_movit_glow.yml
+++ b/src/modules/movit/filter_movit_glow.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.glow
 title: Glow (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -12,7 +12,8 @@ tags:
 description: >
   Cut out the highlights of the image (everything above a certain threshold),
   blur them, and overlay them onto the original image.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: radius
     title: Radius

--- a/src/modules/movit/filter_movit_lift_gamma_gain.yml
+++ b/src/modules/movit/filter_movit_lift_gamma_gain.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: movit.lift_gamma_gain
 title: Lift, Gamma, and Gain (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -23,7 +23,8 @@ notes: >
   rest of the curve relatively little. Thus, we actually convert to gamma 2.2
   before lift, and then back again afterwards. (Gain and gamma are,
   up to constants, commutative with the de-gamma operation.)
-
+image_formats:
+  - glsl
 parameters:
   - identifier: lift_r
     title: Lift Red

--- a/src/modules/movit/filter_movit_mirror.yml
+++ b/src/modules/movit/filter_movit_mirror.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: movit.mirror
 title: Mirror (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -10,3 +10,5 @@ language: en
 description: A simple horizontal mirroring.
 tags:
   - Video
+image_formats:
+  - glsl

--- a/src/modules/movit/filter_movit_opacity.yml
+++ b/src/modules/movit/filter_movit_opacity.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.opacity
 title: Opacity (GLSL)
-version: 5
+version: 6
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -16,7 +16,8 @@ notes: >
   then this preserves that by multiplying the opacity level with the alpha channel.
   This filter is especially handy when used in conjunction with movit.overlay.
   You can also use this to fade a clip from and to black.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: opacity
     title: Opacity

--- a/src/modules/movit/filter_movit_resample.yml
+++ b/src/modules/movit/filter_movit_resample.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.resample
 title: Image Scaler (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -15,3 +15,5 @@ notes: >
   This is not intended to be created directly. Rather, the rescale filter
   loads it if it is available to normalize video and image inputs to the
   consumer/profile resolution.
+image_formats:
+  - glsl

--- a/src/modules/movit/filter_movit_resize.yml
+++ b/src/modules/movit/filter_movit_resize.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.resize
 title: Image Padding (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -17,3 +17,5 @@ notes: >
   requested after an upstream filter first scales the image to maximise
   usage of the image area. This filter is automatically invoked by the loader
   as part of image normalization.
+image_formats:
+  - glsl

--- a/src/modules/movit/filter_movit_saturation.yml
+++ b/src/modules/movit/filter_movit_saturation.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.saturation
 title: Saturation (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -15,7 +15,8 @@ description: >
   interpolate between that (saturation=0) and the original signal
   (saturation=1). Extrapolating that curve further (ie., saturation > 1)
   gives us increased saturation if so desired.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: saturation
     title: Saturation

--- a/src/modules/movit/filter_movit_vignette.yml
+++ b/src/modules/movit/filter_movit_vignette.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: movit.vignette
 title: Vignette (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -12,7 +12,8 @@ tags:
 description: >
   A circular vignette, falling off as cos² of the distance from the center
   (the classic formula for approximating a real lens).
-
+image_formats:
+  - glsl
 parameters:
   - identifier: radius
     title: Outer Radius

--- a/src/modules/movit/filter_movit_white_balance.yml
+++ b/src/modules/movit/filter_movit_white_balance.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: movit.white_balance
 title: White Balance (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -10,7 +10,8 @@ language: en
 tags:
   - Video
 description: Color correction in LMS color space.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: neutral_color
     title: Neutral Color

--- a/src/modules/movit/transition_movit_luma.yml
+++ b/src/modules/movit/transition_movit_luma.yml
@@ -1,8 +1,8 @@
-schema_version: 0.2
+schema_version: 7.2
 type: transition
 identifier: movit.luma_mix
 title: Wipe (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -10,7 +10,8 @@ language: en
 tags:
   - Video
 description: A generic dissolve and wipe transition processor.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/movit/transition_movit_mix.yml
+++ b/src/modules/movit/transition_movit_mix.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: transition
 identifier: movit.mix
 title: Dissolve (GLSL)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -10,7 +10,8 @@ language: en
 tags:
   - Video
 description: A simple video cross-fade or mixing effect.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: mix
     argument: yes

--- a/src/modules/movit/transition_movit_overlay.yml
+++ b/src/modules/movit/transition_movit_overlay.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: transition
 identifier: movit.overlay
 title: Overlay (GLSL)
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Steinar H. Gunderson
 license: GPLv2
@@ -11,7 +11,8 @@ tags:
   - Video
 description: >
   A video overlay or alpha-compositing effect using a Porter-Duff operation or SVG 1.2 blend mode.
-
+image_formats:
+  - glsl
 parameters:
   - identifier: compositing
     title: Composition mode

--- a/src/modules/ndi/consumer_ndi.yml
+++ b/src/modules/ndi/consumer_ndi.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: consumer
 identifier: ndi
 title: NDI Output (*DEPRECATED*)
-version: 1.0
+version: 2
 creator: Maksym Veremeyenko
 license: LGPLv2.1
 language: en
@@ -11,6 +11,11 @@ tags:
   - Video
   - Network
 description: Audio/Video over IP output using NewTek's NDI technology
+audio_formats:
+  - s16
+image_formats:
+  - rgba
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/ndi/producer_ndi.yml
+++ b/src/modules/ndi/producer_ndi.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: ndi
 title: NDI Input (*DEPRECATED*)
-version: 1.0
+version: 2
 creator: Maksym Veremeyenko
 license: LGPLv2.1
 language: en
@@ -11,6 +11,11 @@ tags:
   - Video
   - Network
 description: Audio/Video over IP input using NewTek's NDI technology
+audio_formats:
+  - s16
+image_formats:
+  - rgba
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/normalize/filter_audiolevel.yml
+++ b/src/modules/normalize/filter_audiolevel.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: audiolevel
 title: Audio Levels
-version: 2
+version: 3
 copyright: Meltytech, LLC, Marco Gittler, and Steve Harris
 creator: Dan Dennedy
 contributor:
@@ -19,6 +19,8 @@ notes: >
   where <N> is the channel number starting with 0.
 tags:
   - Audio
+audio_formats:
+  - s16
 parameters:
   - identifier: iec_scale
     title: Use IEC 60268-18 Scale

--- a/src/modules/normalize/filter_volume.yml
+++ b/src/modules/normalize/filter_volume.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: volume
 title: Volume
-version: 3
+version: 4
 copyright: Meltytech, LLC
 creator: Dan Denneedy
 license: GPLv2
@@ -12,6 +12,9 @@ tags:
 description: >
   Adjust an audio stream's volume level. This filter is based on the
   'normalize' utility
+audio_formats:
+  - f32le
+  - s16
 parameters:
   - identifier: gain (*DEPRECATED*)
     argument: yes

--- a/src/modules/oldfilm/filter_dust.yml
+++ b/src/modules/oldfilm/filter_dust.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: dust
 title: Dust
-version: 0.2.5
+version: 1
 copyright: Copyright (C) 2008 Marco Gittler
 license: GPL
 language: en
@@ -17,7 +17,8 @@ icon:
 notes: Implementation or additional usage notes go here.
 bugs: # this can be just for documentation, or the tool may disclose it to help user avoid pitfalls
   - need to do some speed improvement.
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: maxdiameter
     title: Maximal Diameter

--- a/src/modules/oldfilm/filter_grain.yml
+++ b/src/modules/oldfilm/filter_grain.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: grain
 title: Grain
-version: 0.2.5
+version: 1
 copyright: Copyright (C) 2008 Marco Gittler
 license: GPL
 language: en
@@ -18,6 +18,8 @@ notes: Implementation or additional usage notes go here.
 bugs: # this can be just for documentation, or the tool may disclose it to help user avoid pitfalls
   - need to do some speed improvement.
 
+image_formats:
+  - yuv422
 parameters:
   - identifier: noise
     title: Noise

--- a/src/modules/oldfilm/filter_lines.yml
+++ b/src/modules/oldfilm/filter_lines.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: lines
 title: Scratchlines
-version: 0.2.6
+version: 1
 copyright: Copyright (C) 2008 Marco Gittler
 license: GPL
 language: en
@@ -18,6 +18,8 @@ notes: Implementation or additional usage notes go here.
 bugs: # this can be just for documentation, or the tool may disclose it to help user avoid pitfalls
   - need to do some speed improvement.
 
+image_formats:
+  - yuv422
 parameters:
   - identifier: line_width
     title: Width of line

--- a/src/modules/oldfilm/filter_oldfilm.yml
+++ b/src/modules/oldfilm/filter_oldfilm.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: oldfilm
 title: Oldfilm
-version: 0.2.5
+version: 1
 copyright: Copyright (C) 2008 Marco Gittler
 license: GPL
 language: en
@@ -18,6 +18,8 @@ notes: Implementation or additional usage notes go here.
 bugs: # this can be just for documentation, or the tool may disclose it to help user avoid pitfalls
   - need to do some speed improvement.
 
+image_formats:
+  - yuv422
 parameters:
   - identifier: delta
     title: Y-Delta

--- a/src/modules/oldfilm/filter_tcolor.yml
+++ b/src/modules/oldfilm/filter_tcolor.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: tcolor
 title: Technicolor
-version: 0.2.5
+version: 1
 copyright: Copyright (C) 2008 Marco Gittler
 license: GPL
 language: en
@@ -18,6 +18,8 @@ notes: Implementation or additional usage notes go here.
 bugs: # this can be just for documentation, or the tool may disclose it to help user avoid pitfalls
   - need to do some speed improvement.
 
+image_formats:
+  - yuv422
 parameters:
   - identifier: oversaturate_cr # 'argument' is a reserved name for a value supplied to the factory
     title: Blue/Yellow- axis

--- a/src/modules/oldfilm/filter_vignette.yml
+++ b/src/modules/oldfilm/filter_vignette.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: vignette
 title: Vignette Effect
-version: 1.0
+version: 2
 copyright: Copyright (C) 2008 Marco Gittler
 license: GPL
 language: en
@@ -20,6 +20,8 @@ notes: Implementation or additional usage notes go here.
 bugs: # this can be just for documentation, or the tool may disclose it to help user avoid pitfalls
   - need to do some speed improvement.
 
+image_formats:
+  - yuv422
 parameters:
   - identifier: smooth
     title: Feathering

--- a/src/modules/opencv/filter_opencv_tracker.yml
+++ b/src/modules/opencv/filter_opencv_tracker.yml
@@ -1,10 +1,10 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: opencv.tracker
 title: OpenCV Motion Tracker
 copyright: Jean-Baptiste Mardelle
 creator: Jean-Baptiste Mardelle <jb@kdenlive.org>
-version: 2
+version: 3
 license: LGPLv2.1
 language: en
 tags:
@@ -21,6 +21,8 @@ notes: >
   To analyse clip, you can use with melt, use 'melt ... -consumer xml:output.mlt all=1 real_time=-1'.
   Analysis data is stored in a "results" property. For the second pass, you can use output.mlt as the input.
 
+image_formats:
+  - rgb
 parameters:
   - identifier: rect
     title: Target Rect

--- a/src/modules/openfx/factory.c
+++ b/src/modules/openfx/factory.c
@@ -107,6 +107,44 @@ static void plugin_mgr_destroy(mlt_properties p)
     mlt_properties_close((mlt_properties) MltOfxHost.host);
 }
 
+static void add_metadata_image_formats(mlt_properties metadata, mlt_properties image_effect)
+{
+    if (!metadata || !image_effect)
+        return;
+
+    mlt_properties image_formats = mlt_properties_new();
+    if (!image_formats)
+        return;
+
+    int format_index = 0;
+    char key[16] = {'\0'};
+
+    mltofx_components_mask components = mltofx_plugin_supported_components(image_effect);
+    mltofx_depths_mask depths = mltofx_plugin_supported_depths(image_effect);
+
+    if ((components & mltofx_components_rgb) && (depths & mltofx_depth_byte)) {
+        snprintf(key, sizeof(key), "%d", format_index++);
+        mlt_properties_set(image_formats, key, "rgb");
+    }
+
+    if ((components & mltofx_components_rgba) && (depths & mltofx_depth_byte)) {
+        snprintf(key, sizeof(key), "%d", format_index++);
+        mlt_properties_set(image_formats, key, "rgba");
+    }
+
+    if (depths & (mltofx_depth_short | mltofx_depth_half | mltofx_depth_float)) {
+        snprintf(key, sizeof(key), "%d", format_index++);
+        mlt_properties_set(image_formats, key, "rgba64");
+    }
+
+    mlt_properties_set_data(metadata,
+                            "image_formats",
+                            image_formats,
+                            0,
+                            (mlt_destructor) mlt_properties_close,
+                            NULL);
+}
+
 static mlt_properties metadata(mlt_service_type type, const char *id, void *data)
 {
     char file[PATH_MAX];
@@ -132,14 +170,14 @@ static mlt_properties metadata(mlt_service_type type, const char *id, void *data
 
     // parameters
     mlt_properties params = mlt_properties_new();
+    mlt_properties image_effect = mltofx_fetch_params(pt, params, result);
+    add_metadata_image_formats(result, image_effect);
     mlt_properties_set_data(result,
                             "parameters",
                             params,
                             0,
                             (mlt_destructor) mlt_properties_close,
                             NULL);
-
-    mlt_properties image_effect = mltofx_fetch_params(pt, params, result);
     mlt_properties_close(image_effect);
 
     // Fall back to the plugin identifier if the plugin did not provide a label.

--- a/src/modules/openfx/filter_openfx.yml
+++ b/src/modules/openfx/filter_openfx.yml
@@ -1,8 +1,8 @@
-schema_version: 7.1
+schema_version: 7.2
 type: filter
 identifier: openfx
 title: OpenFX
-version: 1
+version: 2
 license: GPLv2
 language: en
 url: https://openeffects.org/

--- a/src/modules/plus/consumer_blipflash.yml
+++ b/src/modules/plus/consumer_blipflash.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: consumer
 identifier: blipflash
 title: Blip Flash
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -12,6 +12,10 @@ tags:
 description: >
   Calculate the A/V sync for a blip flash source. 
   Sync can be recalculated whenever a blip or a flash is detected.
+audio_formats:
+  - float
+image_formats:
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/plus/filter_affine.yml
+++ b/src/modules/plus/filter_affine.yml
@@ -1,14 +1,17 @@
-schema_version: 0.2
+schema_version: 7.2
 type: filter
 identifier: affine
 title: Transform
-version: 6
+version: 7
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: background
     argument: yes

--- a/src/modules/plus/filter_charcoal.yml
+++ b/src/modules/plus/filter_charcoal.yml
@@ -1,15 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: charcoal
 title: Charcoal
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: x_scatter
     title: Line Width

--- a/src/modules/plus/filter_chroma.yml
+++ b/src/modules/plus/filter_chroma.yml
@@ -1,14 +1,15 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: chroma
 title: Chroma Key
-version: 1
+version: 2
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: key
     title: Key Color

--- a/src/modules/plus/filter_chroma_hold.yml
+++ b/src/modules/plus/filter_chroma_hold.yml
@@ -1,14 +1,15 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: chroma_hold
 title: Chroma Hold
-version: 1
+version: 2
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: key
     argument: yes

--- a/src/modules/plus/filter_dance.yml
+++ b/src/modules/plus/filter_dance.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: dance
 title: Dance
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -11,7 +11,9 @@ tags:
 description: >
   An audio visualization filter that moves the image around proportional to the 
   magnitude of the audio spectrum.
-  
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: frequency_low
     title: Low Frequency

--- a/src/modules/plus/filter_dynamic_loudness.yml
+++ b/src/modules/plus/filter_dynamic_loudness.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: dynamic_loudness
 title: Dynamic Loudness
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,7 +15,8 @@ notes: >
   Then, it adjusts the gain on the output based on the difference between the 
   measured loudness and the target loudness in order to achieve the desired 
   loudness.
-  
+audio_formats:
+  - f32le
 parameters:
   - identifier: target_loudness
     title: Target Program Loudness

--- a/src/modules/plus/filter_dynamictext.yml
+++ b/src/modules/plus/filter_dynamictext.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: dynamictext
 title: Dynamic text
-version: 4
+version: 5
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -12,7 +12,8 @@ description: Overlay dynamic text onto the video
 notes: >
   The dynamic text filter will search for keywords in the text to be overlaid
   and will replace those keywords on a frame-by-frame basis.
-  
+image_formats:
+  - rgba
 parameters:
   - identifier: argument
     argument: yes

--- a/src/modules/plus/filter_fft.yml
+++ b/src/modules/plus/filter_fft.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: fft
 title: FFT
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -12,7 +12,9 @@ description: >
   An audio filter that computes the FFT of the audio.
   This filter does not modify the audio or the image. It only computes the FFT
   and stores the result in the "bins" property of the filter.
-  
+audio_formats:
+  - float
+  - s16
 parameters:
   - identifier: window_size
     title: Window Size

--- a/src/modules/plus/filter_gradientmap.yml
+++ b/src/modules/plus/filter_gradientmap.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: gradientmap
 title: Gradient Map
-version: 2
+version: 3
 copyright: Martin Rodriguez Reboredo
 creator: Martin Rodriguez Reboredo
 license: LGPLv2.1
@@ -11,7 +11,9 @@ tags:
   - Video
 description:
   Maps the colors of an image to a gradient according to their intensity.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: stop.*
     title: Color Stop

--- a/src/modules/plus/filter_hslprimaries.yml
+++ b/src/modules/plus/filter_hslprimaries.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: hslprimaries
 title: HSL Primaries
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -11,7 +11,10 @@ tags:
 description: >
   Adjust Hue, Saturation and Lightness for each of the 6 primary/secondary 
   colors.
-
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
 parameters:
   - identifier: h_shift_red
     title: Hue Shift Red

--- a/src/modules/plus/filter_hslrange.yml
+++ b/src/modules/plus/filter_hslrange.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: hslrange
 title: HSL Range
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -11,7 +11,10 @@ tags:
 description: >
   Adjust Hue, Saturation and Lightness for a range of hue values. 
   The user can specify the range of the hue values to be adjusted.
-
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
 parameters:
   - identifier: hue_center
     title: Hue Center

--- a/src/modules/plus/filter_invert.yml
+++ b/src/modules/plus/filter_invert.yml
@@ -1,15 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: invert
 title: Invert
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: alpha
     type: integer

--- a/src/modules/plus/filter_lift_gamma_gain.yml
+++ b/src/modules/plus/filter_lift_gamma_gain.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: lift_gamma_gain
 title: Lift, Gamma, and Gain
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -22,7 +22,10 @@ notes: >
   rest of the curve relatively little. Thus, we actually convert to gamma 2.2
   before lift, and then back again afterwards. (Gain and gamma are,
   up to constants, commutative with the de-gamma operation.)
-
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
 parameters:
   - identifier: lift_r
     title: Lift Red

--- a/src/modules/plus/filter_loudness.yml
+++ b/src/modules/plus/filter_loudness.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: loudness
 title: Loudness
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -14,7 +14,8 @@ notes: >
   the result in the "results" property. The second pass applies the results to
   the audio in order to achieve the desired loudness over the range of the 
   filter.
-  
+audio_formats:
+  - f32le
 parameters:
   - identifier: results
     title: Analysis Results

--- a/src/modules/plus/filter_loudness_meter.yml
+++ b/src/modules/plus/filter_loudness_meter.yml
@@ -1,15 +1,16 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: loudness_meter
 title: Loudness Meter
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Audio
 description: Measure audio loudness as recommended by EBU R128.
-
+audio_formats:
+  - f32le
 parameters:
   - identifier: calc_program
     title: Calculate Program Loudness

--- a/src/modules/plus/filter_lumakey.yml
+++ b/src/modules/plus/filter_lumakey.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: lumakey
 title: Lumakey
-version: 1
+version: 2
 copyright: Janne Liljeblad
 creator: Janne Liljeblad
 license: LGPLv2.1
@@ -15,7 +15,8 @@ description: >
   This is used together with a compositor to combine two images so that 
   bright or dark areas of source image are overwritten on top of the
   destination image.
-
+image_formats:
+  - rgba
 parameters:
   - identifier: threshold
     title: Threshold

--- a/src/modules/plus/filter_rgblut.yml
+++ b/src/modules/plus/filter_rgblut.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: rgblut
 title: RGBLUT
-version: 1
+version: 2
 copyright: Janne Liljeblad
 creator: Janne Liljeblad
 license: LGPLv2.1
@@ -14,7 +14,8 @@ description:
   range 0 - 255 to look-up tables that are then used to modify R, G, B values. 
   
   This creates a generic string interface for color correction.
-
+image_formats:
+  - rgb
 parameters:
   - identifier: R_table
     title: Red channel look-up table

--- a/src/modules/plus/filter_sepia.yml
+++ b/src/modules/plus/filter_sepia.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: sepia
 title: Sepia
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -11,6 +11,8 @@ tags:
   - Video
 description: >
   Apply a color tint. Default values give a sepia tone like an old photograph.
+image_formats:
+  - yuv422
 parameters:
   - identifier: u
     type: integer

--- a/src/modules/plus/filter_shape.yml
+++ b/src/modules/plus/filter_shape.yml
@@ -1,14 +1,17 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: shape
 title: Shape Alpha
-version: 7
+version: 8
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - rgba
+  - rgba64
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/plus/filter_spot_remover.yml
+++ b/src/modules/plus/filter_spot_remover.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: spot_remover
 title: Spot Remover
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -13,6 +13,12 @@ description: >
   
   The new pixel values are interpolated from the nearest pixels immediately
   outside of the specified area.
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
+  - yuv420p
+  - yuv422
 parameters:
   - identifier: rect
     title: Rectangle

--- a/src/modules/plus/filter_strobe.yml
+++ b/src/modules/plus/filter_strobe.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: strobe
 title: Alpha strobing
-version: 2
+version: 3
 copyright: Martin Sandsmark
 creator: Martin Sandsmark
 license: LGPLv2.1
@@ -10,6 +10,15 @@ language: en
 description: Strobes the alpha channel to 0. Many other filters overwrite the alpha channel, in that case this needs to be last.
 tags:
   - Video
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
+  - yuv420p
+  - yuv422p16
+  - yuv420p10
+  - yuv444p10
+  - rgba64
 parameters:
   - identifier: strobe_invert
     title: Invert

--- a/src/modules/plus/filter_subtitle.yml
+++ b/src/modules/plus/filter_subtitle.yml
@@ -1,15 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: subtitle
 title: Subtitle
-version: 4
+version: 5
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
 description: Overlay subtitles onto the video
-
+image_formats:
+  - rgba
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/plus/filter_text.yml
+++ b/src/modules/plus/filter_text.yml
@@ -1,15 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: text
 title: Text
-version: 3
+version: 4
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
 description: Overlay text onto the video
-
+image_formats:
+  - rgba
 parameters:
   - identifier: argument
     title: Text

--- a/src/modules/plus/filter_threshold.yml
+++ b/src/modules/plus/filter_threshold.yml
@@ -1,14 +1,15 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: threshold
 title: Threshold
-version: 2
+version: 3
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: midpoint
     title: Threshold

--- a/src/modules/plus/filter_timer.yml
+++ b/src/modules/plus/filter_timer.yml
@@ -1,15 +1,16 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: timer
 title: Timer
-version: 4
+version: 5
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
 description: Overlay a timer onto the video. The timer can count up or down.
-
+image_formats:
+  - rgba
 parameters:
   - identifier: format
     title: Format

--- a/src/modules/plus/producer_blipflash.yml
+++ b/src/modules/plus/producer_blipflash.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: producer
 identifier: blipflash
 title: Blip Flash
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -12,6 +12,12 @@ tags:
 description: >
   Generate periodic synchronized audio blips and video flashes. 
   Blips are a 1kHz tone and last the duration of the flash frame.
+audio_formats:
+  - float
+image_formats:
+  - rgb
+  - rgba
+  - yuv422
 parameters:
   - identifier: period
     title: Flash Period

--- a/src/modules/plus/producer_count.yml
+++ b/src/modules/plus/producer_count.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: count
 title: Count
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -12,6 +12,10 @@ tags:
 description: >
   Generate frames with a counter and synchronized tone. 
   The counter can go up or down.
+audio_formats:
+  - float
+image_formats:
+  - rgba
 parameters:
   - identifier: direction
     title: Count Direction

--- a/src/modules/plus/producer_pgm.yml
+++ b/src/modules/plus/producer_pgm.yml
@@ -1,14 +1,15 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: pgm
 title: PGM Image
-version: 1
+version: 2
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
-
+image_formats:
+  - yuv422
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/plus/producer_subtitle.yml
+++ b/src/modules/plus/producer_subtitle.yml
@@ -1,15 +1,18 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: subtitle
 title: Subtitle
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
 description: Generate video frames with subtitle overlay
-  
+image_formats:
+  - rgb
+  - rgba
+  - rgba64
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/plus/transition_affine.yml
+++ b/src/modules/plus/transition_affine.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: transition
 identifier: affine
 title: Transform
-version: 8
+version: 9
 copyright: Meltytech, LLC
 creator: Charles Yates
 contributor:
@@ -11,6 +11,9 @@ license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: distort
     title: Ignore aspect ratio

--- a/src/modules/plusgpl/filter_burningtv.yml
+++ b/src/modules/plusgpl/filter_burningtv.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: burningtv
 title: BurningTV
-version: 1
+version: 2
 copyright: FUKUCHI Kentaro, Stephane Fillod
 creator: FUKUCHI Kentaro, Stephane Fillod
 contributor:
@@ -11,7 +11,8 @@ license: GPLv2
 language: en
 tags:
   - Video
-
+image_formats:
+  - rgba
 parameters:
   - identifier: foreground
     title: Foreground

--- a/src/modules/plusgpl/filter_lumaliftgaingamma.yml
+++ b/src/modules/plusgpl/filter_lumaliftgaingamma.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: lumaliftgaingamma
 title: LumaLiftGainGamma
-version: 1
+version: 2
 copyright: Janne Liljeblad
 creator: Janne Liljeblad
 license: GPL
@@ -12,7 +12,8 @@ tags:
 description: >
   Filter can be used to apply lift, gain and gamma correction to
   luma values of image.
-
+image_formats:
+  - rgb
 parameters:
   - identifier: lift
     title: Lift

--- a/src/modules/plusgpl/filter_outline.yml
+++ b/src/modules/plusgpl/filter_outline.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: outline
 title: Outline
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: GPLv2
 language: en
@@ -12,7 +12,9 @@ description: >
   Simulate a stroke along edges within an alpha channel.
   It is not very smart or sophisticate, which is why you should limit the
   thickness and avoid hard angles.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: color
     title: Color

--- a/src/modules/plusgpl/filter_rotoscoping.yml
+++ b/src/modules/plusgpl/filter_rotoscoping.yml
@@ -1,9 +1,9 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: rotoscoping
 title: Rotoscoping
 copyright: Copyright (C) 2011 Till Theato
-version: 0.3
+version: 1
 license: GPL
 language: en
 creator: Till Theato <root@ttill.de>
@@ -13,7 +13,11 @@ description: Keyframable vector based rotoscoping
 
 bugs:
   - in some cases top most row in polygon is assigned to outside
-
+image_formats:
+  - rgb
+  - rgba
+  - yuv420p
+  - yuv422
 parameters:
   - identifier: mode
     title: Mode

--- a/src/modules/plusgpl/filter_telecide.yml
+++ b/src/modules/plusgpl/filter_telecide.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: telecide
 title: Inverse Telecine (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Donald A. Graft and Dan Dennedy
 creator: Donald A. Graft
 contributor:
@@ -16,3 +16,5 @@ notes: >
   This is old work, which never materialized to a completely usable form. It
   is not able to change the frame rate. The video is deinterlaced in a smart
   manner, but repeated frames are not removed.
+image_formats:
+  - yuv422

--- a/src/modules/qt/filter_audiolevelgraph.yml
+++ b/src/modules/qt/filter_audiolevelgraph.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: audiolevelgraph
 title: Audio Level Visualization Filter
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -10,7 +10,9 @@ tags:
   - Video
 description: >
   An audio visualization filter that draws an audio level meter on the image.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: type
     title: Graph type

--- a/src/modules/qt/filter_audiospectrum.yml
+++ b/src/modules/qt/filter_audiospectrum.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: audiospectrum
 title: Audio Spectrum Filter
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -10,7 +10,9 @@ tags:
   - Video
 description: >
   An audio visualization filter that draws an audio spectrum on the image.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: type
     title: Graph type

--- a/src/modules/qt/filter_audiowaveform.yml
+++ b/src/modules/qt/filter_audiowaveform.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: audiowaveform
 title: Audio Waveform Filter
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -10,7 +10,9 @@ tags:
   - Video
 description: >
   An audio visualization filter that draws an audio waveform on the image.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: bgcolor
     title: Background Color

--- a/src/modules/qt/filter_dropshadow.yml
+++ b/src/modules/qt/filter_dropshadow.yml
@@ -1,15 +1,17 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: dropshadow
 title: Drop Shadow
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
 description: Create a shadow effect from the alpha channel.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: color
     title: Color

--- a/src/modules/qt/filter_gpsgraphic.yml
+++ b/src/modules/qt/filter_gpsgraphic.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: gpsgraphic
 title: GPS Graphic
-version: 3
+version: 4
 copyright: Meltytech, LLC
 creator: Daniel F
 license: LGPLv2.1
@@ -10,7 +10,9 @@ language: en
 tags:
   - Video
 description: Overlay GPS-related graphics onto the video
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: resource
     title: GPS File/URL

--- a/src/modules/qt/filter_gpstext.yml
+++ b/src/modules/qt/filter_gpstext.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: gpstext
 title: GPS Text
-version: 7
+version: 8
 copyright: Meltytech, LLC
 creator: Daniel F
 license: LGPLv2.1
@@ -14,7 +14,9 @@ notes: >
   The GPS text filter will search for keywords in the text to be overlaid
   and will replace those keywords on a frame-by-frame basis. 
   It is based on dynamictext filter.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: argument
     argument: yes

--- a/src/modules/qt/filter_lightshow.yml
+++ b/src/modules/qt/filter_lightshow.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: lightshow
 title: Light Show
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -11,7 +11,9 @@ tags:
 description: >
   An audio visualization filter that colors the image proportional to the 
   magnitude of the audio spectrum.
-  
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: frequency_low
     title: Low Frequency

--- a/src/modules/qt/filter_qtblend.yml
+++ b/src/modules/qt/filter_qtblend.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: qtblend
 title: Composite and transform
-version: 3
+version: 4
 copyright: Meltytech, LLC
 creator: Jean-Baptiste Mardelle
 license: LGPLv2.1
@@ -11,7 +11,9 @@ tags:
   - Video
 description: >
   A filter allowing compositing and transform.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: rect
     title: Rectangle

--- a/src/modules/qt/filter_qtblend_mode.yml
+++ b/src/modules/qt/filter_qtblend_mode.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: qtblend_mode
 title: Set Qt Blend Mode
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -10,6 +10,9 @@ language: en
 tags:
   - Video
 description: Change the blend mode used by the qtblend transition.
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: mode
     argument: yes

--- a/src/modules/qt/filter_qtcrop.yml
+++ b/src/modules/qt/filter_qtcrop.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: qtcrop
 title: Crop by padding
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -12,7 +12,9 @@ tags:
 description: >
   This filter crops the image to a rounded rectangle or circle by padding
   it with a color.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: rect
     title: Rectangle

--- a/src/modules/qt/filter_qtext.yml
+++ b/src/modules/qt/filter_qtext.yml
@@ -1,15 +1,17 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: qtext
 title: QText
-version: 7
+version: 8
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
 tags:
   - Video
 description: Overlay text onto the video
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: argument
     title: Text

--- a/src/modules/qt/filter_typewriter.yml
+++ b/src/modules/qt/filter_typewriter.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter # consumer, filter, producer, or transition
 identifier: typewriter
 title: TypeWriter
-version: 0.3.5
+version: 1
 copyright: Copyright (C) Rafal Lalik
 license: GPL
 language: en
@@ -11,10 +11,11 @@ tags:
   - Video
 description: |
     Typewriter effect applied to kdenlivetitler producer
-
 notes: >
     Original development: https://github.com/rlalik/mlt_extra_modules
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: step_length
     title: Distance between basic steps

--- a/src/modules/qt/producer_kdenlivetitle.yml
+++ b/src/modules/qt/producer_kdenlivetitle.yml
@@ -1,4 +1,4 @@
-schema_version: 0.1
+schema_version: 7.2
 type: producer
 identifier: kdenlivetitle
 title: Kdenlive Titler
@@ -9,3 +9,5 @@ license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgba

--- a/src/modules/qt/producer_qimage.yml
+++ b/src/modules/qt/producer_qimage.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: producer
 identifier: qimage
 title: Qt QImage
-version: 2
+version: 3
 creator: Charles Yates
 license: GPLv2
 language: en
@@ -15,6 +15,9 @@ notes: >
     whatever the consumer requests. Therefore, it will lose its aspect ratio if
     so requested, and it is up to the consumer to request a proper width and
     height that maintains the image aspect.
+image_formats:
+  - rgb
+  - rgba
 parameters:
   - identifier: resource
     title: File

--- a/src/modules/qt/producer_qtext.yml
+++ b/src/modules/qt/producer_qtext.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: qtext
 title: Qt Titler
-version: 4
+version: 5
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -20,7 +20,8 @@ notes: >
   whatever the consumer requests. Therefore, it will lose its aspect ratio if 
   so requested, and it is up to the consumer to request a proper width and 
   height that maintains the image aspect.
-
+image_formats:
+  - rgba
 parameters:
   - identifier: resource
     title: File

--- a/src/modules/qt/transition_qtblend.yml
+++ b/src/modules/qt/transition_qtblend.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: transition
 identifier: qtblend
 title: Composite and transform
-version: 4
+version: 5
 copyright: Meltytech, LLC
 creator: Jean-Baptiste Mardelle
 license: LGPLv2.1
@@ -11,7 +11,9 @@ tags:
   - Video
 description: >
   A transition allowing compositing and transform.
-
+image_formats:
+  - rgba
+  - rgba64
 parameters:
   - identifier: rect
     title: Rectangle

--- a/src/modules/qt/transition_vqm.yml
+++ b/src/modules/qt/transition_vqm.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: transition
 identifier: vqm
 title: Video Quality Measurement
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: GPLv3
@@ -16,6 +16,8 @@ description: >
   for visual comparison.
 tags:
   - Video
+image_formats:
+  - yuv422
 parameters:
   - identifier: render
     title: Render

--- a/src/modules/resample/filter_resample.yml
+++ b/src/modules/resample/filter_resample.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: resample
 title: Resample
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy <dan@dennedy.org>
 license: LGPLv2.1
@@ -15,6 +15,8 @@ description: >
   
   This filter is automatically invoked by the loader producer to normalize
   audio from the producer to provide the rate requested by the consumer.
+audio_formats:
+  - f32le
 parameters:
   - identifier: frequency
     title: Frequency

--- a/src/modules/resample/link_resample.yml
+++ b/src/modules/resample/link_resample.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: link
 identifier: resample
 title: SRC Resampler
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPLv2.1
 language: en
@@ -15,3 +15,5 @@ description: >
   
   This link can be added to a chain to normalize audio from the producer to
   provide the rate requested by the consumer.
+audio_formats:
+  - f32le

--- a/src/modules/rtaudio/consumer_rtaudio.yml
+++ b/src/modules/rtaudio/consumer_rtaudio.yml
@@ -1,4 +1,4 @@
-schema_version: 0.3
+schema_version: 7.2
 type: consumer
 identifier: rtaudio
 title: RtAudio
@@ -6,7 +6,7 @@ description: >
   RtAudio provides native, realtime audio output across Linux,
   Macintosh OS X, Windows, and some BSD operating systems.
 url: http://www.music.mcgill.ca/~gary/rtaudio/
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 creator: Gary P. Scavone
@@ -14,6 +14,8 @@ license: LGPLv2.1
 language: en
 tags:
   - Audio
+audio_formats:
+  - s16
 parameters:
   - identifier: resource
     title: Device

--- a/src/modules/rubberband/filter_rbpitch.yml
+++ b/src/modules/rubberband/filter_rbpitch.yml
@@ -1,14 +1,16 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: rbpitch
 title: Rubberband Pitch
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: GPLv2
 language: en
 tags:
   - Audio
 description: Adjust the audio pitch using the Rubberband library.
+audio_formats:
+  - float
 parameters:
   - identifier: octaveshift
     title: Octave Shift

--- a/src/modules/sdl/consumer_sdl.yml
+++ b/src/modules/sdl/consumer_sdl.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: consumer
 identifier: sdl
 title: SDL Fast YUV (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -13,6 +13,11 @@ tags:
 description: >
   Deprecated: use "sdl2" instead.
   Simple DirectMedia Layer audio and video output module.
+audio_formats:
+  - s16
+image_formats:
+  - rgba
+  - yuv422
 parameters:
   - identifier: resolution
     title: Resolution

--- a/src/modules/sdl/consumer_sdl_audio.yml
+++ b/src/modules/sdl/consumer_sdl_audio.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: consumer
 identifier: sdl_audio
 title: SDL Audio Only (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -12,7 +12,8 @@ tags:
 description: >
   Deprecate: use "sdl2_audio" instead.
   Simple DirectMedia Layer audio only output module.
-
+audio_formats:
+  - s16
 parameters:
   - identifier: volume
     title: Volume

--- a/src/modules/sdl/consumer_sdl_still.yml
+++ b/src/modules/sdl/consumer_sdl_still.yml
@@ -1,11 +1,13 @@
-schema_version: 0.1
+schema_version: 7.2
 type: consumer
 identifier: sdl_still
 title: SDL RGB (*DEPRECATED*)
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
 language: en
 tags:
   - Video
+image_formats:
+  - rgba

--- a/src/modules/sdl2/consumer_sdl2.yml
+++ b/src/modules/sdl2/consumer_sdl2.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: consumer
 identifier: sdl2
 title: SDL2
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -12,6 +12,10 @@ tags:
   - Video
 description: >
   Simple DirectMedia Layer audio and video output module
+audio_formats:
+  - s16
+image_formats:
+  - yuv422
 parameters:
   - identifier: resolution
     title: Resolution

--- a/src/modules/sdl2/consumer_sdl2_audio.yml
+++ b/src/modules/sdl2/consumer_sdl2_audio.yml
@@ -1,8 +1,8 @@
-schema_version: 0.3
+schema_version: 7.2
 type: consumer
 identifier: sdl2_audio
 title: SDL2 Audio Only
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -11,7 +11,8 @@ tags:
   - Audio
 description: >
   Simple DirectMedia Layer audio only output module.
-
+audio_formats:
+  - s16
 parameters:
   - identifier: volume
     title: Volume

--- a/src/modules/sox/filter_sox.yml
+++ b/src/modules/sox/filter_sox.yml
@@ -1,8 +1,8 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: sox
 title: SoX
-version: 2
+version: 3
 copyright: Meltytech, LLC
 license: LGPL
 language: en
@@ -14,7 +14,8 @@ description: Process audio using a SoX effect.
 bugs:
   - Some effects are stereo only, but MLT processes each channel separately.
   - Some effects have a temporal side-effect that do not work well.
-
+audio_formats:
+  - s32
 parameters:
   - identifier: effect
     argument: yes

--- a/src/modules/spatialaudio/filter_ambisonic-decoder.yml
+++ b/src/modules/spatialaudio/filter_ambisonic-decoder.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: ambisonic-decoder
 title: Ambisonic Decoder
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPL
 language: en
@@ -14,7 +14,8 @@ notes: >
   This only supports first order for now. It can render to stereo, quad
   surround, and 5.1 surround depending on the number of channels
   configured on the consumer (2, 4, or 6, respectively).
-
+audio_formats:
+  - float
 parameters:
   - identifier: yaw
     title: Yaw

--- a/src/modules/spatialaudio/filter_ambisonic-encoder.yml
+++ b/src/modules/spatialaudio/filter_ambisonic-encoder.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: ambisonic-encoder
 title: Ambisonic Encoder
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: LGPL
 language: en
@@ -14,7 +14,8 @@ notes: >
   This only supports first order for now. The consumer should be configured
   for 4 or more channels. If the source has more than one channel, only the
   first channel is used.
-
+audio_formats:
+  - float
 parameters:
   - identifier: azimuth
     title: Azimuth

--- a/src/modules/vid.stab/filter_deshake.yml
+++ b/src/modules/vid.stab/filter_deshake.yml
@@ -1,10 +1,10 @@
-schema_version: 0.1
+schema_version: 7.2
 type: filter
 identifier: deshake
 title: Vid.Stab Deshake
 copyright: Jakub Ksiezniak
 creator: Georg Martius
-version: 1
+version: 2
 license: GPLv2
 language: en
 url: http://public.hronopik.de/vid.stab/
@@ -15,7 +15,9 @@ notes: >
     Deshakes a video clip by extracting relative transformations
     of subsequent frames and transforms the high-frequency away.
     This is a single pass version of the vidstab filter.
-
+image_formats:
+  - yuv420p
+  - yuv422
 parameters:
   - identifier: shakiness
     title: Shakiness

--- a/src/modules/vid.stab/filter_vidstab.yml
+++ b/src/modules/vid.stab/filter_vidstab.yml
@@ -1,10 +1,10 @@
-schema_version: 0.3
+schema_version: 7.2
 type: filter
 identifier: vidstab
 title: Vid.Stab Detect and Transform
 copyright: Jakub Ksiezniak
 creator: Marco Gittler <g.marco@freenet.de>
-version: 2
+version: 3
 license: GPL
 language: en
 url: http://public.hronopik.de/vid.stab/
@@ -20,7 +20,9 @@ notes: >
   To use with melt, use 'melt ... -consumer xml:output.mlt all=1 real_time=-1' for the
   first pass. Parallel processing (real_time < -1 or > 1) is not supported for
   the first pass. For the second pass, use output.mlt as the input.
-
+image_formats:
+  - yuv420p
+  - yuv422
 parameters:
   - identifier: results
     title: Analysis Results

--- a/src/modules/vorbis/producer_vorbis.yml
+++ b/src/modules/vorbis/producer_vorbis.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: producer
 identifier: vorbis
 title: Ogg Vorbis
-version: 1
+version: 2
 copyright: Meltytech, LLC
 creator: Charles Yates
 license: LGPLv2.1
@@ -11,6 +11,8 @@ tags:
   - Audio
 description: |
   OGG Vorbis file reader.
+audio_formats:
+  - s16
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/xine/filter_deinterlace.yml
+++ b/src/modules/xine/filter_deinterlace.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: filter
 identifier: deinterlace
 title: Xine Deinterlacer
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: GPLv2
 language: en
@@ -15,3 +15,5 @@ notes: >
   This is not intended to be created directly. Rather, the loader producer
   loads it if it is available to set deinterlace interlaced input when the
   consumer or profile is set to progressive.
+image_formats:
+  - yuv422

--- a/src/modules/xine/link_deinterlace.yml
+++ b/src/modules/xine/link_deinterlace.yml
@@ -1,8 +1,8 @@
-schema_version: 7.0
+schema_version: 7.2
 type: link
 identifier: deinterlace
 title: Xine Deinterlacer
-version: 1
+version: 2
 copyright: Meltytech, LLC
 license: GPLv2
 language: en
@@ -15,3 +15,5 @@ description: >
   
   This link can be added to a chain to normalize video from the producer to
   provide deinterlaced images if requested by the consumer.
+image_formats:
+  - yuv422


### PR DESCRIPTION
Add image_formats and audio_formats to the filter metadata so that applications can look up what formats are supported by the service. This can be used in Shotcut to map image formats to keywords rgba, yuv, and 10bit.