### PR TITLE
Fix handling of alpha when using luma file

### DIFF
--- a/src/modules/core/transition_luma.c
+++ b/src/modules/core/transition_luma.c
@@ -418,20 +418,25 @@ static void luma_composite_yuv422(mlt_frame a_frame,
                 while (j--) {
                     float weight = l[x_offset >> 16] / 65535.f;
                     float value = smoothstep_float(weight, softness + weight, field_pos[field]);
+                    mix_a = calculate_mix(1.0f - value, alpha_dest ? *alpha_dest : 255);
                     mix_b = calculate_mix(value, alpha_src ? *alpha_src : 255);
-                    if (alpha_over) {
-                        // Alpha over-blending, source alpha will be passed to dest
-                        mix_a = calculate_mix(1.0f - value, alpha_dest ? *alpha_dest : 255);
-                        if (invert && alpha_src) {
-                            float mix2 = mix_b + mix_a;
+                    if (invert && alpha_src) {
+                        float mix2 = mix_b + mix_a;
+                        if (alpha_over) {
                             *alpha_src = 255 * mix2;
                             if (mix2 != 0.f)
                                 mix_b /= mix2;
-                        } else if (!invert && alpha_dest) {
-                            float mix2 = mix_b + mix_a;
+                        } else {
+                            *alpha_src = CLAMP(*alpha_src + 255 * mix_b, 0, 255);
+                        }
+                    } else if (!invert && alpha_dest) {
+                        float mix2 = mix_b + mix_a;
+                        if (alpha_over) {
                             *alpha_dest = 255 * mix2;
                             if (mix2 != 0.f)
                                 mix_b /= mix2;
+                        } else {
+                            *alpha_dest = CLAMP(*alpha_dest + 255 * mix_b, 0, 255);
                         }
                     }
                     *q = sample_mix(*q, *p++, mix_b);
@@ -540,20 +545,24 @@ static int luma_composite_rgba32(mlt_frame a_frame,
                 while (j--) {
                     float weight = l[x_offset >> 16] / 65535.f;
                     float value = smoothstep_float(weight, softness + weight, field_pos[field]);
+                    mix_a = calculate_mix(1.0f - value, q[3]);
                     mix_b = calculate_mix(value, p[3]);
-                    if (alpha_over) {
-                        // Alpha over-blending, source alpha will be passed to dest
-                        mix_a = calculate_mix(1.0f - value, q[3]);
-                        if (invert) {
-                            float mix2 = mix_b + mix_a;
+                    float mix2 = mix_b + mix_a;
+                    if (invert) {
+                        if (alpha_over) {
                             q[3] = 255 * mix2;
                             if (mix2 != 0.f)
                                 mix_b /= mix2;
                         } else {
-                            float mix2 = mix_b + mix_a;
+                            q[3] = CLAMP(q[3] + 255 * mix_b, 0, 255);
+                        }
+                    } else {
+                        if (alpha_over) {
                             q[3] = 255 * mix2;
                             if (mix2 != 0.f)
                                 mix_b /= mix2;
+                        } else {
+                            q[3] = CLAMP(q[3] + 255 * mix_b, 0, 255);
                         }
                     }
                     q[0] = sample_mix(q[0], p[0], mix_b);
@@ -661,20 +670,24 @@ static int luma_composite_rgba64(mlt_frame a_frame,
                 while (j--) {
                     float weight = l[x_offset >> 16] / 65535.f;
                     float value = smoothstep_float(weight, softness + weight, field_pos[field]);
+                    mix_a = calculate_mix_16(1.0f - value, q[3]);
                     mix_b = calculate_mix_16(value, p[3]);
-                    if (alpha_over) {
-                        // Alpha over-blending, source alpha will be passed to dest
-                        mix_a = calculate_mix_16(1.0f - value, q[3]);
-                        if (invert) {
-                            float mix2 = mix_b + mix_a;
+                    float mix2 = mix_b + mix_a;
+                    if (invert) {
+                        if (alpha_over) {
                             q[3] = 65535 * mix2;
                             if (mix2 != 0.f)
                                 mix_b /= mix2;
                         } else {
-                            float mix2 = mix_b + mix_a;
+                            q[3] = CLAMP(q[3] + 65535 * mix_b, 0, 65535);
+                        }
+                    } else {
+                        if (alpha_over) {
                             q[3] = 65535 * mix2;
                             if (mix2 != 0.f)
                                 mix_b /= mix2;
+                        } else {
+                            q[3] = CLAMP(q[3] + 65535 * mix_b, 0, 65535);
                         }
                     }
                     q[0] = sample_mix_16(q[0], p[0], mix_b);

--- a/src/modules/core/transition_luma.c
+++ b/src/modules/core/transition_luma.c
@@ -336,7 +336,8 @@ static void luma_composite_yuv422(mlt_frame a_frame,
                                   int *width,
                                   int *height,
                                   int invert,
-                                  int fix_background_alpha)
+                                  int fix_background_alpha,
+                                  int alpha_over)
 {
     int width_src = *width, height_src = *height;
     int width_dest = *width, height_dest = *height;
@@ -417,18 +418,21 @@ static void luma_composite_yuv422(mlt_frame a_frame,
                 while (j--) {
                     float weight = l[x_offset >> 16] / 65535.f;
                     float value = smoothstep_float(weight, softness + weight, field_pos[field]);
-                    mix_a = calculate_mix(1.0f - value, alpha_dest ? *alpha_dest : 255);
                     mix_b = calculate_mix(value, alpha_src ? *alpha_src : 255);
-                    if (invert && alpha_src) {
-                        float mix2 = mix_b + mix_a;
-                        *alpha_src = 255 * mix2;
-                        if (mix2 != 0.f)
-                            mix_b /= mix2;
-                    } else if (!invert && alpha_dest) {
-                        float mix2 = mix_b + mix_a;
-                        *alpha_dest = 255 * mix2;
-                        if (mix2 != 0.f)
-                            mix_b /= mix2;
+                    if (alpha_over) {
+                        // Alpha over-blending, source alpha will be passed to dest
+                        mix_a = calculate_mix(1.0f - value, alpha_dest ? *alpha_dest : 255);
+                        if (invert && alpha_src) {
+                            float mix2 = mix_b + mix_a;
+                            *alpha_src = 255 * mix2;
+                            if (mix2 != 0.f)
+                                mix_b /= mix2;
+                        } else if (!invert && alpha_dest) {
+                            float mix2 = mix_b + mix_a;
+                            *alpha_dest = 255 * mix2;
+                            if (mix2 != 0.f)
+                                mix_b /= mix2;
+                        }
                     }
                     *q = sample_mix(*q, *p++, mix_b);
                     q++;
@@ -474,7 +478,8 @@ static int luma_composite_rgba32(mlt_frame a_frame,
                                  int field_order,
                                  int width,
                                  int height,
-                                 int invert)
+                                 int invert,
+                                 int alpha_over)
 {
     if (mlt_properties_get(&a_frame->parent, "distort"))
         mlt_properties_set(&b_frame->parent,
@@ -535,18 +540,21 @@ static int luma_composite_rgba32(mlt_frame a_frame,
                 while (j--) {
                     float weight = l[x_offset >> 16] / 65535.f;
                     float value = smoothstep_float(weight, softness + weight, field_pos[field]);
-                    mix_a = calculate_mix(1.0f - value, q[3]);
                     mix_b = calculate_mix(value, p[3]);
-                    if (invert) {
-                        float mix2 = mix_b + mix_a;
-                        q[3] = 255 * mix2;
-                        if (mix2 != 0.f)
-                            mix_b /= mix2;
-                    } else {
-                        float mix2 = mix_b + mix_a;
-                        q[3] = 255 * mix2;
-                        if (mix2 != 0.f)
-                            mix_b /= mix2;
+                    if (alpha_over) {
+                        // Alpha over-blending, source alpha will be passed to dest
+                        mix_a = calculate_mix(1.0f - value, q[3]);
+                        if (invert) {
+                            float mix2 = mix_b + mix_a;
+                            q[3] = 255 * mix2;
+                            if (mix2 != 0.f)
+                                mix_b /= mix2;
+                        } else {
+                            float mix2 = mix_b + mix_a;
+                            q[3] = 255 * mix2;
+                            if (mix2 != 0.f)
+                                mix_b /= mix2;
+                        }
                     }
                     q[0] = sample_mix(q[0], p[0], mix_b);
                     q[1] = sample_mix(q[1], p[1], mix_b);
@@ -591,7 +599,8 @@ static int luma_composite_rgba64(mlt_frame a_frame,
                                  int field_order,
                                  int width,
                                  int height,
-                                 int invert)
+                                 int invert,
+                                 int alpha_over)
 {
     if (mlt_properties_get(&a_frame->parent, "distort"))
         mlt_properties_set(&b_frame->parent,
@@ -652,18 +661,21 @@ static int luma_composite_rgba64(mlt_frame a_frame,
                 while (j--) {
                     float weight = l[x_offset >> 16] / 65535.f;
                     float value = smoothstep_float(weight, softness + weight, field_pos[field]);
-                    mix_a = calculate_mix_16(1.0f - value, q[3]);
                     mix_b = calculate_mix_16(value, p[3]);
-                    if (invert) {
-                        float mix2 = mix_b + mix_a;
-                        q[3] = 65535 * mix2;
-                        if (mix2 != 0.f)
-                            mix_b /= mix2;
-                    } else {
-                        float mix2 = mix_b + mix_a;
-                        q[3] = 65535 * mix2;
-                        if (mix2 != 0.f)
-                            mix_b /= mix2;
+                    if (alpha_over) {
+                        // Alpha over-blending, source alpha will be passed to dest
+                        mix_a = calculate_mix_16(1.0f - value, q[3]);
+                        if (invert) {
+                            float mix2 = mix_b + mix_a;
+                            q[3] = 65535 * mix2;
+                            if (mix2 != 0.f)
+                                mix_b /= mix2;
+                        } else {
+                            float mix2 = mix_b + mix_a;
+                            q[3] = 65535 * mix2;
+                            if (mix2 != 0.f)
+                                mix_b /= mix2;
+                        }
                     }
                     q[0] = sample_mix_16(q[0], p[0], mix_b);
                     q[1] = sample_mix_16(q[1], p[1], mix_b);
@@ -958,7 +970,8 @@ static int transition_get_image(mlt_frame a_frame,
                                         progressive ? -1 : top_field_first,
                                         *width,
                                         *height,
-                                        invert);
+                                        invert,
+                                        alpha_over);
         } else if (*format == mlt_image_rgba64) {
             ret = luma_composite_rgba64(!invert ? a_frame : b_frame,
                                         !invert ? b_frame : a_frame,
@@ -971,7 +984,8 @@ static int transition_get_image(mlt_frame a_frame,
                                         progressive ? -1 : top_field_first,
                                         *width,
                                         *height,
-                                        invert);
+                                        invert,
+                                        alpha_over);
         } else {
             *format = mlt_image_yuv422;
             luma_composite_yuv422(!invert ? a_frame : b_frame,
@@ -986,7 +1000,8 @@ static int transition_get_image(mlt_frame a_frame,
                                   width,
                                   height,
                                   invert,
-                                  fix_background_alpha);
+                                  fix_background_alpha,
+                                  alpha_over);
         }
     } else {
         if (mlt_properties_get(&a_frame->parent, "distort"))


### PR DESCRIPTION
Currently, the luma transition behaves differently when using a luma file or not on images with an alpha channel. When a luma file is used, it always behaves as if alpha_over was enabled. Here are some screenshot comparing a transition between 2 images of triangles with a transparent background. Each image below contains 4 different cases: 

- top left, normal dissolve with alpha_over disabled
 - top right, normal dissolve with alpha_over enabled
- bottom left, luma file "Vertical bar" with alpha_over disabled
 - bottom right, luma file "Vertical bar" with alpha_over enabled

Frame 0: only first image is visible (red triangle in top right corner):

<img width="1920" height="1080" alt="master-frame-000" src="https://github.com/user-attachments/assets/c3f481c1-0c04-4953-bd82-3147ae70bd73" />

Last frame of the transition, you can see the behavior difference when a luma is used or not (bottom left should be similar to top left):

<img width="1920" height="1080" alt="master-frame-124" src="https://github.com/user-attachments/assets/8c8424cd-ecb9-4cae-8aa4-fe4c91e44169" />


With the changes in this merge request, the result is now as expected:

<img width="1920" height="1080" alt="fixed-frame-124" src="https://github.com/user-attachments/assets/90d2ed05-5739-4dc6-b007-91f963de9112" />


The only question is do we want to maintain backwards compatibility, and how ?
Feedback is welcome.
