### PR TITLE
Fix and enable OpenFX module with MSVC

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,7 @@
                 "MOD_NORMALIZE": "ON",
                 "MOD_OLDFILM": "ON",
                 "MOD_OPENCV": "ON",
-                "MOD_OPENFX": "OFF",
+                "MOD_OPENFX": "ON",
                 "MOD_MOVIT": "OFF",
                 "MOD_PLUS": "ON",
                 "MOD_PLUSGPL": "ON",

--- a/src/modules/openfx/CMakeLists.txt
+++ b/src/modules/openfx/CMakeLists.txt
@@ -4,6 +4,10 @@ add_library(mltopenfx MODULE
   filter_openfx.c
 )
 
+if(MSVC)
+  target_link_libraries(mltopenfx PRIVATE dirent)
+endif()
+
 add_custom_target(Other_openfx_Files SOURCES
   filter_openfx.yml
 )

--- a/src/modules/openfx/factory.c
+++ b/src/modules/openfx/factory.c
@@ -71,12 +71,9 @@ static const char *getArchStr()
 #endif
 #define OFX_DIRSEP "\\"
 
-#if defined(__MINGW32__) || defined(__MINGW64__)
-#include <dirent.h>
-#endif
-
 #include "shlobj.h"
 #include "tchar.h"
+#include <dirent.h>
 #endif
 
 extern mlt_filter filter_openfx_init(mlt_profile profile,
@@ -281,9 +278,13 @@ MLT_REPOSITORY
     char *openfx_path = getenv("OFX_PLUGIN_PATH");
     if (openfx_path) {
         char *path_copy = strdup(openfx_path);
-        char *saveptr;
         for (char *strptr = path_copy;; strptr = NULL) {
+#ifdef _WIN32
+            char *dir = strtok(strptr, MLT_DIRLIST_DELIMITER);
+#else
+            char *saveptr;
             char *dir = strtok_r(strptr, MLT_DIRLIST_DELIMITER, &saveptr);
+#endif
             if (dir == NULL)
                 break;
             scan_ofx_dir(repository, dir, &dli, 0);

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -75,10 +75,11 @@ uint16_t *mltofx_rgba64_to_half(const uint16_t *src, int n_pixels)
     uint16_t *dst = malloc((size_t) count * sizeof(uint16_t));
     if (!dst)
         return NULL;
+    int i;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (int i = 0; i < count; ++i)
+    for (i = 0; i < count; ++i)
         dst[i] = f32_to_f16((float) src[i] * (1.0f / 65535.0f));
     return dst;
 }
@@ -86,10 +87,11 @@ uint16_t *mltofx_rgba64_to_half(const uint16_t *src, int n_pixels)
 void mltofx_half_to_rgba64(const uint16_t *src, uint16_t *dst, int n_pixels)
 {
     int count = n_pixels * 4;
+    int i;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (int i = 0; i < count; ++i) {
+    for (i = 0; i < count; ++i) {
         float v = f16_to_f32(src[i]);
         // This clamping using >= and <= handles NaN and +/-inf
         v = (v >= 0.0f) ? (v <= 1.0f ? v : 1.0f) : 0.0f;
@@ -103,10 +105,11 @@ float *mltofx_rgba64_to_float(const uint16_t *src, int n_pixels)
     float *dst = malloc((size_t) count * sizeof(float));
     if (!dst)
         return NULL;
+    int i;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (int i = 0; i < count; ++i)
+    for (i = 0; i < count; ++i)
         dst[i] = (float) src[i] * (1.0f / 65535.0f);
     return dst;
 }
@@ -114,10 +117,11 @@ float *mltofx_rgba64_to_float(const uint16_t *src, int n_pixels)
 void mltofx_float_to_rgba64(const float *src, uint16_t *dst, int n_pixels)
 {
     int count = n_pixels * 4;
+    int i;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (int i = 0; i < count; ++i) {
+    for (i = 0; i < count; ++i) {
         float v = src[i];
         // This clamping using >= and <= handles NaN and +/-inf
         v = (v >= 0.0f) ? (v <= 1.0f ? v : 1.0f) : 0.0f;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
     "ffmpeg",
     "fftw3",
     "gdk-pixbuf",
+    "glib",
     "libebur128",
     "libexif",
     "libiconv",


### PR DESCRIPTION
Note that for OpenMP for loops the iteration variable has to be declared before the for statement. MSVC fails to compile it otherwise. See https://stackoverflow.com/questions/38941157/c3015-initialization-in-openmp-for-statement-has-improper-form