### PR TITLE
Change default audio format to float32 (#1284)

### DIFF
--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -697,3 +697,8 @@ MLT_7.40.0 {
     mlt_frame_next_convert_image;
     mlt_frame_copy_convert_image;
 } MLT_7.36.0;
+
+MLT_7.42.0 {
+  global:
+    mlt_audio_format_id;
+} MLT_7.40.0;

--- a/src/framework/mlt_audio.c
+++ b/src/framework/mlt_audio.c
@@ -544,6 +544,40 @@ int64_t mlt_audio_calculate_samples_to_position(float fps, int frequency, int64_
     return samples;
 }
 
+/** Get the enum value for an audio format name.
+ *
+ * 
+ * \public \memberof mlt_audio_s
+ * \param name the short name for an audio format
+ * \param[out] format the parsed audio format enum
+ * \return 0 on success, 1 if the name is invalid
+ */
+
+int mlt_audio_format_id(const char *name, mlt_audio_format *format)
+{
+    if (!name || !format)
+        return 1;
+
+    if (!strcmp(name, "none"))
+        *format = mlt_audio_none;
+    else if (!strcmp(name, "s16"))
+        *format = mlt_audio_s16;
+    else if (!strcmp(name, "s32"))
+        *format = mlt_audio_s32;
+    else if (!strcmp(name, "s32le"))
+        *format = mlt_audio_s32le;
+    else if (!strcmp(name, "float"))
+        *format = mlt_audio_float;
+    else if (!strcmp(name, "f32le"))
+        *format = mlt_audio_f32le;
+    else if (!strcmp(name, "u8"))
+        *format = mlt_audio_u8;
+    else
+        return 1;
+
+    return 0;
+}
+
 /** Get the short name for an audio format.
  *
  * You do not need to deallocate the returned string.

--- a/src/framework/mlt_audio.h
+++ b/src/framework/mlt_audio.h
@@ -3,7 +3,7 @@
  * \brief Audio class
  * \see mlt_audio_s
  *
- * Copyright (C) 2020 Meltytech, LLC
+ * Copyright (C) 2020-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -68,6 +68,7 @@ MLT_EXPORT int mlt_audio_calculate_frame_samples(float fps, int frequency, int64
 MLT_EXPORT int64_t mlt_audio_calculate_samples_to_position(float fps,
                                                            int frequency,
                                                            int64_t position);
+MLT_EXPORT int mlt_audio_format_id(const char *name, mlt_audio_format *format);
 MLT_EXPORT const char *mlt_audio_format_name(mlt_audio_format format);
 MLT_EXPORT int mlt_audio_format_size(mlt_audio_format format, int samples, int channels);
 MLT_EXPORT const char *mlt_audio_channel_layout_name(mlt_channel_layout layout);

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -441,22 +441,8 @@ static void set_audio_format(mlt_consumer self)
     consumer_private *priv = self->local;
     mlt_properties properties = MLT_CONSUMER_PROPERTIES(self);
     const char *format = mlt_properties_get(properties, "mlt_audio_format");
-    if (format) {
-        if (!strcmp(format, "none"))
-            priv->audio_format = mlt_audio_none;
-        else if (!strcmp(format, "s16"))
-            priv->audio_format = mlt_audio_s16;
-        else if (!strcmp(format, "s32"))
-            priv->audio_format = mlt_audio_s32;
-        else if (!strcmp(format, "s32le"))
-            priv->audio_format = mlt_audio_s32le;
-        else if (!strcmp(format, "float"))
-            priv->audio_format = mlt_audio_float;
-        else if (!strcmp(format, "f32le"))
-            priv->audio_format = mlt_audio_f32le;
-        else if (!strcmp(format, "u8"))
-            priv->audio_format = mlt_audio_u8;
-    }
+    if (format)
+        mlt_audio_format_id(format, &priv->audio_format);
 }
 
 /** Set the image format to use in render threads.

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -175,7 +175,6 @@ int mlt_consumer_init(mlt_consumer self, void *child, mlt_profile profile)
         // Default to environment test card
         mlt_properties_set(properties, "test_card", mlt_environment("MLT_TEST_CARD"));
 
-        // Hmm - default all consumers to yuv422 with s16 :-/
         priv->image_format = mlt_image_yuv422;
         priv->audio_format = mlt_audio_f32le;
 

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -177,7 +177,7 @@ int mlt_consumer_init(mlt_consumer self, void *child, mlt_profile profile)
 
         // Hmm - default all consumers to yuv422 with s16 :-/
         priv->image_format = mlt_image_yuv422;
-        priv->audio_format = mlt_audio_s16;
+        priv->audio_format = mlt_audio_f32le;
 
         mlt_events_register(properties, "consumer-frame-show");
         mlt_events_register(properties, "consumer-frame-render");

--- a/src/framework/mlt_consumer.c
+++ b/src/framework/mlt_consumer.c
@@ -445,6 +445,8 @@ static void set_audio_format(mlt_consumer self)
     if (format) {
         if (!strcmp(format, "none"))
             priv->audio_format = mlt_audio_none;
+        else if (!strcmp(format, "s16"))
+            priv->audio_format = mlt_audio_s16;
         else if (!strcmp(format, "s32"))
             priv->audio_format = mlt_audio_s32;
         else if (!strcmp(format, "s32le"))

--- a/src/framework/mlt_consumer.h
+++ b/src/framework/mlt_consumer.h
@@ -82,7 +82,7 @@
  * \properties \em top_field_first when not progressive, whether interlace field order is top-field-first, defaults to 0.
  *   Set this to -1 if the consumer does not care about the field order.
  * \properties \em mlt_image_format the image format to request in rendering threads, defaults to yuv422
- * \properties \em mlt_audio_format the audio format to request in rendering threads, defaults to S16
+ * \properties \em mlt_audio_format the audio format to request in rendering threads, defaults to f32le
  * \properties \em audio_off set non-zero to disable audio processing
  * \properties \em video_off set non-zero to disable video processing
  * \properties \em drop_count the number of video frames not rendered since starting consumer

--- a/src/modules/core/consumer_multi.c
+++ b/src/modules/core/consumer_multi.c
@@ -385,7 +385,10 @@ static void foreach_consumer_put(mlt_consumer consumer, mlt_frame frame)
 
             // get the audio for the current frame
             uint8_t *buffer = NULL;
-            mlt_audio_format format = mlt_audio_s16;
+            mlt_audio_format format = mlt_audio_f32le;
+            const char *format_name = mlt_properties_get(properties, "mlt_audio_format");
+            if (format_name)
+                mlt_audio_format_id(format_name, &format);
             int channels = mlt_properties_get_int(properties, "channels");
             int frequency = mlt_properties_get_int(properties, "frequency");
             int current_samples = mlt_audio_calculate_frame_samples(self_fps, frequency, self_pos);

--- a/src/modules/core/consumer_multi.yml
+++ b/src/modules/core/consumer_multi.yml
@@ -2,7 +2,7 @@ schema_version: 7.2
 type: consumer
 identifier: multi
 title: Multiple outputs
-version: 2
+version: 3
 copyright: Copyright (C) 2011-2014 Meltytech, LLC
 license: LGPL
 language: en
@@ -30,6 +30,12 @@ notes: |
 
 audio_formats:
   - s16
+  - s32
+  - s32le
+  - float
+  - f32le
+  - u8
+
 parameters:
   - identifier: resource
     argument: yes

--- a/src/modules/rtaudio/consumer_rtaudio.cpp
+++ b/src/modules/rtaudio/consumer_rtaudio.cpp
@@ -1,6 +1,6 @@
 /*
  * consumer_rtaudio.c -- output through RtAudio audio wrapper
- * Copyright (C) 2011-2023 Meltytech, LLC
+ * Copyright (C) 2011-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -230,7 +230,7 @@ public:
         }
         if (rt->openStream(&parameters,
                            nullptr,
-                           RTAUDIO_SINT16,
+                           RTAUDIO_FLOAT32,
                            frequency,
                            &bufferFrames,
                            &rtaudio_callback,
@@ -249,7 +249,7 @@ public:
             }
             rt->openStream(&parameters,
                            nullptr,
-                           RTAUDIO_SINT16,
+                           RTAUDIO_FLOAT32,
                            frequency,
                            &bufferFrames,
                            &rtaudio_callback,
@@ -565,15 +565,15 @@ public:
         audio_avail = 0;
     }
 
-    int callback(int16_t *outbuf,
-                 int16_t *inbuf,
+    int callback(float *outbuf,
+                 float *inbuf,
                  unsigned int samples,
                  double streamTime,
                  RtAudioStreamStatus status)
     {
         mlt_properties properties = MLT_CONSUMER_PROPERTIES(getConsumer());
         double volume = mlt_properties_get_double(properties, "volume");
-        int len = mlt_audio_format_size(mlt_audio_s16, samples, out_channels);
+        int len = mlt_audio_format_size(mlt_audio_f32le, samples, out_channels);
 
         pthread_mutex_lock(&audio_mutex);
 
@@ -602,7 +602,7 @@ public:
         }
 
         if (volume != 1.0) {
-            int16_t *p = outbuf;
+            float *p = outbuf;
             int i = samples * out_channels + 1;
             while (--i)
                 *p++ *= volume;
@@ -621,7 +621,7 @@ public:
     {
         // Get the properties of this consumer
         mlt_properties properties = MLT_CONSUMER_PROPERTIES(getConsumer());
-        mlt_audio_format afmt = mlt_audio_s16;
+        mlt_audio_format afmt = mlt_audio_f32le;
 
         // Set the preferred params of the test card signal
         int channels = mlt_properties_get_int(properties, "channels");
@@ -631,7 +631,7 @@ public:
         int samples = mlt_audio_calculate_frame_samples(mlt_properties_get_double(properties, "fps"),
                                                         frequency,
                                                         counter++);
-        int16_t *pcm;
+        float *pcm;
 
         mlt_frame_get_audio(frame, (void **) &pcm, &afmt, &frequency, &channels, &samples);
         *duration = 1000000LL * samples / frequency;
@@ -678,7 +678,7 @@ public:
                             memcpy(&audio_buffer[audio_avail], pcm, dst_bytes);
                             pcm += samples_to_copy * channels;
                         } else {
-                            int16_t *dest = (int16_t *) &audio_buffer[audio_avail];
+                            float *dest = (float *) &audio_buffer[audio_avail];
                             int i = samples_to_copy + 1;
                             while (--i) {
                                 memcpy(dest, pcm, dst_stride);
@@ -817,8 +817,8 @@ static int rtaudio_callback(void *outputBuffer,
                             void *userData)
 {
     RtAudioConsumer *rtaudio = (RtAudioConsumer *) userData;
-    return rtaudio->callback((int16_t *) outputBuffer,
-                             (int16_t *) inputBuffer,
+    return rtaudio->callback((float *) outputBuffer,
+                             (float *) inputBuffer,
                              nFrames,
                              streamTime,
                              status);

--- a/src/modules/rtaudio/consumer_rtaudio.cpp
+++ b/src/modules/rtaudio/consumer_rtaudio.cpp
@@ -36,6 +36,8 @@
 #define RTAUDIO_VERSION_6
 #endif
 
+#define RTAUDIO_AUDIO_BUFFER_MIN_BYTES (2048 * 2 * (int) sizeof(float) * 2)
+
 static void consumer_refresh_cb(mlt_consumer sdl, mlt_consumer consumer, mlt_event_data);
 static int rtaudio_callback(void *outputBuffer,
                             void *inputBuffer,
@@ -86,7 +88,8 @@ public:
     int joined;
     int running;
     int out_channels;
-    uint8_t audio_buffer[4096 * 10];
+    uint8_t *audio_buffer;
+    int audio_buffer_size;
     int audio_avail;
     pthread_mutex_t audio_mutex;
     pthread_cond_t audio_cond;
@@ -106,6 +109,8 @@ public:
         , queue(nullptr)
         , joined(0)
         , running(0)
+        , audio_buffer(nullptr)
+        , audio_buffer_size(0)
         , audio_avail(0)
         , playing(0)
         , refresh_count(0)
@@ -116,6 +121,8 @@ public:
 
     ~RtAudioConsumer()
     {
+        free(audio_buffer);
+
         // Close the queue
         mlt_deque_close(queue);
 
@@ -131,6 +138,20 @@ public:
             rt->closeStream();
         delete rt;
         rt = nullptr;
+    }
+
+    bool ensure_audio_buffer_capacity(int minimum)
+    {
+        if (audio_buffer_size >= minimum)
+            return true;
+
+        auto new_buffer = (uint8_t *) realloc(audio_buffer, minimum);
+        if (!new_buffer)
+            return false;
+
+        audio_buffer = new_buffer;
+        audio_buffer_size = minimum;
+        return true;
     }
 
     bool create_rtaudio(RtAudio::Api api, int channels, int frequency)
@@ -235,8 +256,23 @@ public:
                            &bufferFrames,
                            &rtaudio_callback,
                            this,
-                           &options)
-            || rt->startStream()) {
+                           &options)) {
+            mlt_log_info(getConsumer(), "%s\n", rt->getErrorText().c_str());
+            delete rt;
+            rt = nullptr;
+            return false;
+        }
+        {
+            int audio_queue_size = mlt_audio_format_size(mlt_audio_f32le, bufferFrames, channels);
+            if (audio_queue_size < RTAUDIO_AUDIO_BUFFER_MIN_BYTES)
+                audio_queue_size = RTAUDIO_AUDIO_BUFFER_MIN_BYTES;
+            if (!ensure_audio_buffer_capacity(audio_queue_size)) {
+                delete rt;
+                rt = nullptr;
+                return false;
+            }
+        }
+        if (rt->startStream()) {
             mlt_log_info(getConsumer(), "%s\n", rt->getErrorText().c_str());
             delete rt;
             rt = nullptr;
@@ -255,6 +291,18 @@ public:
                            &rtaudio_callback,
                            this,
                            &options);
+            {
+                int audio_queue_size = mlt_audio_format_size(mlt_audio_f32le,
+                                                             bufferFrames,
+                                                             channels);
+                if (audio_queue_size < RTAUDIO_AUDIO_BUFFER_MIN_BYTES)
+                    audio_queue_size = RTAUDIO_AUDIO_BUFFER_MIN_BYTES;
+                if (!ensure_audio_buffer_capacity(audio_queue_size)) {
+                    delete rt;
+                    rt = nullptr;
+                    return false;
+                }
+            }
             rt->startStream();
         }
 #ifdef RTERROR_H
@@ -660,11 +708,11 @@ public:
             pthread_mutex_lock(&audio_mutex);
 
             while (running && samples_copied < samples) {
-                int sample_space = (sizeof(audio_buffer) - audio_avail) / dst_stride;
+                int sample_space = (audio_buffer_size - audio_avail) / dst_stride;
 
                 while (running && sample_space == 0) {
                     pthread_cond_wait(&audio_cond, &audio_mutex);
-                    sample_space = (sizeof(audio_buffer) - audio_avail) / dst_stride;
+                    sample_space = (audio_buffer_size - audio_avail) / dst_stride;
                 }
                 if (running) {
                     int samples_to_copy = samples - samples_copied;

--- a/src/modules/rtaudio/consumer_rtaudio.yml
+++ b/src/modules/rtaudio/consumer_rtaudio.yml
@@ -6,7 +6,7 @@ description: >
   RtAudio provides native, realtime audio output across Linux,
   Macintosh OS X, Windows, and some BSD operating systems.
 url: http://www.music.mcgill.ca/~gary/rtaudio/
-version: 3
+version: 4
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 creator: Gary P. Scavone
@@ -15,7 +15,7 @@ language: en
 tags:
   - Audio
 audio_formats:
-  - s16
+  - f32le
 parameters:
   - identifier: resource
     title: Device

--- a/src/modules/sdl2/common.c
+++ b/src/modules/sdl2/common.c
@@ -1,6 +1,6 @@
 /*
  * common.h
- * Copyright (C) 2018 Meltytech, LLC
+ * Copyright (C) 2018-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,6 +20,7 @@
 #include "common.h"
 
 #include <framework/mlt_log.h>
+#include <stdlib.h>
 #include <string.h>
 
 SDL_AudioDeviceID sdl2_open_audio(const SDL_AudioSpec *desired, SDL_AudioSpec *obtained)
@@ -65,4 +66,23 @@ SDL_AudioDeviceID sdl2_open_audio(const SDL_AudioSpec *desired, SDL_AudioSpec *o
     }
 
     return dev;
+}
+
+int sdl2_ensure_buffer_capacity(uint8_t **buffer, int *capacity, int minimum)
+{
+    uint8_t *resized = NULL;
+
+    if (!buffer || !capacity || minimum <= 0)
+        return 1;
+
+    if (*capacity >= minimum)
+        return 0;
+
+    resized = realloc(*buffer, minimum);
+    if (!resized)
+        return 1;
+
+    *buffer = resized;
+    *capacity = minimum;
+    return 0;
 }

--- a/src/modules/sdl2/common.h
+++ b/src/modules/sdl2/common.h
@@ -1,6 +1,6 @@
 /*
  * common.h
- * Copyright (C) 2018 Meltytech, LLC
+ * Copyright (C) 2018-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,9 @@
 
 #include <SDL.h>
 
+#define SDL_AUDIO_BUFFER_MIN_BYTES (2048 * 2 * (int) sizeof(float) * 2)
+
 SDL_AudioDeviceID sdl2_open_audio(const SDL_AudioSpec *desired, SDL_AudioSpec *obtained);
+int sdl2_ensure_buffer_capacity(uint8_t **buffer, int *capacity, int minimum);
 
 #endif // COMMON_H

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -1,6 +1,6 @@
 /*
  * consumer_sdl.c -- A Simple DirectMedia Layer consumer
- * Copyright (C) 2017-2025 Meltytech, LLC
+ * Copyright (C) 2017-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -327,10 +327,11 @@ static void sdl_fill_audio(void *udata, uint8_t *stream, int len)
     if (self->audio_avail >= len) {
         // Place in the audio buffer
         if (volume != 1.0)
-            SDL_MixAudio(stream,
-                         self->audio_buffer,
-                         len,
-                         (int) ((float) SDL_MIX_MAXVOLUME * volume));
+            SDL_MixAudioFormat(stream,
+                               self->audio_buffer,
+                               AUDIO_F32SYS,
+                               len,
+                               (int) ((float) SDL_MIX_MAXVOLUME * volume));
         else
             memcpy(stream, self->audio_buffer, len);
 
@@ -341,7 +342,11 @@ static void sdl_fill_audio(void *udata, uint8_t *stream, int len)
         memmove(self->audio_buffer, self->audio_buffer + len, self->audio_avail);
     } else {
         // Mix the audio
-        SDL_MixAudio(stream, self->audio_buffer, len, (int) ((float) SDL_MIX_MAXVOLUME * volume));
+        SDL_MixAudioFormat(stream,
+                           self->audio_buffer,
+                           AUDIO_F32SYS,
+                           len,
+                           (int) ((float) SDL_MIX_MAXVOLUME * volume));
 
         // No audio left
         self->audio_avail = 0;
@@ -355,7 +360,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
 {
     // Get the properties of self consumer
     mlt_properties properties = self->properties;
-    mlt_audio_format afmt = mlt_audio_s16;
+    mlt_audio_format afmt = mlt_audio_f32le;
 
     // Set the preferred params of the test card signal
     int channels = mlt_properties_get_int(properties, "channels");
@@ -367,7 +372,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
                                                                               "fps"),
                                                     frequency,
                                                     counter++);
-    int16_t *pcm;
+    float *pcm;
     mlt_frame_get_audio(frame, (void **) &pcm, &afmt, &frequency, &channels, &samples);
     *duration = ((samples * 1000) / frequency);
     pcm += mlt_properties_get_int(properties, "audio_offset");
@@ -386,7 +391,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
         // specify audio format
         memset(&request, 0, sizeof(SDL_AudioSpec));
         request.freq = frequency;
-        request.format = AUDIO_S16SYS;
+        request.format = AUDIO_F32SYS;
         request.channels = mlt_properties_get_int(properties, "channels");
         request.samples = audio_buffer;
         request.callback = sdl_fill_audio;
@@ -454,7 +459,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
                         memcpy(&self->audio_buffer[self->audio_avail], pcm, dst_bytes);
                         pcm += samples_to_copy * channels;
                     } else {
-                        int16_t *dest = (int16_t *) &self->audio_buffer[self->audio_avail];
+                        float *dest = (float *) &self->audio_buffer[self->audio_avail];
                         int i = samples_to_copy + 1;
                         while (--i) {
                             memcpy(dest, pcm, dst_stride);

--- a/src/modules/sdl2/consumer_sdl2.c
+++ b/src/modules/sdl2/consumer_sdl2.c
@@ -55,7 +55,8 @@ struct consumer_sdl_s
     pthread_t thread;
     int joined;
     atomic_int running;
-    uint8_t audio_buffer[4096 * 10];
+    uint8_t *audio_buffer;
+    int audio_buffer_size;
     int audio_avail;
     pthread_mutex_t audio_mutex;
     pthread_cond_t audio_cond;
@@ -387,6 +388,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
         SDL_AudioSpec got;
         SDL_AudioDeviceID dev;
         int audio_buffer = mlt_properties_get_int(properties, "audio_buffer");
+        int audio_queue_size = 0;
 
         // specify audio format
         memset(&request, 0, sizeof(SDL_AudioSpec));
@@ -402,6 +404,16 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
             mlt_log_error(MLT_CONSUMER_SERVICE(self), "SDL failed to open audio\n");
             init_audio = 2;
         } else {
+            audio_queue_size = got.size > SDL_AUDIO_BUFFER_MIN_BYTES ? got.size
+                                                                     : SDL_AUDIO_BUFFER_MIN_BYTES;
+            if (sdl2_ensure_buffer_capacity(&self->audio_buffer,
+                                            &self->audio_buffer_size,
+                                            audio_queue_size)) {
+                mlt_log_error(MLT_CONSUMER_SERVICE(self), "Failed to allocate SDL audio queue\n");
+                SDL_CloseAudioDevice(dev);
+                init_audio = 2;
+                return init_audio;
+            }
             if (got.channels != request.channels) {
                 mlt_log_info(MLT_CONSUMER_SERVICE(self),
                              "Unable to output %d channels. Change to %d\n",
@@ -427,7 +439,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
         pthread_mutex_lock(&self->audio_mutex);
 
         while (self->running && samples_copied < samples) {
-            int sample_space = (sizeof(self->audio_buffer) - self->audio_avail) / dst_stride;
+            int sample_space = (self->audio_buffer_size - self->audio_avail) / dst_stride;
             while (self->running && sample_space == 0) {
                 struct timeval now;
                 struct timespec tm;
@@ -436,7 +448,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
                 tm.tv_sec = now.tv_sec + 1;
                 tm.tv_nsec = now.tv_usec * 1000;
                 pthread_cond_timedwait(&self->audio_cond, &self->audio_mutex, &tm);
-                sample_space = (sizeof(self->audio_buffer) - self->audio_avail) / dst_stride;
+                sample_space = (self->audio_buffer_size - self->audio_avail) / dst_stride;
 
                 if (sample_space == 0 && self->running) {
                     mlt_log_warning(MLT_CONSUMER_SERVICE(&self->parent), "audio timed out\n");
@@ -930,6 +942,7 @@ static void consumer_close(mlt_consumer parent)
     // Destroy mutexes
     pthread_mutex_destroy(&self->audio_mutex);
     pthread_cond_destroy(&self->audio_cond);
+    free(self->audio_buffer);
 
     // Finally clean up this
     free(self);

--- a/src/modules/sdl2/consumer_sdl2.yml
+++ b/src/modules/sdl2/consumer_sdl2.yml
@@ -2,7 +2,7 @@ schema_version: 7.2
 type: consumer
 identifier: sdl2
 title: SDL2
-version: 2
+version: 3
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -13,7 +13,7 @@ tags:
 description: >
   Simple DirectMedia Layer audio and video output module
 audio_formats:
-  - s16
+  - f32le
 image_formats:
   - yuv422
 parameters:

--- a/src/modules/sdl2/consumer_sdl2_audio.c
+++ b/src/modules/sdl2/consumer_sdl2_audio.c
@@ -53,7 +53,8 @@ struct consumer_sdl_s
     pthread_t thread;
     int joined;
     atomic_int running;
-    uint8_t audio_buffer[4096 * 10];
+    uint8_t *audio_buffer;
+    int audio_buffer_size;
     int audio_avail;
     pthread_mutex_t audio_mutex;
     pthread_cond_t audio_cond;
@@ -334,6 +335,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
         SDL_AudioSpec got;
         SDL_AudioDeviceID dev;
         int audio_buffer = mlt_properties_get_int(properties, "audio_buffer");
+        int audio_queue_size = 0;
 
         // specify audio format
         memset(&request, 0, sizeof(SDL_AudioSpec));
@@ -349,6 +351,16 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
             mlt_log_error(MLT_CONSUMER_SERVICE(self), "SDL failed to open audio\n");
             init_audio = 2;
         } else {
+            audio_queue_size = got.size > SDL_AUDIO_BUFFER_MIN_BYTES ? got.size
+                                                                     : SDL_AUDIO_BUFFER_MIN_BYTES;
+            if (sdl2_ensure_buffer_capacity(&self->audio_buffer,
+                                            &self->audio_buffer_size,
+                                            audio_queue_size)) {
+                mlt_log_error(MLT_CONSUMER_SERVICE(self), "Failed to allocate SDL audio queue\n");
+                SDL_CloseAudioDevice(dev);
+                init_audio = 2;
+                return init_audio;
+            }
             if (got.channels != request.channels) {
                 mlt_log_info(MLT_CONSUMER_SERVICE(self),
                              "Unable to output %d channels. Change to %d\n",
@@ -374,7 +386,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
         pthread_mutex_lock(&self->audio_mutex);
 
         while (self->running && samples_copied < samples) {
-            int sample_space = (sizeof(self->audio_buffer) - self->audio_avail) / dst_stride;
+            int sample_space = (self->audio_buffer_size - self->audio_avail) / dst_stride;
             while (self->running && sample_space == 0) {
                 struct timeval now;
                 struct timespec tm;
@@ -383,7 +395,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
                 tm.tv_sec = now.tv_sec + 1;
                 tm.tv_nsec = now.tv_usec * 1000;
                 pthread_cond_timedwait(&self->audio_cond, &self->audio_mutex, &tm);
-                sample_space = (sizeof(self->audio_buffer) - self->audio_avail) / dst_stride;
+                sample_space = (self->audio_buffer_size - self->audio_avail) / dst_stride;
 
                 if (sample_space == 0) {
                     mlt_log_warning(MLT_CONSUMER_SERVICE(&self->parent), "audio timed out\n");
@@ -697,6 +709,7 @@ static void consumer_close(mlt_consumer parent)
     pthread_cond_destroy(&self->video_cond);
     pthread_mutex_destroy(&self->refresh_mutex);
     pthread_cond_destroy(&self->refresh_cond);
+    free(self->audio_buffer);
 
     // Finally clean up this
     free(self);

--- a/src/modules/sdl2/consumer_sdl2_audio.c
+++ b/src/modules/sdl2/consumer_sdl2_audio.c
@@ -1,6 +1,6 @@
 /*
  * consumer_sdl2_audio.c -- A Simple DirectMedia Layer audio-only consumer
- * Copyright (C) 2009-2024 Meltytech, LLC
+ * Copyright (C) 2009-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -282,11 +282,11 @@ static void sdl_fill_audio(void *udata, uint8_t *stream, int len)
     // Place in the audio buffer
     if (volume != 1.0) {
         // Adjust the volume while copying.
-        int16_t *src = (int16_t *) self->audio_buffer;
-        int16_t *dst = (int16_t *) stream;
+        float *src = (float *) self->audio_buffer;
+        float *dst = (float *) stream;
         int i = bytes / sizeof(*dst) + 1;
         while (--i) {
-            *dst++ = CLAMP(volume * src[0], -32768, 32767);
+            *dst++ = volume * src[0];
             src++;
         }
     } else {
@@ -307,7 +307,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
 {
     // Get the properties of self consumer
     mlt_properties properties = self->properties;
-    mlt_audio_format afmt = mlt_audio_s16;
+    mlt_audio_format afmt = mlt_audio_f32le;
 
     // Set the preferred params of the test card signal
     int channels = mlt_properties_get_int(properties, "channels");
@@ -319,7 +319,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
                                                                               "fps"),
                                                     frequency,
                                                     counter++);
-    int16_t *pcm;
+    float *pcm;
     mlt_frame_get_audio(frame, (void **) &pcm, &afmt, &frequency, &channels, &samples);
     *duration = 1000000LL * samples / frequency;
     pcm += mlt_properties_get_int(properties, "audio_offset");
@@ -338,7 +338,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
         // specify audio format
         memset(&request, 0, sizeof(SDL_AudioSpec));
         request.freq = frequency;
-        request.format = AUDIO_S16SYS;
+        request.format = AUDIO_F32SYS;
         request.channels = mlt_properties_get_int(properties, "channels");
         request.samples = audio_buffer;
         request.callback = sdl_fill_audio;
@@ -406,7 +406,7 @@ static int consumer_play_audio(consumer_sdl self, mlt_frame frame, int init_audi
                         memcpy(&self->audio_buffer[self->audio_avail], pcm, dst_bytes);
                         pcm += samples_to_copy * channels;
                     } else {
-                        int16_t *dest = (int16_t *) &self->audio_buffer[self->audio_avail];
+                        float *dest = (float *) &self->audio_buffer[self->audio_avail];
                         int i = samples_to_copy + 1;
                         while (--i) {
                             memcpy(dest, pcm, dst_stride);

--- a/src/modules/sdl2/consumer_sdl2_audio.yml
+++ b/src/modules/sdl2/consumer_sdl2_audio.yml
@@ -2,7 +2,7 @@ schema_version: 7.2
 type: consumer
 identifier: sdl2_audio
 title: SDL2 Audio Only
-version: 3
+version: 4
 copyright: Meltytech, LLC
 creator: Dan Dennedy
 license: LGPLv2.1
@@ -12,7 +12,7 @@ tags:
 description: >
   Simple DirectMedia Layer audio only output module.
 audio_formats:
-  - s16
+  - f32le
 parameters:
   - identifier: volume
     title: Volume


### PR DESCRIPTION
```
ddennedy@pop-os:~/Downloads$ sh audio_null_test.sh

== 1. transparency: no filters, float in, float out ==
default flags:
  PASS  residual -inf dBFS (bit-exact)
mlt_audio_format=f32le:
  PASS  residual -inf dBFS (bit-exact)

== 2. correctness: acompressor vs FFmpeg's own float output ==
reference peak        : 12.589864 dBFS
MLT default peak      : 12.589864 dBFS
MLT f32le peak        : 12.589864 dBFS
default flags:
  PASS  residual -inf dBFS (bit-exact)
mlt_audio_format=f32le:
  PASS  residual -inf dBFS (bit-exact)

== 3. damage: residual written out for listening ==
  ./null-test/residual.wav  peak -inf dBFS
  (normalise it up and play it: this is the distortion the default path adds)

RESULT: all checks passed
```