### PR TITLE
Fix motion tracker shapes not properly clipping out of frame

### DIFF
--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -468,18 +468,19 @@ static int filter_get_image(mlt_frame frame,
     }
 
     if (blur > 0 && data->boundingBox.width > 1 && data->boundingBox.height > 1) {
+        cv::Mat roi = cvFrame(data->boundingBox);
+        cv::Mat blurredRoi;
+        roi.copyTo(blurredRoi);
+        bool do_blur = true;
+
         switch (mlt_properties_get_int(filter_properties, "blur_type")) {
         case 1:
             // Gaussian Blur
-            cv::GaussianBlur(cvFrame(data->boundingBox),
-                             cvFrame(data->boundingBox),
-                             cv::Size(0, 0),
-                             blur);
+            cv::GaussianBlur(roi, blurredRoi, cv::Size(0, 0), blur);
             break;
         case 2:
             // Pixelate
             {
-                cv::Mat roi = cvFrame(data->boundingBox);
                 cv::Mat res;
                 cv::resize(roi,
                            res,
@@ -487,17 +488,17 @@ static int filter_get_image(mlt_frame frame,
                                     MAX(2, data->boundingBox.height / blur)),
                            cv::INTER_NEAREST);
                 cv::resize(res,
-                           roi,
+                           blurredRoi,
                            cv::Size(data->boundingBox.width, data->boundingBox.height),
                            0,
                            0,
                            cv::INTER_NEAREST);
-                cvFrame(data->boundingBox) = roi;
             }
             break;
         case 3:
             // Opaque fill, handled in shape_width option
             shape_width = -1;
+            do_blur = false;
             break;
         case 0:
             // Median Blur
@@ -506,11 +507,31 @@ static int filter_get_image(mlt_frame frame,
                 // median blur param must be odd and, minimum 3
                 ++blur;
             }
-            cv::medianBlur(cvFrame(data->boundingBox), cvFrame(data->boundingBox), blur);
+            cv::medianBlur(roi, blurredRoi, blur);
             break;
         default:
-            // Do nothing
+            do_blur = false;
             break;
+        }
+
+        if (do_blur) {
+            switch (mlt_properties_get_int(filter_properties, "shape")) {
+            case 1:
+                // Ellipse
+                {
+                    cv::Mat mask = cv::Mat::zeros(roi.size(), CV_8UC1);
+                    cv::RotatedRect bounding = cv::RotatedRect(cv::Point2f(data->boundingBox.width / 2.0f,
+                                                                           data->boundingBox.height / 2.0f),
+                                                               cv::Size2f(data->boundingBox.width, data->boundingBox.height),
+                                                               0);
+                    cv::ellipse(mask, bounding, cv::Scalar(255), -1, 1);
+                    blurredRoi.copyTo(roi, mask);
+                }
+                break;
+            default:
+                blurredRoi.copyTo(roi);
+                break;
+            }
         }
     }
 

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -446,37 +446,8 @@ static int filter_get_image(mlt_frame frame,
                 data->producer_in + data->producer_length);
     }
 
-    if (blur > 0 && 
-        data->boundingBox.width > 1 && 
-        data->boundingBox.height > 1 &&
-        data->boundingBox.x > - data->boundingBox.width && 
-        data->boundingBox.x < *width &&
-        data->boundingBox.y > - data->boundingBox.height && 
-        data->boundingBox.y < *height) {
-        // ensure bounding box is within the frame boundaries or OpenCV will crash
-        // this only affects the blurring functions, drawn shapes are handled properly
-        cv::Rect clippedBox = data->boundingBox;
-        if (clippedBox.x > *width) {
-            clippedBox.x = *width;
-            clippedBox.width = 0;
-        } else if (clippedBox.x < 0) {
-            clippedBox.width = MAX(0, clippedBox.width + clippedBox.x);
-            clippedBox.x = 0;
-        }
-        if (clippedBox.y > *height) {
-            clippedBox.y = *height;
-            clippedBox.height = 0;
-        } else if (clippedBox.y < 0) {
-            clippedBox.height = MAX(0, clippedBox.height + clippedBox.y);
-            clippedBox.y = 0;
-        }
-        if (clippedBox.x + clippedBox.width > *width) {
-            clippedBox.width = *width - clippedBox.x;
-        }
-        if (clippedBox.y + clippedBox.height > *height) {
-            clippedBox.height = *height - clippedBox.y;
-        }
-
+    cv::Rect clippedBox = data->boundingBox & cv::Rect(0, 0, *width, *height);
+    if (blur > 0 && clippedBox.width > 1 && clippedBox.height > 1) {
         cv::Mat roi = cvFrame(clippedBox);
         cv::Mat blurredRoi;
         bool do_blur = true;
@@ -528,8 +499,8 @@ static int filter_get_image(mlt_frame frame,
                 // Ellipse
                 {
                     cv::Mat mask = cv::Mat::zeros(roi.size(), CV_8UC1);
-                    cv::RotatedRect bounding = cv::RotatedRect(cv::Point2f(data->boundingBox.x < 0 ? data->boundingBox.width / 2.0f + data->boundingBox.x : data->boundingBox.width / 2.0f,
-                                                                           data->boundingBox.y < 0 ? data->boundingBox.height / 2.0f + data->boundingBox.y : data->boundingBox.height / 2.0f),
+                    cv::RotatedRect bounding = cv::RotatedRect(cv::Point2f(data->boundingBox.x + data->boundingBox.width / 2.0f - clippedBox.x,
+                                                                            data->boundingBox.y + data->boundingBox.height / 2.0f - clippedBox.y),
                                                                cv::Size2f(data->boundingBox.width, data->boundingBox.height),
                                                                0);
                     cv::ellipse(mask, bounding, cv::Scalar(255), -1, cv::LINE_4);

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -470,7 +470,6 @@ static int filter_get_image(mlt_frame frame,
     if (blur > 0 && data->boundingBox.width > 1 && data->boundingBox.height > 1) {
         cv::Mat roi = cvFrame(data->boundingBox);
         cv::Mat blurredRoi;
-        roi.copyTo(blurredRoi);
         bool do_blur = true;
 
         switch (mlt_properties_get_int(filter_properties, "blur_type")) {
@@ -524,7 +523,7 @@ static int filter_get_image(mlt_frame frame,
                                                                            data->boundingBox.height / 2.0f),
                                                                cv::Size2f(data->boundingBox.width, data->boundingBox.height),
                                                                0);
-                    cv::ellipse(mask, bounding, cv::Scalar(255), -1, 1);
+                    cv::ellipse(mask, bounding, cv::Scalar(255), -1, cv::LINE_4);
                     blurredRoi.copyTo(roi, mask);
                 }
                 break;

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -446,7 +446,11 @@ static int filter_get_image(mlt_frame frame,
                 data->producer_in + data->producer_length);
     }
 
-    if (blur > 0 && data->boundingBox.width > 1 && data->boundingBox.height > 1) {
+    if (blur > 0 && 
+        data->boundingBox.width > 1 && 
+        data->boundingBox.height > 1 &&
+        data->boundingBox.x > - data->boundingBox.width && data->boundingBox.x < *width &&
+        data->boundingBox.y > - data->boundingBox.height && data->boundingBox.y < *height) {
         // ensure bounding box is within the frame boundaries or OpenCV will crash
         // this only affects the blurring functions, drawn shapes are handled properly
         cv::Rect clippedBox = data->boundingBox;

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -445,30 +445,33 @@ static int filter_get_image(mlt_frame frame,
                 position,
                 data->producer_in + data->producer_length);
     }
-    // ensure bounding box is within the frame boundaries or OpenCV will crash
-    if (data->boundingBox.x > *width) {
-        data->boundingBox.x = *width;
-        data->boundingBox.width = 0;
-    } else if (data->boundingBox.x < 0) {
-        data->boundingBox.width = MAX(0, data->boundingBox.width + data->boundingBox.x);
-        data->boundingBox.x = 0;
-    }
-    if (data->boundingBox.y > *height) {
-        data->boundingBox.y = *height;
-        data->boundingBox.height = 0;
-    } else if (data->boundingBox.y < 0) {
-        data->boundingBox.height = MAX(0, data->boundingBox.height + data->boundingBox.y);
-        data->boundingBox.y = 0;
-    }
-    if (data->boundingBox.x + data->boundingBox.width > *width) {
-        data->boundingBox.width = *width - data->boundingBox.x;
-    }
-    if (data->boundingBox.y + data->boundingBox.height > *height) {
-        data->boundingBox.height = *height - data->boundingBox.y;
-    }
 
     if (blur > 0 && data->boundingBox.width > 1 && data->boundingBox.height > 1) {
-        cv::Mat roi = cvFrame(data->boundingBox);
+        // ensure bounding box is within the frame boundaries or OpenCV will crash
+        // this only affects the blurring functions, drawn shapes are handled properly
+        cv::Rect clippedBox = data->boundingBox;
+        if (clippedBox.x > *width) {
+            clippedBox.x = *width;
+            clippedBox.width = 0;
+        } else if (clippedBox.x < 0) {
+            clippedBox.width = MAX(0, clippedBox.width + clippedBox.x);
+            clippedBox.x = 0;
+        }
+        if (clippedBox.y > *height) {
+            clippedBox.y = *height;
+            clippedBox.height = 0;
+        } else if (clippedBox.y < 0) {
+            clippedBox.height = MAX(0, clippedBox.height + clippedBox.y);
+            clippedBox.y = 0;
+        }
+        if (clippedBox.x + clippedBox.width > *width) {
+            clippedBox.width = *width - clippedBox.x;
+        }
+        if (clippedBox.y + clippedBox.height > *height) {
+            clippedBox.height = *height - clippedBox.y;
+        }
+
+        cv::Mat roi = cvFrame(clippedBox);
         cv::Mat blurredRoi;
         bool do_blur = true;
 
@@ -519,8 +522,8 @@ static int filter_get_image(mlt_frame frame,
                 // Ellipse
                 {
                     cv::Mat mask = cv::Mat::zeros(roi.size(), CV_8UC1);
-                    cv::RotatedRect bounding = cv::RotatedRect(cv::Point2f(data->boundingBox.width / 2.0f,
-                                                                           data->boundingBox.height / 2.0f),
+                    cv::RotatedRect bounding = cv::RotatedRect(cv::Point2f(data->boundingBox.x < 0 ? data->boundingBox.width / 2.0f + data->boundingBox.x : data->boundingBox.width / 2.0f,
+                                                                           data->boundingBox.y < 0 ? data->boundingBox.height / 2.0f + data->boundingBox.y : data->boundingBox.height / 2.0f),
                                                                cv::Size2f(data->boundingBox.width, data->boundingBox.height),
                                                                0);
                     cv::ellipse(mask, bounding, cv::Scalar(255), -1, cv::LINE_4);

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -465,6 +465,8 @@ static int filter_get_image(mlt_frame frame,
                            res,
                            cv::Size(MAX(2, clippedBox.width / blur),
                                     MAX(2, clippedBox.height / blur)),
+                           0,
+                           0,
                            cv::INTER_NEAREST);
                 cv::resize(res,
                            blurredRoi,

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -566,7 +566,7 @@ static int filter_get_image(mlt_frame frame,
                             bounding,
                             cv::Scalar(shape_color.r, shape_color.g, shape_color.b),
                             shape_width,
-                            1);
+                            cv::LINE_4);
             }
             break;
         case 0:

--- a/src/modules/opencv/filter_opencv_tracker.cpp
+++ b/src/modules/opencv/filter_opencv_tracker.cpp
@@ -449,8 +449,10 @@ static int filter_get_image(mlt_frame frame,
     if (blur > 0 && 
         data->boundingBox.width > 1 && 
         data->boundingBox.height > 1 &&
-        data->boundingBox.x > - data->boundingBox.width && data->boundingBox.x < *width &&
-        data->boundingBox.y > - data->boundingBox.height && data->boundingBox.y < *height) {
+        data->boundingBox.x > - data->boundingBox.width && 
+        data->boundingBox.x < *width &&
+        data->boundingBox.y > - data->boundingBox.height && 
+        data->boundingBox.y < *height) {
         // ensure bounding box is within the frame boundaries or OpenCV will crash
         // this only affects the blurring functions, drawn shapes are handled properly
         cv::Rect clippedBox = data->boundingBox;
@@ -490,12 +492,12 @@ static int filter_get_image(mlt_frame frame,
                 cv::Mat res;
                 cv::resize(roi,
                            res,
-                           cv::Size(MAX(2, data->boundingBox.width / blur),
-                                    MAX(2, data->boundingBox.height / blur)),
+                           cv::Size(MAX(2, clippedBox.width / blur),
+                                    MAX(2, clippedBox.height / blur)),
                            cv::INTER_NEAREST);
                 cv::resize(res,
                            blurredRoi,
-                           cv::Size(data->boundingBox.width, data->boundingBox.height),
+                           cv::Size(clippedBox.width, clippedBox.height),
                            0,
                            0,
                            cv::INTER_NEAREST);


### PR DESCRIPTION
This PR includes the changes in https://github.com/mltframework/mlt/pull/1275

Previously, we would bound the bounding box center from 0 to height/width since opencv was crashing. This meant that shapes would draw weirdly at boundaries. The crash only came from the blur, as drawing shapes out of bounds works fine as expected, so this moves the bounding logic to the blur only.

Before:
<img width="381" height="361" alt="Screenshot 2026-07-29 182806" src="https://github.com/user-attachments/assets/a400ef97-409f-422d-b37e-93ac277a0c81" />

After:
<img width="252" height="227" alt="Screenshot 2026-08-03 171554" src="https://github.com/user-attachments/assets/725fcba0-1fd6-403d-818d-968a0adf517c" />
