### PR TITLE
openfx: honor OFX bottom-left row order with negative row bytes

### DIFF
--- a/src/modules/openfx/factory.c
+++ b/src/modules/openfx/factory.c
@@ -169,6 +169,27 @@ static mlt_properties metadata(mlt_service_type type, const char *id, void *data
     mlt_properties params = mlt_properties_new();
     mlt_properties image_effect = mltofx_fetch_params(pt, params, result);
     add_metadata_image_formats(result, image_effect);
+
+    // Append the MLT-level mlt_origin parameter after all OFX plugin parameters.
+    {
+        char key[20];
+        snprintf(key, sizeof(key), "%d", mlt_properties_count(params));
+        mlt_properties p = mlt_properties_new();
+        mlt_properties_set_data(params, key, p, 0, (mlt_destructor) mlt_properties_close, NULL);
+        mlt_properties_set(p, "identifier", "mlt_origin");
+        mlt_properties_set(p, "title", "Top-Left Origin");
+        mlt_properties_set(p,
+                           "description",
+                           "Set to 1 to use MLT top-left image origin instead of the OFX "
+                           "bottom-left origin. Use for plugins that crash or produce incorrect "
+                           "output with negative row bytes.");
+        mlt_properties_set(p, "type", "boolean");
+        mlt_properties_set(p, "default", "0");
+        mlt_properties_set(p, "minimum", "0");
+        mlt_properties_set(p, "maximum", "1");
+        mlt_properties_set(p, "widget", "checkbox");
+    }
+
     mlt_properties_set_data(result,
                             "parameters",
                             params,

--- a/src/modules/openfx/filter_openfx.c
+++ b/src/modules/openfx/filter_openfx.c
@@ -270,6 +270,7 @@ static int filter_get_image(mlt_frame frame,
     OfxPlugin *plugin = mlt_properties_get_data(properties, "ofx_plugin", NULL);
     mlt_properties base_image_effect = mlt_properties_get_properties(properties, OFX_IMAGE_EFFECT);
     int allow_frame_threading = mlt_properties_get_int(properties, "_allow_frame_threading");
+    int top_left_origin = mlt_properties_get_int(properties, "mlt_origin");
     mlt_properties image_effect = base_image_effect;
     if (allow_frame_threading) {
         image_effect = create_image_effect_instance(plugin, properties, 0);
@@ -376,6 +377,12 @@ static int filter_get_image(mlt_frame frame,
 
     // In serialized mode, image_effect is shared across frames; update scale under lock.
     mltofx_set_render_scale(image_effect, render_scale_x, render_scale_y);
+    mltofx_set_project_properties(image_effect,
+                                  *width,
+                                  *height,
+                                  pixel_aspect_ratio,
+                                  mlt_profile_fps(profile),
+                                  (double) length);
 
     update_plugin_params(properties, image_effect_params, params, position, length);
 
@@ -389,7 +396,8 @@ static int filter_get_image(mlt_frame frame,
                                 *height,
                                 *format,
                                 pixel_aspect_ratio,
-                                ofx_depth);
+                                ofx_depth,
+                                top_left_origin);
     mltofx_set_output_clip_data(plugin,
                                 image_effect,
                                 prime_buf,
@@ -397,7 +405,8 @@ static int filter_get_image(mlt_frame frame,
                                 *height,
                                 *format,
                                 pixel_aspect_ratio,
-                                ofx_depth);
+                                ofx_depth,
+                                top_left_origin);
 
     // OFX pre-render action order:
     // GetClipPreferences -> GetRegionOfDefinition -> GetRegionsOfInterest -> BeginSequenceRender
@@ -414,7 +423,8 @@ static int filter_get_image(mlt_frame frame,
                                 *height,
                                 *format,
                                 pixel_aspect_ratio,
-                                ofx_depth);
+                                ofx_depth,
+                                top_left_origin);
     mltofx_set_output_clip_data(plugin,
                                 image_effect,
                                 render_dst,
@@ -422,7 +432,8 @@ static int filter_get_image(mlt_frame frame,
                                 *height,
                                 *format,
                                 pixel_aspect_ratio,
-                                ofx_depth);
+                                ofx_depth,
+                                top_left_origin);
 
     mltofx_action_render(plugin, image_effect, ofx_time, *width, *height);
     mltofx_end_sequence_render(plugin, image_effect, ofx_time);

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -247,9 +247,16 @@ static OfxStatus clipGetRegionOfDefinition(OfxImageClipHandle clip, OfxTime time
     propGetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRegionOfDefinition, 1, &y1);
     propGetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRegionOfDefinition, 2, &x2);
     propGetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRegionOfDefinition, 3, &y2);
-    bounds->x1 = (double) x1;
+    // OFX spec requires canonical coordinates: x scaled by PAR, y in pixels.
+    double par = 1.0;
+    mlt_properties par_props = mlt_properties_get_properties(clip_prop, "0");
+    if (par_props && mlt_properties_exists(par_props, kOfxImagePropPixelAspectRatio))
+        par = mlt_properties_get_double(par_props, kOfxImagePropPixelAspectRatio);
+    if (par <= 0.0)
+        par = 1.0;
+    bounds->x1 = (double) x1 * par;
     bounds->y1 = (double) y1;
-    bounds->x2 = (double) x2;
+    bounds->x2 = (double) x2 * par;
     bounds->y2 = (double) y2;
 
     if (bounds->x2 < bounds->x1 || bounds->y2 < bounds->y1) {
@@ -2241,6 +2248,51 @@ static void mltofx_get_render_scale(mlt_properties image_effect, double *scale_x
         *scale_y = y;
 }
 
+void mltofx_set_project_properties(mlt_properties image_effect,
+                                   int width,
+                                   int height,
+                                   double pixel_aspect_ratio,
+                                   double fps,
+                                   double duration)
+{
+    if (!image_effect)
+        return;
+    if (pixel_aspect_ratio <= 0.0)
+        pixel_aspect_ratio = 1.0;
+    // OFX canonical coordinates: x scaled by PAR, y in pixels.
+    double canonical_width = (double) width * pixel_aspect_ratio;
+    double canonical_height = (double) height;
+    propSetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectExtent,
+                  0,
+                  canonical_width);
+    propSetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectExtent,
+                  1,
+                  canonical_height);
+    propSetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectSize,
+                  0,
+                  canonical_width);
+    propSetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectSize,
+                  1,
+                  canonical_height);
+    propSetDouble((OfxPropertySetHandle) image_effect, kOfxImageEffectPropProjectOffset, 0, 0.0);
+    propSetDouble((OfxPropertySetHandle) image_effect, kOfxImageEffectPropProjectOffset, 1, 0.0);
+    propSetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectPixelAspectRatio,
+                  0,
+                  pixel_aspect_ratio);
+    if (fps > 0.0)
+        propSetDouble((OfxPropertySetHandle) image_effect, kOfxImageEffectPropFrameRate, 0, fps);
+    if (duration > 0.0)
+        propSetDouble((OfxPropertySetHandle) image_effect,
+                      kOfxImageEffectInstancePropEffectDuration,
+                      0,
+                      duration);
+}
+
 int mltofx_allows_frame_threading(mlt_properties image_effect)
 {
     if (!image_effect)
@@ -2271,7 +2323,8 @@ void mltofx_set_source_clip_data(OfxPlugin *plugin,
                                  int height,
                                  mlt_image_format format,
                                  double pixel_aspect_ratio,
-                                 const char *ofx_depth)
+                                 const char *ofx_depth,
+                                 int top_left_origin)
 {
     mlt_properties clip;
     mlt_properties clip_prop;
@@ -2313,7 +2366,7 @@ void mltofx_set_source_clip_data(OfxPlugin *plugin,
 
     int row_bytes = width * depth_byte_size;
     uint8_t *image_origin = image;
-    if (row_bytes > 0 && height > 0) {
+    if (!top_left_origin && row_bytes > 0 && height > 0) {
         // OFX CPU images are addressed from lower-left. Point data at the
         // first byte of the last scanline and use negative row bytes.
         image_origin = image + ((size_t) (height - 1) * (size_t) row_bytes);
@@ -2423,7 +2476,8 @@ void mltofx_set_output_clip_data(OfxPlugin *plugin,
                                  int height,
                                  mlt_image_format format,
                                  double pixel_aspect_ratio,
-                                 const char *ofx_depth)
+                                 const char *ofx_depth,
+                                 int top_left_origin)
 {
     mlt_properties clip;
     mlt_properties clip_prop;
@@ -2457,7 +2511,7 @@ void mltofx_set_output_clip_data(OfxPlugin *plugin,
 
     int row_bytes = width * depth_byte_size;
     uint8_t *image_origin = image;
-    if (row_bytes > 0 && height > 0) {
+    if (!top_left_origin && row_bytes > 0 && height > 0) {
         // OFX CPU images are addressed from lower-left. Point data at the
         // first byte of the last scanline and use negative row bytes.
         image_origin = image + ((size_t) (height - 1) * (size_t) row_bytes);
@@ -3137,6 +3191,16 @@ void mltofx_get_region_of_definition(OfxPlugin *plugin, mlt_properties image_eff
                   (OfxImageClipHandle *) &output_clip,
                   (OfxPropertySetHandle *) &output_clip_props);
 
+    // Read PAR for pixel<->canonical conversion; x_canonical = x_pixel * par.
+    double rod_par = 1.0;
+    if (output_clip_props)
+        propGetDouble((OfxPropertySetHandle) output_clip_props,
+                      kOfxImagePropPixelAspectRatio,
+                      0,
+                      &rod_par);
+    if (rod_par <= 0.0)
+        rod_par = 1.0;
+
     int default_x1 = 0;
     int default_y1 = 0;
     int default_x2 = 0;
@@ -3193,10 +3257,11 @@ void mltofx_get_region_of_definition(OfxPlugin *plugin, mlt_properties image_eff
                   1,
                   render_scale_y);
 
+    // Seed outArgs with canonical defaults (x * PAR).
     propSetDouble((OfxPropertySetHandle) get_rod_out_args,
                   kOfxImageEffectPropRegionOfDefinition,
                   0,
-                  (double) default_x1);
+                  (double) default_x1 * rod_par);
     propSetDouble((OfxPropertySetHandle) get_rod_out_args,
                   kOfxImageEffectPropRegionOfDefinition,
                   1,
@@ -3204,7 +3269,7 @@ void mltofx_get_region_of_definition(OfxPlugin *plugin, mlt_properties image_eff
     propSetDouble((OfxPropertySetHandle) get_rod_out_args,
                   kOfxImageEffectPropRegionOfDefinition,
                   2,
-                  (double) default_x2);
+                  (double) default_x2 * rod_par);
     propSetDouble((OfxPropertySetHandle) get_rod_out_args,
                   kOfxImageEffectPropRegionOfDefinition,
                   3,
@@ -3237,9 +3302,10 @@ void mltofx_get_region_of_definition(OfxPlugin *plugin, mlt_properties image_eff
                       3,
                       &rod_y2);
 
-        int out_x1 = (int) floor(rod_x1);
+        // Convert canonical ROD back to pixel coordinates for storage.
+        int out_x1 = (int) floor(rod_x1 / rod_par);
         int out_y1 = (int) floor(rod_y1);
-        int out_x2 = (int) ceil(rod_x2);
+        int out_x2 = (int) ceil(rod_x2 / rod_par);
         int out_y2 = (int) ceil(rod_y2);
 
         if (out_x2 >= out_x1 && out_y2 >= out_y1) {
@@ -3286,6 +3352,17 @@ void mltofx_get_regions_of_interest(
                   1,
                   render_scale_y);
 
+    // ROI must be in canonical coordinates; read from project extent set earlier.
+    double canonical_width = width;
+    double canonical_height = height;
+    propGetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectExtent,
+                  0,
+                  &canonical_width);
+    propGetDouble((OfxPropertySetHandle) image_effect,
+                  kOfxImageEffectPropProjectExtent,
+                  1,
+                  &canonical_height);
     propSetDouble((OfxPropertySetHandle) get_roi_in_args,
                   kOfxImageEffectPropRegionOfInterest,
                   0,
@@ -3297,11 +3374,11 @@ void mltofx_get_regions_of_interest(
     propSetDouble((OfxPropertySetHandle) get_roi_in_args,
                   kOfxImageEffectPropRegionOfInterest,
                   2,
-                  width);
+                  canonical_width);
     propSetDouble((OfxPropertySetHandle) get_roi_in_args,
                   kOfxImageEffectPropRegionOfInterest,
                   3,
-                  height);
+                  canonical_height);
 
     OfxStatus status_code = plugin->mainEntry(kOfxImageEffectActionGetRegionsOfInterest,
                                               (OfxImageEffectHandle) image_effect,

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -2366,7 +2366,8 @@ void mltofx_set_source_clip_data(OfxPlugin *plugin,
 
     int row_bytes = width * depth_byte_size;
     uint8_t *image_origin = image;
-    if (!top_left_origin && row_bytes > 0 && height > 0) {
+    int gmic = !strncmp(plugin->pluginIdentifier, "eu.gmic.", 8);
+    if (!gmic && !top_left_origin && row_bytes > 0 && height > 0) {
         // OFX CPU images are addressed from lower-left. Point data at the
         // first byte of the last scanline and use negative row bytes.
         image_origin = image + ((size_t) (height - 1) * (size_t) row_bytes);

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -2311,7 +2311,16 @@ void mltofx_set_source_clip_data(OfxPlugin *plugin,
                                                   : (format == mlt_image_rgb ? "rgb" : "Unknown")),
                   depth_format);
 
-    propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRowBytes, 0, width * depth_byte_size);
+    int row_bytes = width * depth_byte_size;
+    uint8_t *image_origin = image;
+    if (row_bytes > 0 && height > 0) {
+        // OFX CPU images are addressed from lower-left. Point data at the
+        // first byte of the last scanline and use negative row bytes.
+        image_origin = image + ((size_t) (height - 1) * (size_t) row_bytes);
+        row_bytes = -row_bytes;
+    }
+
+    propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRowBytes, 0, row_bytes);
     propSetString((OfxPropertySetHandle) clip_prop, kOfxImageEffectPropPixelDepth, 0, depth_format);
     propSetString((OfxPropertySetHandle) clip_prop,
                   kOfxImageClipPropUnmappedPixelDepth,
@@ -2321,7 +2330,7 @@ void mltofx_set_source_clip_data(OfxPlugin *plugin,
                   kOfxImageEffectPropComponents,
                   0,
                   prop_component);
-    propSetPointer((OfxPropertySetHandle) clip_prop, kOfxImagePropData, 0, (void *) image);
+    propSetPointer((OfxPropertySetHandle) clip_prop, kOfxImagePropData, 0, (void *) image_origin);
     propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropBounds, 0, 0);
     propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropBounds, 1, 0);
     propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropBounds, 2, width);
@@ -2446,7 +2455,16 @@ void mltofx_set_output_clip_data(OfxPlugin *plugin,
         prop_component = kOfxImageComponentRGB;
     }
 
-    propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRowBytes, 0, width * depth_byte_size);
+    int row_bytes = width * depth_byte_size;
+    uint8_t *image_origin = image;
+    if (row_bytes > 0 && height > 0) {
+        // OFX CPU images are addressed from lower-left. Point data at the
+        // first byte of the last scanline and use negative row bytes.
+        image_origin = image + ((size_t) (height - 1) * (size_t) row_bytes);
+        row_bytes = -row_bytes;
+    }
+
+    propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropRowBytes, 0, row_bytes);
     propSetString((OfxPropertySetHandle) clip_prop, kOfxImageEffectPropPixelDepth, 0, depth_format);
     propSetString((OfxPropertySetHandle) clip_prop,
                   kOfxImageClipPropUnmappedPixelDepth,
@@ -2456,7 +2474,7 @@ void mltofx_set_output_clip_data(OfxPlugin *plugin,
                   kOfxImageEffectPropComponents,
                   0,
                   prop_component);
-    propSetPointer((OfxPropertySetHandle) clip_prop, kOfxImagePropData, 0, (void *) image);
+    propSetPointer((OfxPropertySetHandle) clip_prop, kOfxImagePropData, 0, (void *) image_origin);
     propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropBounds, 0, 0);
     propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropBounds, 1, 0);
     propSetInt((OfxPropertySetHandle) clip_prop, kOfxImagePropBounds, 2, width);

--- a/src/modules/openfx/mlt_openfx.h
+++ b/src/modules/openfx/mlt_openfx.h
@@ -70,7 +70,8 @@ void mltofx_set_source_clip_data(OfxPlugin *plugin,
                                  int height,
                                  mlt_image_format format,
                                  double pixel_aspect_ratio,
-                                 const char *ofx_depth);
+                                 const char *ofx_depth,
+                                 int top_left_origin);
 
 void mltofx_set_output_clip_data(OfxPlugin *plugin,
                                  mlt_properties image_effect,
@@ -79,7 +80,8 @@ void mltofx_set_output_clip_data(OfxPlugin *plugin,
                                  int height,
                                  mlt_image_format format,
                                  double pixel_aspect_ratio,
-                                 const char *ofx_depth);
+                                 const char *ofx_depth,
+                                 int top_left_origin);
 
 int mltofx_detect_plugin(OfxPlugin *plugin);
 
@@ -88,6 +90,13 @@ void *mltofx_fetch_params(OfxPlugin *plugin, mlt_properties params, mlt_properti
 void mltofx_param_set_value(mlt_properties params, char *key, mltofx_property_type type, ...);
 
 void mltofx_set_render_scale(mlt_properties image_effect, double scale_x, double scale_y);
+
+void mltofx_set_project_properties(mlt_properties image_effect,
+                                   int width,
+                                   int height,
+                                   double pixel_aspect_ratio,
+                                   double fps,
+                                   double duration);
 
 int mltofx_allows_frame_threading(mlt_properties image_effect);
 


### PR DESCRIPTION
Set kOfxImagePropRowBytes negative and shift kOfxImagePropData to the last scanline for Source and Output clips so CPU images are presented to OpenFX in lower-left origin order without repacking.

An easy way to test this is to apply the AboutGMIC plugin and see if the image is upside down

All the openfx plugins were operating on the image upside down because openfx wants the first pixel to be the bottom left. The API allows negative row-bytes, so this patch allows us to provide the correct orientation without repacking the frame. 

I was feeling confident about this patch with my testing and then I ran into a crash. Specifically openfx.net.fxarena.openfx.Charcoal crashes with this patch. When I  test that same plugin without this patch, it does not crash, but it also doesn't work (black frame). Maybe something else is wrong with that plugin that this change is exposing. So I'm posting this patch here to allow for more testing.