### PR TITLE
Fix fx_cut frames missing producer meta. and set. properties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,12 @@ Add `animation: yes` for keyframeable parameters, `mutable: yes` for runtime-cha
 
 ---
 
+## Symbol Export
+
+New public C functions in `src/framework/` must be listed in `src/framework/mlt.vers` under the current release node (see `NEWS`). New public mlt++ methods must be listed in `src/mlt++/mlt++.vers` under the current release node, using the demangled C++ signature in quotes (e.g. `"Mlt::Producer::probe()"`). A symbol omitted from the version script is not exported from the shared library, so callers cannot link to it.
+
+---
+
 ## Naming Conventions
 
 - **Source files:** `filter_<name>.c/.cpp`, `producer_<name>.c`, `transition_<name>.c`, `consumer_<name>.c`
@@ -223,3 +229,4 @@ The repo includes `.devcontainer/` with a `devcontainer.json` and `Dockerfile`.
 - **`mlt_properties_pass_list` in `filter_process`:** pass properties to the sub-filter on `mlt_frame_unique_properties`, not on the sub-filter's own properties, to avoid data races.
 - **YAML `readonly`:** set `readonly: no` on any parameter the user is expected to set; omitting it defaults to read-only in some tooling.
 - **Delegating to `qtext` vs `text`:** `filter_subtitle` tries `qtext` first, then falls back to `text`. Properties specific to `qtext` (e.g. `typewriter.*`) are silently ignored by the `text` fallback.
+- **Missing version-script entry:** a new exported C function without a `mlt.vers` entry, or a new exported mlt++ method without a `mlt++.vers` entry, will not be visible to linkers. Add it under the current release node when you add the symbol.

--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,7 @@ Framework
   - Copy `meta.` and `set.` properties from the producer onto `fx_cut` frames
     so producer annotations reach tractor output. New public API:
     - `mlt_producer_pass_frame_properties()`
+    - `Mlt::Producer::pass_frame_properties()`
 
 Modules
   - Image converters (`movit.convert`, `avcolor_space`, `imageconvert`) are

--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@ Framework
     an in-progress Movit chain to rgba64 and does not copy producer-keyed
     `_movit` chain state. Same-producer prepends keep the GPU chain. Playlist
     `fx_cut` frames now set `_producer` so Movit can key the chain.
+  - Copy `meta.` and `set.` properties from the producer onto `fx_cut` frames
+    so producer annotations reach tractor output. New public API:
+    - `mlt_producer_pass_frame_properties()`
 
 Modules
   - Image converters (`movit.convert`, `avcolor_space`, `imageconvert`) are

--- a/src/framework/mlt.vers
+++ b/src/framework/mlt.vers
@@ -703,4 +703,5 @@ MLT_7.42.0 {
     mlt_audio_format_id;
     mlt_frame_prepend_image_from_service;
     mlt_frame_push_image_with_fx_cut;
+    mlt_producer_pass_frame_properties;
 } MLT_7.40.0;

--- a/src/framework/mlt_playlist.c
+++ b/src/framework/mlt_playlist.c
@@ -2047,13 +2047,13 @@ static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int in
         mlt_frame_set_position(*frame, mlt_producer_get_in((mlt_producer) real) + clip_position);
         mlt_frame_push_service(*frame, NULL);
         mlt_frame_push_audio(*frame, NULL);
+        // Match producer_get_frame(): parent meta, parent filters, cut meta, cut filters.
+        mlt_producer_pass_frame_properties(parent, *frame);
         mlt_service_apply_filters(MLT_PRODUCER_SERVICE(parent), *frame, 0);
+        mlt_producer_pass_frame_properties((mlt_producer) real, *frame);
         mlt_service_apply_filters(real, *frame, 0);
         mlt_deque_pop_front(MLT_FRAME_IMAGE_STACK(*frame));
         mlt_deque_pop_front(MLT_FRAME_AUDIO_STACK(*frame));
-        // This path skips producer_get_frame(); match its parent-then-cut pass.
-        mlt_producer_pass_frame_properties(parent, *frame);
-        mlt_producer_pass_frame_properties((mlt_producer) real, *frame);
     }
     mlt_properties_dec_ref(MLT_SERVICE_PROPERTIES(real));
 

--- a/src/framework/mlt_playlist.c
+++ b/src/framework/mlt_playlist.c
@@ -2051,6 +2051,9 @@ static int producer_get_frame(mlt_producer producer, mlt_frame_ptr frame, int in
         mlt_service_apply_filters(real, *frame, 0);
         mlt_deque_pop_front(MLT_FRAME_IMAGE_STACK(*frame));
         mlt_deque_pop_front(MLT_FRAME_AUDIO_STACK(*frame));
+        // This path skips producer_get_frame(); match its parent-then-cut pass.
+        mlt_producer_pass_frame_properties(parent, *frame);
+        mlt_producer_pass_frame_properties((mlt_producer) real, *frame);
     }
     mlt_properties_dec_ref(MLT_SERVICE_PROPERTIES(real));
 

--- a/src/framework/mlt_producer.c
+++ b/src/framework/mlt_producer.c
@@ -746,16 +746,33 @@ static int producer_get_frame(mlt_service service, mlt_frame_ptr frame, int inde
     }
 
     // Pass on all meta properties from the producer/cut on to the frame
-    if (*frame != NULL && self != NULL) {
-        mlt_properties p_props = MLT_PRODUCER_PROPERTIES(self);
-        mlt_properties f_props = MLT_FRAME_PROPERTIES(*frame);
-        mlt_properties_lock(p_props);
-        mlt_properties_copy(f_props, p_props, "meta.");
-        mlt_properties_pass(f_props, p_props, "set.");
-        mlt_properties_unlock(p_props);
-    }
+    mlt_producer_pass_frame_properties(self, *frame);
 
     return result;
+}
+
+/** Copy producer \c meta. and \c set. properties onto a frame.
+ *
+ * \c producer_get_frame() does this for every frame. Services that construct a
+ * frame without going through that path (for example playlist \c fx_cut) should
+ * call this so producer annotations still reach the frame.
+ * \c set. prefixes are stripped, matching \c mlt_properties_pass().
+ *
+ * \public \memberof mlt_producer_s
+ * \param self a producer
+ * \param frame a frame
+ */
+
+void mlt_producer_pass_frame_properties(mlt_producer self, mlt_frame frame)
+{
+    if (!self || !frame)
+        return;
+    mlt_properties p_props = MLT_PRODUCER_PROPERTIES(self);
+    mlt_properties f_props = MLT_FRAME_PROPERTIES(frame);
+    mlt_properties_lock(p_props);
+    mlt_properties_copy(f_props, p_props, "meta.");
+    mlt_properties_pass(f_props, p_props, "set.");
+    mlt_properties_unlock(p_props);
 }
 
 /** Attach a filter.

--- a/src/framework/mlt_producer.h
+++ b/src/framework/mlt_producer.h
@@ -3,7 +3,7 @@
  * \brief abstraction for all producer services
  * \see mlt_producer_s
  *
- * Copyright (C) 2003-2014 Meltytech, LLC
+ * Copyright (C) 2003-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -146,5 +146,6 @@ MLT_EXPORT void mlt_producer_close(mlt_producer self);
 MLT_EXPORT int64_t mlt_producer_get_creation_time(mlt_producer self);
 MLT_EXPORT void mlt_producer_set_creation_time(mlt_producer self, int64_t creation_time);
 MLT_EXPORT int mlt_producer_probe(mlt_producer self);
+MLT_EXPORT void mlt_producer_pass_frame_properties(mlt_producer self, mlt_frame frame);
 
 #endif

--- a/src/mlt++/MltProducer.cpp
+++ b/src/mlt++/MltProducer.cpp
@@ -1,6 +1,6 @@
 /**
  * MltProducer.cpp - MLT Wrapper
- * Copyright (C) 2004-2019 Meltytech, LLC
+ * Copyright (C) 2004-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,7 @@
 #include "MltConsumer.h"
 #include "MltEvent.h"
 #include "MltFilter.h"
+#include "MltFrame.h"
 #include "MltProfile.h"
 using namespace Mlt;
 
@@ -265,4 +266,9 @@ void Producer::set_creation_time(int64_t creation_time)
 bool Producer::probe()
 {
     return mlt_producer_probe(get_producer());
+}
+
+void Producer::pass_frame_properties(Frame &frame)
+{
+    mlt_producer_pass_frame_properties(get_producer(), frame.get_frame());
 }

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -108,6 +108,8 @@ public:
     int64_t get_creation_time();
     void set_creation_time(int64_t creation_time);
     bool probe();
+    /** Copy this producer's \c meta. and \c set. properties onto \p frame. */
+    void pass_frame_properties(Frame &frame);
 };
 } // namespace Mlt
 

--- a/src/mlt++/MltProducer.h
+++ b/src/mlt++/MltProducer.h
@@ -108,7 +108,8 @@ public:
     int64_t get_creation_time();
     void set_creation_time(int64_t creation_time);
     bool probe();
-    /** Copy this producer's \c meta. and \c set. properties onto \p frame. */
+    /** Copy this producer's serializable \c meta. properties onto \p frame and
+     * copy serializable \c set. properties with the prefix removed. */
     void pass_frame_properties(Frame &frame);
 };
 } // namespace Mlt

--- a/src/mlt++/mlt++.vers
+++ b/src/mlt++/mlt++.vers
@@ -728,3 +728,10 @@ MLT_7.36.0 {
       "Mlt::Profile::is_valid()";
   };
 } MLT_7.32.0;
+
+MLT_7.42.0 {
+  global:
+    extern "C++" {
+      "Mlt::Producer::pass_frame_properties(Mlt::Frame&)";
+    };
+} MLT_7.36.0;

--- a/src/tests/test_playlist/test_playlist.cpp
+++ b/src/tests/test_playlist/test_playlist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Meltytech, LLC
+ * Copyright (C) 2019-2026 Meltytech, LLC
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/tests/test_playlist/test_playlist.cpp
+++ b/src/tests/test_playlist/test_playlist.cpp
@@ -263,6 +263,27 @@ private Q_SLOTS:
         delete pp2;
         delete pp3;
     }
+
+    void FxCutFrameReceivesProducerMeta()
+    {
+        Producer p(profile, "color", "0x00000000");
+        QVERIFY(p.is_valid());
+        p.set("mlt_image_format", "rgba");
+        p.set("meta.fx_cut", 1);
+        p.set("meta.test.flag", 1);
+        p.set("set.consumer.dummy", 1);
+        p.set_in_and_out(0, 9);
+
+        Playlist pl(profile);
+        pl.append(p);
+
+        Frame *frame = pl.get_frame();
+        QVERIFY(frame != NULL);
+        QCOMPARE(frame->get_int("fx_cut"), 1);
+        QCOMPARE(frame->get_int("meta.test.flag"), 1);
+        QCOMPARE(frame->get_int("consumer.dummy"), 1);
+        delete frame;
+    }
 };
 
 QTEST_APPLESS_MAIN(TestPlaylist)

--- a/src/tests/test_tractor/test_tractor.cpp
+++ b/src/tests/test_tractor/test_tractor.cpp
@@ -829,6 +829,33 @@ private Q_SLOTS:
         QVERIFY(image != NULL);
         delete frame;
     }
+
+    void FxCutPassesProducerMetaToTractorFrame()
+    {
+        Filter brightness(profile, "brightness");
+        if (!brightness.is_valid())
+            QSKIP("brightness not available");
+
+        Producer red = makeColor(profile, "0xff0000ff");
+        QVERIFY(red.is_valid());
+        Producer fx = makeFxCut(profile, brightness);
+        QVERIFY(fx.is_valid());
+        fx.set("meta.test.flag", 1);
+
+        Playlist track0(profile);
+        Playlist track1(profile);
+        track0.append(red);
+        track1.append(fx);
+
+        Tractor t(profile);
+        t.set_track(track0, 0);
+        t.set_track(track1, 1);
+
+        Frame *frame = t.get_frame();
+        QVERIFY(frame != NULL);
+        QCOMPARE(frame->get_int("meta.test.flag"), 1);
+        delete frame;
+    }
 };
 
 QTEST_APPLESS_MAIN(TestTractor)


### PR DESCRIPTION
Playlist fx_cut skips producer_get_frame(), so producer annotations never reached tractor output. Extract `mlt_producer_pass_frame_properties()` and use it from both `producer_get_frame` and the fx_cut path.