### PR TITLE
Fix Android mlt++ build by disabling symbol versioning

### DIFF
--- a/src/mlt++/CMakeLists.txt
+++ b/src/mlt++/CMakeLists.txt
@@ -95,7 +95,7 @@ if(WIN32)
   target_compile_definitions(mlt++ PRIVATE MLTPP_EXPORTS)
 endif()
 
-if(NOT (WIN32 OR APPLE))
+if(NOT (WIN32 OR APPLE OR ANDROID))
   target_link_options(mlt++ PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/mlt++.vers)
   set_target_properties(mlt++ PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mlt++.vers)
 endif()


### PR DESCRIPTION
Building mlt++ on Android fails with:

```
ld.lld: error: version script assignment of 'MLTPP_0.8.8' to symbol 'Mlt::Properties::debug(char const*, _IO_FILE*)' failed: symbol not defined
ld.lld: error: version script assignment of 'MLTPP_0.8.8' to symbol 'Mlt::Properties::dump(_IO_FILE*)' failed: symbol not defined
```

(On Android the symbol is `Mlt::Properties::debug(char const*, __sFILE*)`.)

Disable the versioning.