### PR TITLE
Openfx filters

### DIFF
--- a/src/modules/openfx/factory.c
+++ b/src/modules/openfx/factory.c
@@ -20,6 +20,7 @@
 #include "mlt_openfx.h"
 #include <glib.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 extern OfxHost MltOfxHost;
 mlt_properties mltofx_context;
@@ -265,8 +266,20 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
 
                 char *s = NULL;
                 size_t pluginIdentifier_len = strlen(plugin_id);
-                s = malloc(pluginIdentifier_len + 8);
-                sprintf(s, "openfx.%s", plugin_id);
+                size_t service_prefix_len = strlen("openfx.");
+                if (pluginIdentifier_len > SIZE_MAX - service_prefix_len - 1) {
+                    continue;
+                }
+                size_t service_key_size = pluginIdentifier_len + service_prefix_len + 1;
+                s = malloc(service_key_size);
+                if (!s) {
+                    continue;
+                }
+                if (snprintf(s, service_key_size, "openfx.%s", plugin_id)
+                    >= (int) service_key_size) {
+                    free(s);
+                    continue;
+                }
                 // if colon `:` exists in plugin identifier change it to accent
                 // sign `^` because `:` can cause issues with mlt if put in
                 // filter name
@@ -312,10 +325,20 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
                 }
 
                 mlt_properties p = mlt_properties_new();
-                mlt_properties_set_properties(mltofx_context, s, p);
-                mlt_properties_close(p);
+                if (!p) {
+                    free(s);
+                    continue;
+                }
+
                 mlt_properties_set(p, "dli", dl_n);
                 mlt_properties_set_int(p, "index", i);
+                if (mlt_properties_set_properties(mltofx_context, s, p)) {
+                    mlt_properties_close(p);
+                    free(s);
+                    continue;
+                }
+                mlt_properties_close(p);
+
                 MLT_REGISTER(mlt_service_filter_type, s, filter_openfx_init);
                 MLT_REGISTER_METADATA(mlt_service_filter_type, s, metadata, "filter_openfx.yml");
                 if (diagnostics) {

--- a/src/modules/openfx/factory.c
+++ b/src/modules/openfx/factory.c
@@ -263,6 +263,19 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
                     continue;
                 }
 
+                char *s = NULL;
+                size_t pluginIdentifier_len = strlen(plugin_id);
+                s = malloc(pluginIdentifier_len + 8);
+                sprintf(s, "openfx.%s", plugin_id);
+                // if colon `:` exists in plugin identifier change it to accent
+                // sign `^` because `:` can cause issues with mlt if put in
+                // filter name
+                char *str_ptr = strchr(s, ':');
+                while (str_ptr != NULL) {
+                    *str_ptr++ = '^';
+                    str_ptr = strchr(str_ptr, ':');
+                }
+
                 int diagnostics = mltofx_discovery_diagnostics_enabled(plugin_id);
                 if (diagnostics) {
                     mlt_log_info(NULL,
@@ -270,6 +283,20 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
                                  plugin_id ? plugin_id : "(null)",
                                  name,
                                  i);
+                }
+
+                // Skip duplicate service keys before detect/register work.
+                if (mlt_properties_get_properties(mltofx_context, s) != NULL) {
+                    if (diagnostics) {
+                        mlt_log_info(NULL,
+                                     "[openfx] skipped plugin `%s` (index=%d): duplicate service "
+                                     "`%s` already registered\n",
+                                     plugin_id ? plugin_id : "(null)",
+                                     i,
+                                     s);
+                    }
+                    free(s);
+                    continue;
                 }
 
                 int detected = mltofx_detect_plugin(plugin_ptr);
@@ -280,22 +307,8 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
                                      "[openfx] skipped plugin `%s`: detection rejected it\n",
                                      plugin_id ? plugin_id : "(null)");
                     }
+                    free(s);
                     continue;
-                }
-
-                char *s = NULL;
-                size_t pluginIdentifier_len = strlen(plugin_id);
-                s = malloc(pluginIdentifier_len + 8);
-                sprintf(s, "openfx.%s", plugin_id);
-
-                // if colon `:` exists in plugin identifier
-                // change it to accent sign `^` because `:`
-                // can cause issues with mlt if put in filter
-                // name
-                char *str_ptr = strchr(s, ':');
-                while (str_ptr != NULL) {
-                    *str_ptr++ = '^';
-                    str_ptr = strchr(str_ptr, ':');
                 }
 
                 mlt_properties p = mlt_properties_new();

--- a/src/modules/openfx/factory.c
+++ b/src/modules/openfx/factory.c
@@ -252,15 +252,41 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
                 if (!plugin_ptr)
                     break;
 
+                const char *plugin_id = plugin_ptr->pluginIdentifier;
+                if (!plugin_id || !plugin_id[0]) {
+                    mlt_log_warning(
+                        NULL,
+                        "[openfx] skipping plugin with missing identifier in bundle `%s` "
+                        "(index=%d)\n",
+                        name,
+                        i);
+                    continue;
+                }
+
+                int diagnostics = mltofx_discovery_diagnostics_enabled(plugin_id);
+                if (diagnostics) {
+                    mlt_log_info(NULL,
+                                 "[openfx] discovered plugin `%s` in bundle `%s` (index=%d)\n",
+                                 plugin_id ? plugin_id : "(null)",
+                                 name,
+                                 i);
+                }
+
                 int detected = mltofx_detect_plugin(plugin_ptr);
 
-                if (!detected)
+                if (!detected) {
+                    if (diagnostics) {
+                        mlt_log_info(NULL,
+                                     "[openfx] skipped plugin `%s`: detection rejected it\n",
+                                     plugin_id ? plugin_id : "(null)");
+                    }
                     continue;
+                }
 
                 char *s = NULL;
-                size_t pluginIdentifier_len = strlen(plugin_ptr->pluginIdentifier);
+                size_t pluginIdentifier_len = strlen(plugin_id);
                 s = malloc(pluginIdentifier_len + 8);
-                sprintf(s, "openfx.%s", plugin_ptr->pluginIdentifier);
+                sprintf(s, "openfx.%s", plugin_id);
 
                 // if colon `:` exists in plugin identifier
                 // change it to accent sign `^` because `:`
@@ -279,6 +305,12 @@ static void scan_ofx_dir(mlt_repository repository, const char *dir, int *dli, i
                 mlt_properties_set_int(p, "index", i);
                 MLT_REGISTER(mlt_service_filter_type, s, filter_openfx_init);
                 MLT_REGISTER_METADATA(mlt_service_filter_type, s, metadata, "filter_openfx.yml");
+                if (diagnostics) {
+                    mlt_log_info(NULL,
+                                 "[openfx] added plugin `%s` as filter `%s`\n",
+                                 plugin_id ? plugin_id : "(null)",
+                                 s);
+                }
                 free(s);
             }
         } else if (depth == 0 && name[0] != '.') {

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -2884,10 +2884,14 @@ static void mltofx_log_clip_diagnostics(int diagnostics, const char *plugin_id, 
                  clip_count);
     for (int c = 0; c < clip_count; ++c) {
         char *clip_name = mlt_properties_get_name(clips, c);
-        mlt_properties clip_props = mlt_properties_get_properties(clips, clip_name);
+        mlt_properties clip = mlt_properties_get_properties(clips, clip_name);
+        mlt_properties clip_props = clip ? mlt_properties_get_properties(clip, "props") : NULL;
         int optional = 0;
-        if (clip_props)
+        if (clip_props
+            && propGetInt((OfxPropertySetHandle) clip_props, kOfxImageClipPropOptional, 0, &optional)
+                   != kOfxStatOK) {
             optional = mlt_properties_get_int(clip_props, kOfxImageClipPropOptional);
+        }
         const char *role = clip_name && !strcmp(clip_name, kOfxImageEffectOutputClipName) ? "output"
                                                                                           : "input";
         mlt_log_info(NULL,

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -2875,9 +2875,6 @@ static void mltofx_log_clip_diagnostics(int diagnostics, const char *plugin_id, 
         return;
 
     int clip_count = mlt_properties_count(clips);
-    int output_clip_count = 0;
-    int input_clip_count = 0;
-    int optional_input_clip_count = 0;
     mlt_log_info(NULL,
                  "[openfx] plugin `%s`: clip_count=%d\n",
                  plugin_id ? plugin_id : "(null)",
@@ -2901,13 +2898,6 @@ static void mltofx_log_clip_diagnostics(int diagnostics, const char *plugin_id, 
                      clip_name ? clip_name : "(null)",
                      role,
                      optional);
-        if (clip_name && !strcmp(clip_name, kOfxImageEffectOutputClipName))
-            ++output_clip_count;
-        else {
-            ++input_clip_count;
-            if (optional)
-                ++optional_input_clip_count;
-        }
     }
 }
 

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -2839,8 +2839,79 @@ void mltofx_set_output_clip_data(OfxPlugin *plugin,
     mltofx_apply_cached_clip_preferences(image_effect);
 }
 
+// Logs all indexed string values for an OFX property (for discovery diagnostics).
+static void mltofx_log_property_diagnostics(int diagnostics,
+                                            const char *plugin_id,
+                                            mlt_properties props,
+                                            const char *property,
+                                            const char *label)
+{
+    if (!diagnostics || !props)
+        return;
+
+    int count = 0;
+    propGetDimension((OfxPropertySetHandle) props, property, &count);
+    mlt_log_info(NULL,
+                 "[openfx] plugin `%s`: %s count=%d\n",
+                 plugin_id ? plugin_id : "(null)",
+                 label,
+                 count);
+    for (int i = 0; i < count; ++i) {
+        char *value = NULL;
+        if (propGetString((OfxPropertySetHandle) props, property, i, &value) == kOfxStatOK) {
+            mlt_log_info(NULL,
+                         "[openfx] plugin `%s`: %s[%d]=`%s`\n",
+                         plugin_id ? plugin_id : "(null)",
+                         label,
+                         i,
+                         value ? value : "(null)");
+        }
+    }
+}
+
+static void mltofx_log_clip_diagnostics(int diagnostics, const char *plugin_id, mlt_properties clips)
+{
+    if (!diagnostics || !clips)
+        return;
+
+    int clip_count = mlt_properties_count(clips);
+    int output_clip_count = 0;
+    int input_clip_count = 0;
+    int optional_input_clip_count = 0;
+    mlt_log_info(NULL,
+                 "[openfx] plugin `%s`: clip_count=%d\n",
+                 plugin_id ? plugin_id : "(null)",
+                 clip_count);
+    for (int c = 0; c < clip_count; ++c) {
+        char *clip_name = mlt_properties_get_name(clips, c);
+        mlt_properties clip_props = mlt_properties_get_properties(clips, clip_name);
+        int optional = 0;
+        if (clip_props)
+            optional = mlt_properties_get_int(clip_props, kOfxImageClipPropOptional);
+        const char *role = clip_name && !strcmp(clip_name, kOfxImageEffectOutputClipName) ? "output"
+                                                                                          : "input";
+        mlt_log_info(NULL,
+                     "[openfx] plugin `%s`: clip[%d]=`%s` role=%s optional=%d\n",
+                     plugin_id ? plugin_id : "(null)",
+                     c,
+                     clip_name ? clip_name : "(null)",
+                     role,
+                     optional);
+        if (clip_name && !strcmp(clip_name, kOfxImageEffectOutputClipName))
+            ++output_clip_count;
+        else {
+            ++input_clip_count;
+            if (optional)
+                ++optional_input_clip_count;
+        }
+    }
+}
+
 int mltofx_detect_plugin(OfxPlugin *plugin)
 {
+    const char *plugin_id = plugin ? plugin->pluginIdentifier : NULL;
+    int diagnostics = mltofx_discovery_diagnostics_enabled(plugin_id);
+
     mlt_properties image_effect = mlt_properties_new();
     mlt_properties clips = mlt_properties_new();
     mlt_properties props = mlt_properties_new();
@@ -2865,6 +2936,12 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
     mltofx_log_status_code(status_code, "kOfxActionLoad");
 
     if (status_code != kOfxStatOK) {
+        if (diagnostics) {
+            mlt_log_info(NULL,
+                         "[openfx] rejected plugin `%s`: load failed status=%d\n",
+                         plugin_id ? plugin_id : "(null)",
+                         status_code);
+        }
         return 0;
     }
 
@@ -2873,6 +2950,12 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
     mltofx_log_status_code(status_code, "kOfxActionDescribe");
 
     if (status_code != kOfxStatOK) {
+        if (diagnostics) {
+            mlt_log_info(NULL,
+                         "[openfx] rejected plugin `%s`: describe failed status=%d\n",
+                         plugin_id ? plugin_id : "(null)",
+                         status_code);
+        }
         plugin->mainEntry(kOfxActionUnload, NULL, NULL, NULL);
         return 0;
     }
@@ -2889,8 +2972,16 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
         describe_in_context_valid = 1;
     }
 
+    mltofx_log_clip_diagnostics(diagnostics, plugin_id, clips);
+
     int i = 0;
     int count = 0;
+
+    mltofx_log_property_diagnostics(diagnostics,
+                                    plugin_id,
+                                    props,
+                                    kOfxImageEffectPropSupportedContexts,
+                                    "supported_context");
 
     propGetDimension((OfxPropertySetHandle) props, kOfxImageEffectPropSupportedContexts, &count);
     for (i = 0; i < count; i++) {
@@ -2904,10 +2995,21 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
         }
     }
     if (i == count) {
+        if (diagnostics) {
+            mlt_log_info(NULL,
+                         "[openfx] rejected plugin `%s`: missing filter context\n",
+                         plugin_id ? plugin_id : "(null)");
+        }
         mlt_log_debug(NULL, "[openfx] Plugin not a filter: %s\n", plugin->pluginIdentifier);
         // since plugin is not filter then load fail so we must not unload it
         return 0;
     }
+
+    mltofx_log_property_diagnostics(diagnostics,
+                                    plugin_id,
+                                    props,
+                                    kOfxImageEffectPropSupportedPixelDepths,
+                                    "supported_pixel_depth");
 
     count = 0;
 
@@ -2924,6 +3026,11 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
         }
     }
     if (i == count) {
+        if (diagnostics) {
+            mlt_log_info(NULL,
+                         "[openfx] rejected plugin `%s`: no supported pixel depth\n",
+                         plugin_id ? plugin_id : "(null)");
+        }
         mlt_log_verbose(NULL,
                         "[openfx] Plugin does not support byte, short, half, or float pixels: %s\n",
                         plugin->pluginIdentifier);
@@ -2931,8 +3038,18 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
         return 0;
     }
 
-    if (describe_in_context_valid)
+    if (describe_in_context_valid) {
+        if (diagnostics) {
+            mlt_log_info(NULL, "[openfx] accepted plugin `%s`\n", plugin_id ? plugin_id : "(null)");
+        }
         return 1;
+    }
+
+    if (diagnostics) {
+        mlt_log_info(NULL,
+                     "[openfx] rejected plugin `%s`: missing host feature in describeInContext\n",
+                     plugin_id ? plugin_id : "(null)");
+    }
 
     plugin->mainEntry(kOfxActionUnload, NULL, NULL, NULL);
     mlt_properties_close(image_effect);

--- a/src/modules/openfx/mlt_openfx.c
+++ b/src/modules/openfx/mlt_openfx.c
@@ -2905,6 +2905,7 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
 {
     const char *plugin_id = plugin ? plugin->pluginIdentifier : NULL;
     int diagnostics = mltofx_discovery_diagnostics_enabled(plugin_id);
+    int result = 0;
 
     mlt_properties image_effect = mlt_properties_new();
     mlt_properties clips = mlt_properties_new();
@@ -2936,7 +2937,7 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
                          plugin_id ? plugin_id : "(null)",
                          status_code);
         }
-        return 0;
+        goto cleanup;
     }
 
     status_code
@@ -2951,7 +2952,7 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
                          status_code);
         }
         plugin->mainEntry(kOfxActionUnload, NULL, NULL, NULL);
-        return 0;
+        goto cleanup;
     }
 
     status_code = plugin->mainEntry(kOfxImageEffectActionDescribeInContext,
@@ -2996,7 +2997,7 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
         }
         mlt_log_debug(NULL, "[openfx] Plugin not a filter: %s\n", plugin->pluginIdentifier);
         // since plugin is not filter then load fail so we must not unload it
-        return 0;
+        goto cleanup;
     }
 
     mltofx_log_property_diagnostics(diagnostics,
@@ -3029,14 +3030,15 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
                         "[openfx] Plugin does not support byte, short, half, or float pixels: %s\n",
                         plugin->pluginIdentifier);
         // since no pixel depth is supported by us then plugin is load fail so we must not unload it
-        return 0;
+        goto cleanup;
     }
 
     if (describe_in_context_valid) {
         if (diagnostics) {
             mlt_log_info(NULL, "[openfx] accepted plugin `%s`\n", plugin_id ? plugin_id : "(null)");
         }
-        return 1;
+        result = 1;
+        goto cleanup;
     }
 
     if (diagnostics) {
@@ -3046,12 +3048,13 @@ int mltofx_detect_plugin(OfxPlugin *plugin)
     }
 
     plugin->mainEntry(kOfxActionUnload, NULL, NULL, NULL);
+cleanup:
     mlt_properties_close(image_effect);
     mlt_properties_close(clips);
     mlt_properties_close(iparams);
     mlt_properties_close(props);
     mlt_properties_close(params);
-    return 0;
+    return result;
 }
 
 static int param_type_is_supported(const char *type)

--- a/src/modules/openfx/mlt_openfx.h
+++ b/src/modules/openfx/mlt_openfx.h
@@ -59,6 +59,30 @@ typedef enum {
     mltofx_components_rgba = 2,
 } mltofx_components_mask;
 
+// Set to 1 to print OpenFX discovery diagnostics during repository initialization.
+#ifndef MLTOFX_DISCOVERY_DIAGNOSTICS
+#define MLTOFX_DISCOVERY_DIAGNOSTICS 0
+#endif
+
+// Optional plugin identifier substring filter for diagnostics (example: "MergeDifference").
+// Set to NULL or "" to log all detected OpenFX plugins.
+#ifndef MLTOFX_DISCOVERY_DIAGNOSTICS_PLUGIN
+#define MLTOFX_DISCOVERY_DIAGNOSTICS_PLUGIN NULL
+#endif
+
+static inline int mltofx_discovery_diagnostics_enabled(const char *plugin_identifier)
+{
+#if MLTOFX_DISCOVERY_DIAGNOSTICS
+    const char *filter = MLTOFX_DISCOVERY_DIAGNOSTICS_PLUGIN;
+    if (!filter || !filter[0])
+        return 1;
+    return plugin_identifier && strstr(plugin_identifier, filter);
+#else
+    (void) plugin_identifier;
+    return 0;
+#endif
+}
+
 void mltofx_init_host_properties(OfxPropertySetHandle host_properties);
 
 void mltofx_create_instance(OfxPlugin *plugin, mlt_properties image_effect);


### PR DESCRIPTION
This PR does not change the number of openfx filters that are available. It just skips registering a filter if it is a duplicate. It also adds some diagnostics that are useful when debugging plugin detection and capabilities.