### PR TITLE
Fix heap overflow in time formatting and disable ante/post exec by de…

### DIFF
--- a/0001-fix-heap-overflow-mlt_property_get_time.patch
+++ b/0001-fix-heap-overflow-mlt_property_get_time.patch
@@ -1,0 +1,171 @@
+--- a/src/framework/mlt_property.c
++++ b/src/framework/mlt_property.c
+@@ -48,6 +48,13 @@
+ #define NEED_LOCALE_SAVE_RESTORE 1
+ #endif
+ 
++/** Maximum size, in bytes, of a formatted SMPTE timecode or SMIL clock value
++ * string, including the terminating NUL. This is sized generously so that
++ * it cannot be exceeded even for pathological/attacker-supplied frame counts
++ * or frame rates (see time_smpte_from_frames() and time_clock_from_frames()).
++ */
++#define MLT_TIME_STRING_MAX 64
++
+ /** Bit pattern used internally to indicated representations available.
+ */
+ 
+@@ -972,7 +979,7 @@
+  * \private \memberof mlt_property_s
+  * \param frames a frame count
+  * \param fps frames per second
+- * \param[out] s the string to write into - must have enough space to hold largest time string
++ * \param[out] s the string to write into - must be at least MLT_TIME_STRING_MAX bytes
+  * \param drop whether to use drop-frame timecode for applicable frame rates
+  */
+ 
+@@ -1007,36 +1014,61 @@
+     } else if (fps != lrint(fps)) {
+         frame_sep = ';';
+     }
+-    hours = frames / (fps * 3600);
+-    frames -= floor(hours * 3600 * fps);
+ 
+-    mins = frames / (fps * 60);
++    // Guard against a degenerate or absurdly small fps (e.g. supplied by an
++    // untrusted profile/property) producing an hours/mins value so large that
++    // it would overflow the output buffer or an int. %02d is a *minimum*
++    // field width, not a maximum, so very large hour counts would otherwise
++    // print far more digits than the buffer was sized for.
++    if (!(fps > 0.0))
++        fps = 1.0;
++
++    double hours_d = frames / (fps * 3600);
++    if (hours_d > 999999.0)
++        hours_d = 999999.0;
++    else if (hours_d < -999999.0)
++        hours_d = -999999.0;
++    hours = (int) hours_d;
++    frames -= floor((double) hours * 3600 * fps);
++
++    double mins_d = frames / (fps * 60);
++    if (mins_d > 99.0)
++        mins_d = 99.0;
++    else if (mins_d < -99.0)
++        mins_d = -99.0;
++    mins = (int) mins_d;
+     if (mins == 60) { // floating point error
+         ++hours;
+-        frames = save_frames - floor(hours * 3600 * fps);
++        frames = save_frames - floor((double) hours * 3600 * fps);
+         mins = 0;
+     }
+     save_frames = frames;
+-    frames -= floor(mins * 60 * fps);
++    frames -= floor((double) mins * 60 * fps);
+ 
+-    secs = frames / fps;
++    double secs_d = frames / fps;
++    if (secs_d > 99.0)
++        secs_d = 99.0;
++    else if (secs_d < -99.0)
++        secs_d = -99.0;
++    secs = (int) secs_d;
+     if (secs == 60) { // floating point error
+         ++mins;
+-        frames = save_frames - floor(mins * 60 * fps);
++        frames = save_frames - floor((double) mins * 60 * fps);
+         secs = 0;
+     }
+     frames -= ceil(secs * fps);
+ 
+-    sprintf(s,
+-            "%02d:%02d:%02d%c%0*d",
+-            hours,
+-            mins,
+-            secs,
+-            frame_sep,
+-            (fps > 999  ? 4
+-             : fps > 99 ? 3
+-                        : 2),
+-            frames);
++    snprintf(s,
++             MLT_TIME_STRING_MAX,
++             "%02d:%02d:%02d%c%0*d",
++             hours,
++             mins,
++             secs,
++             frame_sep,
++             (fps > 999  ? 4
++              : fps > 99 ? 3
++                         : 2),
++             frames);
+ }
+ 
+ /** Convert frame count to a SMIL clock value string.
+@@ -1044,7 +1076,7 @@
+  * \private \memberof mlt_property_s
+  * \param frames a frame count
+  * \param fps frames per second
+- * \param[out] s the string to write into - must have enough space to hold largest time string
++ * \param[out] s the string to write into - must be at least MLT_TIME_STRING_MAX bytes
+  */
+ 
+ static void time_clock_from_frames(int frames, double fps, char *s)
+@@ -1053,26 +1085,40 @@
+     double secs;
+     int save_frames = frames;
+ 
+-    hours = frames / (fps * 3600);
+-    frames -= floor(hours * 3600 * fps);
+-
+-    mins = frames / (fps * 60);
++    // See comment in time_smpte_from_frames() above.
++    if (!(fps > 0.0))
++        fps = 1.0;
++
++    double hours_d = frames / (fps * 3600);
++    if (hours_d > 999999.0)
++        hours_d = 999999.0;
++    else if (hours_d < -999999.0)
++        hours_d = -999999.0;
++    hours = (int) hours_d;
++    frames -= floor((double) hours * 3600 * fps);
++
++    double mins_d = frames / (fps * 60);
++    if (mins_d > 99.0)
++        mins_d = 99.0;
++    else if (mins_d < -99.0)
++        mins_d = -99.0;
++    mins = (int) mins_d;
+     if (mins == 60) { // floating point error
+         ++hours;
+-        frames = save_frames - floor(hours * 3600 * fps);
++        frames = save_frames - floor((double) hours * 3600 * fps);
+         mins = 0;
+     }
+     save_frames = frames;
+-    frames -= floor(mins * 60 * fps);
++    frames -= floor((double) mins * 60 * fps);
+ 
+     secs = frames / fps;
+     if (secs >= 60.0) { // floating point error
+         ++mins;
+-        frames = save_frames - floor(mins * 60 * fps);
++        frames = save_frames - floor((double) mins * 60 * fps);
+         secs = frames / fps;
+     }
+ 
+-    sprintf(s, "%02d:%02d:%06.3f", hours, mins, secs);
++    snprintf(s, MLT_TIME_STRING_MAX, "%02d:%02d:%06.3f", hours, mins, secs);
+ }
+ 
+ /** Get the property as a time string.
+@@ -1147,7 +1193,7 @@
+     }
+ 
+     self->types |= mlt_prop_string;
+-    self->prop_string = malloc(32);
++    self->prop_string = malloc(MLT_TIME_STRING_MAX);
+ 
+     if (format == mlt_time_clock)
+         time_clock_from_frames(frames, fps, self->prop_string);

--- a/0002-disable-ante-post-system-exec-by-default.patch
+++ b/0002-disable-ante-post-system-exec-by-default.patch
@@ -1,0 +1,80 @@
+--- a/src/framework/mlt_consumer.c
++++ b/src/framework/mlt_consumer.c
+@@ -47,6 +47,29 @@
+  */
+ MLT_EXPORT pthread_mutex_t mlt_sdl_mutex = PTHREAD_MUTEX_INITIALIZER;
+ 
++/** Determine whether the "ante" and "post" consumer properties are permitted
++ * to be executed via system().
++ *
++ * SECURITY: The "ante" and "post" properties can run arbitrary shell
++ * commands. These properties can be set merely by loading an MLT XML
++ * document (e.g. a <consumer> element's attributes), which means that
++ * opening an untrusted .mlt file could otherwise result in arbitrary
++ * command execution with no explicit action by the user beyond rendering
++ * or previewing the file. To prevent this, execution of these commands is
++ * disabled by default. An application that intentionally relies on this
++ * feature (e.g. its own trusted, locally authored profiles/scripts) can
++ * opt in by setting the environment variable MLT_CONSUMER_ANTE_POST_ALLOWED
++ * to "1" (or any non-empty value other than "0").
++ *
++ * \return 1 if execution of ante/post commands is permitted, 0 otherwise
++ */
++
++static int ante_post_commands_allowed()
++{
++    const char *e = getenv("MLT_CONSUMER_ANTE_POST_ALLOWED");
++    return e && e[0] && strcmp(e, "0") != 0;
++}
++
+ /** mlt_frame_s::is_processing can not be made atomic, so protect it with a mutex.
+  */
+ MLT_EXPORT pthread_mutex_t mlt_frame_processing_mutex = PTHREAD_MUTEX_INITIALIZER;
+@@ -542,12 +565,21 @@
+     mlt_properties_set_int(properties, "drop_count", 0);
+ 
+     // Check and run an ante command
+-    if (mlt_properties_get(properties, "ante"))
+-        if (system(mlt_properties_get(properties, "ante")) == -1)
++    if (mlt_properties_get(properties, "ante")) {
++        if (!ante_post_commands_allowed()) {
++            mlt_log(MLT_CONSUMER_SERVICE(self),
++                    MLT_LOG_WARNING,
++                    "Ignoring \"ante\" command (%s) because execution of ante/post commands is "
++                    "disabled by default for security reasons. Set the environment variable "
++                    "MLT_CONSUMER_ANTE_POST_ALLOWED=1 to allow it.\n",
++                    mlt_properties_get(properties, "ante"));
++        } else if (system(mlt_properties_get(properties, "ante")) == -1) {
+             mlt_log(MLT_CONSUMER_SERVICE(self),
+                     MLT_LOG_ERROR,
+                     "system(%s) failed!\n",
+                     mlt_properties_get(properties, "ante"));
++        }
++    }
+ 
+     // Set the real_time preference
+     priv->real_time = mlt_properties_get_int(properties, "real_time");
+@@ -1704,12 +1736,21 @@
+     mlt_properties_set_data(properties, "test_card_producer", NULL, 0, NULL, NULL);
+ 
+     // Check and run a post command
+-    if (mlt_properties_get(properties, "post"))
+-        if (system(mlt_properties_get(properties, "post")) == -1)
++    if (mlt_properties_get(properties, "post")) {
++        if (!ante_post_commands_allowed()) {
++            mlt_log(MLT_CONSUMER_SERVICE(self),
++                    MLT_LOG_WARNING,
++                    "Ignoring \"post\" command (%s) because execution of ante/post commands is "
++                    "disabled by default for security reasons. Set the environment variable "
++                    "MLT_CONSUMER_ANTE_POST_ALLOWED=1 to allow it.\n",
++                    mlt_properties_get(properties, "post"));
++        } else if (system(mlt_properties_get(properties, "post")) == -1) {
+             mlt_log(MLT_CONSUMER_SERVICE(self),
+                     MLT_LOG_ERROR,
+                     "system(%s) failed!\n",
+                     mlt_properties_get(properties, "post"));
++        }
++    }
+ 
+     mlt_log(MLT_CONSUMER_SERVICE(self), MLT_LOG_DEBUG, "stopped\n");
+ 

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -47,6 +47,29 @@
  */
 MLT_EXPORT pthread_mutex_t mlt_sdl_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+/** Determine whether the "ante" and "post" consumer properties are permitted
+ * to be executed via system().
+ *
+ * SECURITY: The "ante" and "post" properties can run arbitrary shell
+ * commands. These properties can be set merely by loading an MLT XML
+ * document (e.g. a <consumer> element's attributes), which means that
+ * opening an untrusted .mlt file could otherwise result in arbitrary
+ * command execution with no explicit action by the user beyond rendering
+ * or previewing the file. To prevent this, execution of these commands is
+ * disabled by default. An application that intentionally relies on this
+ * feature (e.g. its own trusted, locally authored profiles/scripts) can
+ * opt in by setting the environment variable MLT_CONSUMER_ANTE_POST_ALLOWED
+ * to "1" (or any non-empty value other than "0").
+ *
+ * \return 1 if execution of ante/post commands is permitted, 0 otherwise
+ */
+
+static int ante_post_commands_allowed()
+{
+    const char *e = getenv("MLT_CONSUMER_ANTE_POST_ALLOWED");
+    return e && e[0] && strcmp(e, "0") != 0;
+}
+
 /** mlt_frame_s::is_processing can not be made atomic, so protect it with a mutex.
  */
 MLT_EXPORT pthread_mutex_t mlt_frame_processing_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -542,12 +565,21 @@ int mlt_consumer_start(mlt_consumer self)
     mlt_properties_set_int(properties, "drop_count", 0);
 
     // Check and run an ante command
-    if (mlt_properties_get(properties, "ante"))
-        if (system(mlt_properties_get(properties, "ante")) == -1)
+    if (mlt_properties_get(properties, "ante")) {
+        if (!ante_post_commands_allowed()) {
+            mlt_log(MLT_CONSUMER_SERVICE(self),
+                    MLT_LOG_WARNING,
+                    "Ignoring \"ante\" command (%s) because execution of ante/post commands is "
+                    "disabled by default for security reasons. Set the environment variable "
+                    "MLT_CONSUMER_ANTE_POST_ALLOWED=1 to allow it.\n",
+                    mlt_properties_get(properties, "ante"));
+        } else if (system(mlt_properties_get(properties, "ante")) == -1) {
             mlt_log(MLT_CONSUMER_SERVICE(self),
                     MLT_LOG_ERROR,
                     "system(%s) failed!\n",
                     mlt_properties_get(properties, "ante"));
+        }
+    }
 
     // Set the real_time preference
     priv->real_time = mlt_properties_get_int(properties, "real_time");
@@ -1704,12 +1736,21 @@ int mlt_consumer_stop(mlt_consumer self)
     mlt_properties_set_data(properties, "test_card_producer", NULL, 0, NULL, NULL);
 
     // Check and run a post command
-    if (mlt_properties_get(properties, "post"))
-        if (system(mlt_properties_get(properties, "post")) == -1)
+    if (mlt_properties_get(properties, "post")) {
+        if (!ante_post_commands_allowed()) {
+            mlt_log(MLT_CONSUMER_SERVICE(self),
+                    MLT_LOG_WARNING,
+                    "Ignoring \"post\" command (%s) because execution of ante/post commands is "
+                    "disabled by default for security reasons. Set the environment variable "
+                    "MLT_CONSUMER_ANTE_POST_ALLOWED=1 to allow it.\n",
+                    mlt_properties_get(properties, "post"));
+        } else if (system(mlt_properties_get(properties, "post")) == -1) {
             mlt_log(MLT_CONSUMER_SERVICE(self),
                     MLT_LOG_ERROR,
                     "system(%s) failed!\n",
                     mlt_properties_get(properties, "post"));
+        }
+    }
 
     mlt_log(MLT_CONSUMER_SERVICE(self), MLT_LOG_DEBUG, "stopped\n");
 

--- a/src/framework/mlt_property.c
+++ b/src/framework/mlt_property.c
@@ -48,6 +48,13 @@
 #define NEED_LOCALE_SAVE_RESTORE 1
 #endif
 
+/** Maximum size, in bytes, of a formatted SMPTE timecode or SMIL clock value
+ * string, including the terminating NUL. This is sized generously so that
+ * it cannot be exceeded even for pathological/attacker-supplied frame counts
+ * or frame rates (see time_smpte_from_frames() and time_clock_from_frames()).
+ */
+#define MLT_TIME_STRING_MAX 64
+
 /** Bit pattern used internally to indicated representations available.
 */
 
@@ -972,7 +979,7 @@ void mlt_property_pass(mlt_property self, mlt_property that)
  * \private \memberof mlt_property_s
  * \param frames a frame count
  * \param fps frames per second
- * \param[out] s the string to write into - must have enough space to hold largest time string
+ * \param[out] s the string to write into - must be at least MLT_TIME_STRING_MAX bytes
  * \param drop whether to use drop-frame timecode for applicable frame rates
  */
 
@@ -1007,36 +1014,61 @@ static void time_smpte_from_frames(int frames, double fps, char *s, int drop)
     } else if (fps != lrint(fps)) {
         frame_sep = ';';
     }
-    hours = frames / (fps * 3600);
-    frames -= floor(hours * 3600 * fps);
 
-    mins = frames / (fps * 60);
+    // Guard against a degenerate or absurdly small fps (e.g. supplied by an
+    // untrusted profile/property) producing an hours/mins value so large that
+    // it would overflow the output buffer or an int. %02d is a *minimum*
+    // field width, not a maximum, so very large hour counts would otherwise
+    // print far more digits than the buffer was sized for.
+    if (!(fps > 0.0))
+        fps = 1.0;
+
+    double hours_d = frames / (fps * 3600);
+    if (hours_d > 999999.0)
+        hours_d = 999999.0;
+    else if (hours_d < -999999.0)
+        hours_d = -999999.0;
+    hours = (int) hours_d;
+    frames -= floor((double) hours * 3600 * fps);
+
+    double mins_d = frames / (fps * 60);
+    if (mins_d > 99.0)
+        mins_d = 99.0;
+    else if (mins_d < -99.0)
+        mins_d = -99.0;
+    mins = (int) mins_d;
     if (mins == 60) { // floating point error
         ++hours;
-        frames = save_frames - floor(hours * 3600 * fps);
+        frames = save_frames - floor((double) hours * 3600 * fps);
         mins = 0;
     }
     save_frames = frames;
-    frames -= floor(mins * 60 * fps);
+    frames -= floor((double) mins * 60 * fps);
 
-    secs = frames / fps;
+    double secs_d = frames / fps;
+    if (secs_d > 99.0)
+        secs_d = 99.0;
+    else if (secs_d < -99.0)
+        secs_d = -99.0;
+    secs = (int) secs_d;
     if (secs == 60) { // floating point error
         ++mins;
-        frames = save_frames - floor(mins * 60 * fps);
+        frames = save_frames - floor((double) mins * 60 * fps);
         secs = 0;
     }
     frames -= ceil(secs * fps);
 
-    sprintf(s,
-            "%02d:%02d:%02d%c%0*d",
-            hours,
-            mins,
-            secs,
-            frame_sep,
-            (fps > 999  ? 4
-             : fps > 99 ? 3
-                        : 2),
-            frames);
+    snprintf(s,
+             MLT_TIME_STRING_MAX,
+             "%02d:%02d:%02d%c%0*d",
+             hours,
+             mins,
+             secs,
+             frame_sep,
+             (fps > 999  ? 4
+              : fps > 99 ? 3
+                         : 2),
+             frames);
 }
 
 /** Convert frame count to a SMIL clock value string.
@@ -1044,7 +1076,7 @@ static void time_smpte_from_frames(int frames, double fps, char *s, int drop)
  * \private \memberof mlt_property_s
  * \param frames a frame count
  * \param fps frames per second
- * \param[out] s the string to write into - must have enough space to hold largest time string
+ * \param[out] s the string to write into - must be at least MLT_TIME_STRING_MAX bytes
  */
 
 static void time_clock_from_frames(int frames, double fps, char *s)
@@ -1053,26 +1085,40 @@ static void time_clock_from_frames(int frames, double fps, char *s)
     double secs;
     int save_frames = frames;
 
-    hours = frames / (fps * 3600);
-    frames -= floor(hours * 3600 * fps);
+    // See comment in time_smpte_from_frames() above.
+    if (!(fps > 0.0))
+        fps = 1.0;
 
-    mins = frames / (fps * 60);
+    double hours_d = frames / (fps * 3600);
+    if (hours_d > 999999.0)
+        hours_d = 999999.0;
+    else if (hours_d < -999999.0)
+        hours_d = -999999.0;
+    hours = (int) hours_d;
+    frames -= floor((double) hours * 3600 * fps);
+
+    double mins_d = frames / (fps * 60);
+    if (mins_d > 99.0)
+        mins_d = 99.0;
+    else if (mins_d < -99.0)
+        mins_d = -99.0;
+    mins = (int) mins_d;
     if (mins == 60) { // floating point error
         ++hours;
-        frames = save_frames - floor(hours * 3600 * fps);
+        frames = save_frames - floor((double) hours * 3600 * fps);
         mins = 0;
     }
     save_frames = frames;
-    frames -= floor(mins * 60 * fps);
+    frames -= floor((double) mins * 60 * fps);
 
     secs = frames / fps;
     if (secs >= 60.0) { // floating point error
         ++mins;
-        frames = save_frames - floor(mins * 60 * fps);
+        frames = save_frames - floor((double) mins * 60 * fps);
         secs = frames / fps;
     }
 
-    sprintf(s, "%02d:%02d:%06.3f", hours, mins, secs);
+    snprintf(s, MLT_TIME_STRING_MAX, "%02d:%02d:%06.3f", hours, mins, secs);
 }
 
 /** Get the property as a time string.
@@ -1147,7 +1193,7 @@ char *mlt_property_get_time(mlt_property self,
     }
 
     self->types |= mlt_prop_string;
-    self->prop_string = malloc(32);
+    self->prop_string = malloc(MLT_TIME_STRING_MAX);
 
     if (format == mlt_time_clock)
         time_clock_from_frames(frames, fps, self->prop_string);


### PR DESCRIPTION
# MLT security fixes — 2 patches
 
Apply from the repo root (where `CMakeLists.txt` lives):
 
```
git apply 0001-fix-heap-overflow-mlt_property_get_time.patch
git apply 0002-disable-ante-post-system-exec-by-default.patch
```
 
(Or `patch -p1 < 0001-...patch` if you're not using git.)
 
## 0001 — Heap buffer overflow in `mlt_property_get_time`
 
**File:** `src/framework/mlt_property.c`
 
`mlt_property_get_time()` allocated a fixed 32-byte buffer and filled it via
`sprintf()` with hours/minutes/seconds computed from an attacker-controlled
frame count and frame rate (both reachable from an untrusted `.mlt` XML
project file — e.g. a producer's `in`/`out`/`length` property, or an
animation keyframe, combined with a profile's frame rate). `%02d` is a
*minimum* field width, not a maximum, so a large `hours` value (achievable
with a huge frame count and/or a very small fps) produces a string far
longer than 32 bytes, overflowing the heap allocation.
 
**Fix:**
- Replaced `sprintf` with `snprintf` bounded by a new `MLT_TIME_STRING_MAX`
  (64 bytes) constant, so the function can never write past the buffer
  regardless of input.
- Increased the allocation at the call site from `malloc(32)` to
  `malloc(MLT_TIME_STRING_MAX)`.
- Clamped the intermediate `hours`/`mins`/`secs` values to sane ranges
  before formatting, so degenerate/extreme inputs (e.g. `fps <= 0`, or a
  frame count near `INT_MAX`/`INT_MIN` with a very small fps) produce a
  well-formed, bounded string instead of nonsensical or wildly long output.
- Forced `double` arithmetic in a couple of intermediate computations
  (`hours * 3600 * fps`, `mins * 60 * fps`) that were previously done in
  `int`, which could overflow (undefined behavior) for large clamped
  `hours`/`mins` values.
Verified with ASan + UBSan against a battery of extreme/adversarial inputs
(`INT_MAX`/`INT_MIN` frame counts, fps of 0, negative, near-zero, and
absurdly large) — no overflow or UB is triggered post-fix, and normal
inputs (e.g. NTSC 29.97fps) produce identical output to before.
 
## 0002 — Arbitrary command execution via `ante`/`post` consumer properties
 
**File:** `src/framework/mlt_consumer.c`
 
The consumer's `ante` and `post` properties are passed directly to
`system()` when a consumer starts/stops. These properties can be set
purely by loading an `.mlt` XML file — a `<consumer>` element's attributes
(or child `<property>` tags) flow straight through
`mlt_properties_inherit()` into the real consumer's property set with no
sanitization or opt-in. This means simply opening/rendering an untrusted
project file (e.g. `melt evil.mlt`) can execute arbitrary shell commands
with no other action by the user.
 
**Fix:** Execution of `ante`/`post` is now disabled by default. If either
property is present but execution isn't explicitly allowed, MLT logs a
warning naming the blocked command and skips it instead of running it. An
application that intentionally wants this feature (e.g. for its own
trusted, locally-authored scripts/projects) can opt back in by setting the
environment variable:
 
```
MLT_CONSUMER_ANTE_POST_ALLOWED=1
```
 
This preserves the documented feature for users who knowingly want it,
while closing the "open a file → arbitrary code execution" path for the
common case of loading project files from an untrusted or unknown source.
 
## Notes / things to double check before merging
 
- The `MLT_CONSUMER_ANTE_POST_ALLOWED` opt-in is a minimal stopgap. If you'd
  prefer a different mechanism (e.g. a `mlt_consumer` API flag the
  *application* sets explicitly, rather than an environment variable),
  that's a reasonable alternative design — happy to rework it.
- These two patches address the most severe issues I found in the time
  available. I did not do an exhaustive audit of the rest of the codebase
  (avformat/FFmpeg integration, Qt/GDK image loaders, the `melt` CLI parser,
  subtitle parsers, etc.) — see the earlier conversation for what was and
  wasn't covered.