### PR TITLE
Fix crash applying a Movit filter to an fx_cut

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,10 +25,19 @@ Framework
     New image-stack helpers used by tractor stacking and this path:
     - `mlt_frame_prepend_image_from_service()`
     - `mlt_frame_push_image_with_fx_cut()`
+  - Fix crash applying a Movit (OpenGL) filter to an `fx_cut` (Adjustment Clip).
+    `mlt_frame_prepend_image_from_service()` finalizes an in-progress Movit
+    chain to rgba64 before sharing onto another producer, and does not copy
+    producer-keyed `_movit` chain state across that boundary. Playlist `fx_cut`
+    frames now set `_producer` so Movit can key the chain.
 
 Modules
   - Image converters (`movit.convert`, `avcolor_space`, `imageconvert`) are
     now attached data-driven via `loader.ini` key `image_convert`.
+  - Movit `rgba64` is now a valid *input* as well as output: `FlatInput` is
+    created with `GL_UNSIGNED_SHORT` and `set_pixel_data()` uses the 16-bit
+    overload. Previously rgba64 was uploaded as 8-bit, which distorted the
+    image when an OpenGL filter ran on an `fx_cut`.
 
 
 Version 7.40.0

--- a/NEWS
+++ b/NEWS
@@ -26,10 +26,10 @@ Framework
     - `mlt_frame_prepend_image_from_service()`
     - `mlt_frame_push_image_with_fx_cut()`
   - Fix crash applying a Movit (OpenGL) filter to an `fx_cut` (Adjustment Clip).
-    `mlt_frame_prepend_image_from_service()` finalizes an in-progress Movit
-    chain to rgba64 before sharing onto another producer, and does not copy
-    producer-keyed `_movit` chain state across that boundary. Playlist `fx_cut`
-    frames now set `_producer` so Movit can key the chain.
+    Cross-producer image sharing (including the reverse fx_cut share) finalizes
+    an in-progress Movit chain to rgba64 and does not copy producer-keyed
+    `_movit` chain state. Same-producer prepends keep the GPU chain. Playlist
+    `fx_cut` frames now set `_producer` so Movit can key the chain.
 
 Modules
   - Image converters (`movit.convert`, `avcolor_space`, `imageconvert`) are

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -1065,6 +1065,26 @@ static void share_data(mlt_properties dst, const char *name, void *data, int siz
         mlt_properties_set_data(dst, name, data, size, NULL, NULL);
 }
 
+/** True when both frames have the same cut-parent original producer. */
+static int same_original_producer(mlt_frame a, mlt_frame b)
+{
+    mlt_producer pa = mlt_producer_cut_parent(mlt_frame_get_original_producer(a));
+    mlt_producer pb = mlt_producer_cut_parent(mlt_frame_get_original_producer(b));
+    return pa && pa == pb;
+}
+
+/** Do not fetch an in-progress Movit chain from a different producer.
+ *
+ * mlt_image_movit is keyed by original producer. Across fx_cut / stacking,
+ * finalize to rgba64 so the destination can start its own chain. Same-producer
+ * prepends keep movit so GPU effects can chain without a CPU round trip.
+ */
+static void flatten_foreign_movit(mlt_frame dst, mlt_frame src, mlt_image_format *format)
+{
+    if (format && *format == mlt_image_movit && !same_original_producer(dst, src))
+        *format = mlt_image_rgba64;
+}
+
 /** Copy image properties, alpha, converters, and Movit state from \p src to \p dst.
  *
  * Does not take ownership of the image or alpha buffers.
@@ -1102,9 +1122,7 @@ static void copy_image_state(mlt_frame dst, mlt_frame src)
     mlt_properties_set_int(dst_properties,
                            "movit.convert.use_texture",
                            mlt_properties_get_int(src_properties, "movit.convert.use_texture"));
-    mlt_producer src_producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(src));
-    mlt_producer dst_producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(dst));
-    if (src_producer && src_producer == dst_producer) {
+    if (same_original_producer(dst, src)) {
         int i;
         for (i = 0; i < mlt_properties_count(src_properties); i++) {
             char *name = mlt_properties_get_name(src_properties, i);
@@ -1141,9 +1159,8 @@ static void share_image(mlt_frame dst, mlt_frame src, uint8_t *image)
  * buffer onto \p self without taking ownership, along with format, alpha,
  * converters, and Movit state.
  *
- * Do not fetch mlt_image_movit from another producer: that format is an
- * in-progress GPU chain keyed by the source producer. Finalize to rgba64
- * (RGB+alpha, 16-bit) so the destination can start its own chain.
+ * Across producers, do not fetch mlt_image_movit: flatten to rgba64 so the
+ * destination starts its own chain. Same-producer prepends keep the GPU chain.
  *
  * \private \memberof mlt_frame_s
  * \return true if the stacked source frame is missing
@@ -1160,8 +1177,7 @@ static int get_image_from_service(mlt_frame self,
         return 1;
 
     copy_consumer_image_hints(frame, self);
-    if (*format == mlt_image_movit)
-        *format = mlt_image_rgba64;
+    flatten_foreign_movit(self, frame, format);
     mlt_frame_get_image(frame, buffer, format, width, height, writable);
     share_image(self, frame, (buffer && *buffer) ? *buffer : NULL);
     return 0;
@@ -1207,6 +1223,9 @@ static int get_image_with_fx_cut(mlt_frame a_frame,
 
     mlt_frame_prepend_image_from_service(fx_frame, a_frame);
 
+    // Reverse share onto a_frame is a producer boundary: do not hand back an
+    // in-progress Movit chain whose _movit keys will be dropped.
+    flatten_foreign_movit(a_frame, fx_frame, format);
     int error = mlt_frame_get_image(fx_frame, image, format, width, height, writable);
     if (!error)
         share_image(a_frame, fx_frame, (image && *image) ? *image : NULL);

--- a/src/framework/mlt_frame.c
+++ b/src/framework/mlt_frame.c
@@ -1068,6 +1068,8 @@ static void share_data(mlt_properties dst, const char *name, void *data, int siz
 /** Copy image properties, alpha, converters, and Movit state from \p src to \p dst.
  *
  * Does not take ownership of the image or alpha buffers.
+ * Producer-keyed `_movit ` chain keys are copied only when both frames
+ * share the same original producer.
  */
 static void copy_image_state(mlt_frame dst, mlt_frame src)
 {
@@ -1100,11 +1102,18 @@ static void copy_image_state(mlt_frame dst, mlt_frame src)
     mlt_properties_set_int(dst_properties,
                            "movit.convert.use_texture",
                            mlt_properties_get_int(src_properties, "movit.convert.use_texture"));
-    int i;
-    for (i = 0; i < mlt_properties_count(src_properties); i++) {
-        char *name = mlt_properties_get_name(src_properties, i);
-        if (name && !strncmp(name, "_movit ", 7))
-            share_data(dst_properties, name, mlt_properties_get_data_at(src_properties, i, NULL), 0);
+    mlt_producer src_producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(src));
+    mlt_producer dst_producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(dst));
+    if (src_producer && src_producer == dst_producer) {
+        int i;
+        for (i = 0; i < mlt_properties_count(src_properties); i++) {
+            char *name = mlt_properties_get_name(src_properties, i);
+            if (name && !strncmp(name, "_movit ", 7))
+                share_data(dst_properties,
+                           name,
+                           mlt_properties_get_data_at(src_properties, i, NULL),
+                           0);
+        }
     }
 
     data = mlt_frame_get_alpha_size(src, &size);
@@ -1132,6 +1141,10 @@ static void share_image(mlt_frame dst, mlt_frame src, uint8_t *image)
  * buffer onto \p self without taking ownership, along with format, alpha,
  * converters, and Movit state.
  *
+ * Do not fetch mlt_image_movit from another producer: that format is an
+ * in-progress GPU chain keyed by the source producer. Finalize to rgba64
+ * (RGB+alpha, 16-bit) so the destination can start its own chain.
+ *
  * \private \memberof mlt_frame_s
  * \return true if the stacked source frame is missing
  */
@@ -1147,6 +1160,8 @@ static int get_image_from_service(mlt_frame self,
         return 1;
 
     copy_consumer_image_hints(frame, self);
+    if (*format == mlt_image_movit)
+        *format = mlt_image_rgba64;
     mlt_frame_get_image(frame, buffer, format, width, height, writable);
     share_image(self, frame, (buffer && *buffer) ? *buffer : NULL);
     return 0;

--- a/src/framework/mlt_playlist.c
+++ b/src/framework/mlt_playlist.c
@@ -2042,6 +2042,7 @@ static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int in
     } else {
         mlt_producer parent = mlt_producer_cut_parent((mlt_producer) real);
         *frame = mlt_frame_init(MLT_PRODUCER_SERVICE(parent));
+        mlt_properties_set_data(MLT_FRAME_PROPERTIES(*frame), "_producer", real, 0, NULL, NULL);
         mlt_properties_set_int(MLT_FRAME_PROPERTIES(*frame), "fx_cut", 1);
         mlt_frame_set_position(*frame, mlt_producer_get_in((mlt_producer) real) + clip_position);
         mlt_frame_push_service(*frame, NULL);

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -243,6 +243,8 @@ int mlt_producer_is_blank(mlt_producer self)
 
 mlt_producer mlt_producer_cut_parent(mlt_producer self)
 {
+    if (!self)
+        return NULL;
     mlt_properties properties = MLT_PRODUCER_PROPERTIES(self);
     if (mlt_producer_is_cut(self))
         return mlt_properties_get_data(properties, "_cut_parent", NULL);

--- a/src/modules/movit/filter_movit_convert.cpp
+++ b/src/modules/movit/filter_movit_convert.cpp
@@ -153,23 +153,40 @@ static void get_format_from_properties(mlt_properties properties,
     ycbcr_format->cb_y_position = ycbcr_format->cr_y_position = 0.5f;
 }
 
-static void build_fingerprint(GlslChain *chain,
-                              mlt_service service,
-                              mlt_frame frame,
-                              std::string *fingerprint)
+static MltInput *chain_input(GlslChain *chain, mlt_producer producer)
+{
+    if (!chain || !producer)
+        return nullptr;
+    auto it = chain->inputs.find(producer);
+    return it != chain->inputs.end() ? it->second : nullptr;
+}
+
+static Effect *chain_effect(GlslChain *chain, mlt_service service)
+{
+    if (!chain || !service)
+        return nullptr;
+    auto it = chain->effects.find(service);
+    return it != chain->effects.end() ? it->second : nullptr;
+}
+
+static void append_unique_id(std::string *fingerprint, mlt_service service)
+{
+    const char *id = service ? mlt_properties_get(MLT_SERVICE_PROPERTIES(service), "_unique_id")
+                             : NULL;
+    fingerprint->append(id ? id : "unknown");
+}
+
+static void build_fingerprint(mlt_service service, mlt_frame frame, std::string *fingerprint)
 {
     if (service == (mlt_service) -1) {
         mlt_producer producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(frame));
-        if (producer && chain && chain->inputs[producer])
-            fingerprint->append(mlt_properties_get(MLT_PRODUCER_PROPERTIES(producer), "_unique_id"));
-        else
-            fingerprint->append("input");
+        append_unique_id(fingerprint, producer ? MLT_PRODUCER_SERVICE(producer) : nullptr);
         return;
     }
 
     mlt_service input_a = GlslManager::get_effect_input(service, frame);
     fingerprint->push_back('(');
-    build_fingerprint(chain, input_a, frame, fingerprint);
+    build_fingerprint(input_a, frame, fingerprint);
     fingerprint->push_back(')');
 
     mlt_frame frame_b;
@@ -177,19 +194,19 @@ static void build_fingerprint(GlslChain *chain,
     GlslManager::get_effect_secondary_input(service, frame, &input_b, &frame_b);
     if (input_b) {
         fingerprint->push_back('(');
-        build_fingerprint(chain, input_b, frame_b, fingerprint);
+        build_fingerprint(input_b, frame_b, fingerprint);
         fingerprint->push_back(')');
     }
 
     GlslManager::get_effect_third_input(service, frame, &input_b, &frame_b);
     if (input_b) {
         fingerprint->push_back('(');
-        build_fingerprint(chain, input_b, frame_b, fingerprint);
+        build_fingerprint(input_b, frame_b, fingerprint);
         fingerprint->push_back(')');
     }
 
     fingerprint->push_back('(');
-    fingerprint->append(mlt_properties_get(MLT_SERVICE_PROPERTIES(service), "_unique_id"));
+    append_unique_id(fingerprint, service);
 
     const char *effect_fingerprint = mlt_properties_get(MLT_SERVICE_PROPERTIES(service),
                                                         "_movit fingerprint");
@@ -277,7 +294,7 @@ static void finalize_movit_chain(mlt_service leaf_service, mlt_frame frame, mlt_
     auto properties = MLT_FRAME_PROPERTIES(frame);
 
     std::string new_fingerprint;
-    build_fingerprint(chain, leaf_service, frame, &new_fingerprint);
+    build_fingerprint(leaf_service, frame, &new_fingerprint);
 
     // Build the chain if needed.
     if (!chain || new_fingerprint != chain->fingerprint) {
@@ -348,13 +365,15 @@ static void set_movit_parameters(GlslChain *chain, mlt_service service, mlt_fram
 {
     if (service == (mlt_service) -1) {
         mlt_producer producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(frame));
-        MltInput *input = chain->inputs[producer];
+        MltInput *input = chain_input(chain, producer);
         if (input)
             input->set_pixel_data(GlslManager::get_input_pixel_pointer(producer, frame));
         return;
     }
 
-    Effect *effect = chain->effects[service];
+    Effect *effect = chain_effect(chain, service);
+    if (!effect)
+        return;
     mlt_service input_a = GlslManager::get_effect_input(service, frame);
     set_movit_parameters(chain, input_a, frame);
 
@@ -422,7 +441,7 @@ static void dispose_pixel_pointers(GlslChain *chain, mlt_service service, mlt_fr
 {
     if (service == (mlt_service) -1) {
         mlt_producer producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(frame));
-        MltInput *input = chain->inputs[producer];
+        MltInput *input = chain_input(chain, producer);
         if (input)
             input->invalidate_pixel_data();
         mlt_pool_release(GlslManager::get_input_pixel_pointer(producer, frame));
@@ -637,6 +656,10 @@ static int convert_image(mlt_frame frame,
         }
 
         mlt_producer producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(frame));
+        if (!producer) {
+            GlslManager::get_instance()->unlock_service(frame);
+            return 1;
+        }
         mlt_profile profile = mlt_service_profile(MLT_PRODUCER_SERVICE(producer));
         MltInput *input
             = create_input(properties, *format, profile->width, profile->height, width, height);
@@ -673,6 +696,11 @@ static int convert_image(mlt_frame frame,
             // yield the conversion.
             mlt_producer producer = mlt_producer_cut_parent(mlt_frame_get_original_producer(frame));
             MltInput *input = GlslManager::get_input(producer, frame);
+            if (!input) {
+                mlt_log_error(NULL, "[filter movit.convert] missing MltInput for passthrough\n");
+                GlslManager::get_instance()->unlock_service(frame);
+                return 1;
+            }
             *image = GlslManager::get_input_pixel_pointer(producer, frame);
             *format = input->get_format();
             delete input;

--- a/src/modules/movit/mlt_movit_input.cpp
+++ b/src/modules/movit/mlt_movit_input.cpp
@@ -49,7 +49,8 @@ void MltInput::useFlatInput(MovitPixelFormat pix_fmt, unsigned width, unsigned h
         ImageFormat image_format;
         image_format.color_space = COLORSPACE_sRGB;
         image_format.gamma_curve = GAMMA_REC_709; // GAMMA_sRGB causes a color level problem
-        input = new FlatInput(image_format, pix_fmt, GL_UNSIGNED_BYTE, width, height);
+        GLenum type = m_format == mlt_image_rgba64 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+        input = new FlatInput(image_format, pix_fmt, type, width, height);
     }
 }
 
@@ -94,7 +95,10 @@ void MltInput::set_pixel_data(const unsigned char *data)
 
     if (isRGB) {
         FlatInput *flat = (FlatInput *) input;
-        flat->set_pixel_data(data);
+        if (m_format == mlt_image_rgba64)
+            flat->set_pixel_data(reinterpret_cast<const unsigned short *>(data));
+        else
+            flat->set_pixel_data(data);
     } else if (m_ycbcr_format.num_levels == 1024) {
         YCbCrInput *ycbcr = (YCbCrInput *) input;
         auto p = reinterpret_cast<const uint16_t *>(data);

--- a/src/modules/movit/mlt_movit_input.cpp
+++ b/src/modules/movit/mlt_movit_input.cpp
@@ -27,6 +27,7 @@ using namespace movit;
 
 MltInput::MltInput(mlt_image_format format)
     : m_format(format)
+    , m_gl_type(GL_UNSIGNED_BYTE)
     , m_width(0)
     , m_height(0)
     , input(0)
@@ -49,8 +50,8 @@ void MltInput::useFlatInput(MovitPixelFormat pix_fmt, unsigned width, unsigned h
         ImageFormat image_format;
         image_format.color_space = COLORSPACE_sRGB;
         image_format.gamma_curve = GAMMA_REC_709; // GAMMA_sRGB causes a color level problem
-        GLenum type = m_format == mlt_image_rgba64 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
-        input = new FlatInput(image_format, pix_fmt, type, width, height);
+        m_gl_type = m_format == mlt_image_rgba64 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+        input = new FlatInput(image_format, pix_fmt, m_gl_type, width, height);
     }
 }
 
@@ -95,7 +96,7 @@ void MltInput::set_pixel_data(const unsigned char *data)
 
     if (isRGB) {
         FlatInput *flat = (FlatInput *) input;
-        if (m_format == mlt_image_rgba64)
+        if (m_gl_type == GL_UNSIGNED_SHORT)
             flat->set_pixel_data(reinterpret_cast<const unsigned short *>(data));
         else
             flat->set_pixel_data(data);

--- a/src/modules/movit/mlt_movit_input.h
+++ b/src/modules/movit/mlt_movit_input.h
@@ -47,6 +47,7 @@ public:
 
 private:
     mlt_image_format m_format;
+    GLenum m_gl_type;
     unsigned m_width, m_height;
     // Note: Owned by the EffectChain, so should not be deleted by us.
     movit::Input *input;

--- a/src/tests/test_tractor/test_tractor.cpp
+++ b/src/tests/test_tractor/test_tractor.cpp
@@ -589,39 +589,6 @@ private Q_SLOTS:
         delete frame;
     }
 
-    void FxCutAppliesMovitFilterToTrackBelow()
-    {
-        Filter saturation(profile, "movit.saturation");
-        if (!saturation.is_valid())
-            QSKIP("movit.saturation not available");
-        saturation.set("saturation", 0.0);
-
-        Producer red = makeColor(profile, "0xff0000ff");
-        QVERIFY(red.is_valid());
-        Producer fx = makeFxCut(profile, saturation);
-        QVERIFY(fx.is_valid());
-
-        Playlist track0(profile);
-        Playlist track1(profile);
-        track0.append(red);
-        track1.append(fx);
-
-        Tractor t(profile);
-        t.set_track(track0, 0);
-        t.set_track(track1, 1);
-
-        Frame *frame = t.get_frame();
-        QVERIFY(frame != NULL);
-        int r = 0, g = 0, b = 0;
-        QVERIFY(sampleCenterRgb(frame, r, g, b));
-        QString pixel = QString("rgb=%1,%2,%3").arg(r).arg(g).arg(b);
-        // Rec. 709 desaturation of red is a gray, not the original red or black.
-        QVERIFY2(qAbs(r - g) < 40, qPrintable(pixel));
-        QVERIFY2(qAbs(g - b) < 40, qPrintable(pixel));
-        QVERIFY2(r > 40, qPrintable(pixel));
-        delete frame;
-    }
-
     void FxCutDoesNotAffectTrackAbove()
     {
         Transition blendFx(profile, "composite");

--- a/src/tests/test_tractor/test_tractor.cpp
+++ b/src/tests/test_tractor/test_tractor.cpp
@@ -589,6 +589,39 @@ private Q_SLOTS:
         delete frame;
     }
 
+    void FxCutAppliesMovitFilterToTrackBelow()
+    {
+        Filter saturation(profile, "movit.saturation");
+        if (!saturation.is_valid())
+            QSKIP("movit.saturation not available");
+        saturation.set("saturation", 0.0);
+
+        Producer red = makeColor(profile, "0xff0000ff");
+        QVERIFY(red.is_valid());
+        Producer fx = makeFxCut(profile, saturation);
+        QVERIFY(fx.is_valid());
+
+        Playlist track0(profile);
+        Playlist track1(profile);
+        track0.append(red);
+        track1.append(fx);
+
+        Tractor t(profile);
+        t.set_track(track0, 0);
+        t.set_track(track1, 1);
+
+        Frame *frame = t.get_frame();
+        QVERIFY(frame != NULL);
+        int r = 0, g = 0, b = 0;
+        QVERIFY(sampleCenterRgb(frame, r, g, b));
+        QString pixel = QString("rgb=%1,%2,%3").arg(r).arg(g).arg(b);
+        // Rec. 709 desaturation of red is a gray, not the original red or black.
+        QVERIFY2(qAbs(r - g) < 40, qPrintable(pixel));
+        QVERIFY2(qAbs(g - b) < 40, qPrintable(pixel));
+        QVERIFY2(r > 40, qPrintable(pixel));
+        delete frame;
+    }
+
     void FxCutDoesNotAffectTrackAbove()
     {
         Transition blendFx(profile, "composite");


### PR DESCRIPTION
Playlist fx_cut frames skipped mlt_producer_get_frame, so _producer was unset and Movit keyed the chain with a NULL unique id. Pulling mlt_image_movit from another producer also shared an in-progress GPU chain onto the cut.

Finalize that chain to rgba64 before sharing, do not copy producer-keyed _movit state across the boundary, and upload rgba64 as GL_UNSIGNED_SHORT so 10-bit OpenGL filters on an Adjustment Clip are not distorted.